### PR TITLE
Add support for playlist shuffle setting within alarms

### DIFF
--- a/HTML/EN/settings/player/alarm.html
+++ b/HTML/EN/settings/player/alarm.html
@@ -55,6 +55,21 @@
 			</select>
 		[% END %]
 	
+		[% alarmTitle = "SHUFFLE" | string %]
+		[% WRAPPER settingGroup title='<div style="font-weight:normal;">' _ alarmTitle _ "</div>" desc="" %]
+			<select class="stdedit" name="alarm_shufflemode[% alarm.id %]" id="alarm_shufflemode[% alarm.id %]">
+
+				[% FOREACH option = {
+					'0' => 'SHUFFLE_OFF',
+					'1' => 'SHUFFLE_ON_SONGS',
+					'2' => 'SHUFFLE_ON_ALBUMS',
+				} %]
+					<option [% IF alarm.shufflemode == option.key %]selected='selected' [% END %]value="[% option.key %]">[% option.value | string %]</option>
+				[%- END -%]
+
+			</select>
+		[% END %]
+
 		[% alarmTitle = "ALARM_ALARM_REPEAT" | string %]
 		[% WRAPPER settingGroup title='<div style="font-weight:normal;">' _ alarmTitle _ "</div>" desc="ALARM_ALARM_REPEAT_DESC" %]
 			<select class="stdedit" name="alarm_repeat[% alarm.id %]" id="alarm_repeat[% alarm.id %]">

--- a/Slim/Buttons/Alarm.pm
+++ b/Slim/Buttons/Alarm.pm
@@ -45,6 +45,13 @@ my @daysMenu = (
 	{ title => 'ALARM_DAY0', type => 'checkbox', checked => \&dayEnabled, toggleFunc => \&toggleDay, params => {day => 0} },
 );
 
+# Alarm playlist shuffle option menu
+my @shuffleModeMenu = (
+	{ title => 'SHUFFLE_OFF',       type => 'checkbox', checked => \&shuffleModeSelected, toggleFunc => \&toggleShuffleMode, params => {shuffleMode => 0} },
+	{ title => 'SHUFFLE_ON_SONGS',  type => 'checkbox', checked => \&shuffleModeSelected, toggleFunc => \&toggleShuffleMode, params => {shuffleMode => 1} },
+	{ title => 'SHUFFLE_ON_ALBUMS', type => 'checkbox', checked => \&shuffleModeSelected, toggleFunc => \&toggleShuffleMode, params => {shuffleMode => 2} },
+);
+
 # Menu to confirm removal of an alarm
 my @deleteMenu = (
 	{
@@ -123,6 +130,11 @@ my @alarmMenu = (
 		title	=> 'ALARM_SELECT_PLAYLIST',
 		type	=> 'menu',
 		items => \&buildPlaylistMenu, 
+	},
+	{
+		title	=> 'SHUFFLE',
+		type	=> 'menu',
+		items => \@shuffleModeMenu,
 	},
 	{
 		title	=> 'ALARM_ALARM_REPEAT',
@@ -257,6 +269,30 @@ sub dayEnabled {
 		# $day should be [0-6]
 		return $alarm->day($day);  
 	}
+}
+
+sub toggleShuffleMode {
+	my $client = shift;
+	my $item = shift;
+
+	my $alarm = $client->modeParam('alarm_alarm');
+	my $shuffleMode = $item->{params}->{shuffleMode};
+
+	main::DEBUGLOG && $log->debug("toggleShuffleMode called for mode: $shuffleMode");
+
+	$alarm->shufflemode($shuffleMode);
+	saveAlarm($client, $alarm);
+}
+
+# Return whether the current alarm shuffle mode is set to a specific mode
+sub shuffleModeSelected {
+	my $client = shift;
+	my $item = shift;
+
+	my $alarm = $client->modeParam('alarm_alarm');
+	my $shuffleMode = $item->{params}->{shuffleMode};
+
+	return $alarm->shufflemode == $shuffleMode;
 }
 
 sub init {

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -85,7 +85,7 @@ sub alarmCommand {
 	my $client      = $request->client();
 	my $cmd         = $request->getParam('_cmd');
 
-	my @tags = qw( id dow dowAdd dowDel enabled repeat time volume playlisturl url cmd );
+	my @tags = qw( id dow dowAdd dowDel enabled repeat time volume shufflemode playlisturl url cmd );
 
 	# legacy support for "bare" alarm cli command (i.e., sending all tagged params)
 	my $params;
@@ -195,6 +195,7 @@ sub alarmCommand {
 			}
 
 			$alarm->volume($params->{volume}) if defined $params->{volume};
+			$alarm->shufflemode($params->{shufflemode}) if defined $params->{shufflemode};
 			$alarm->enabled($params->{enabled}) if defined $params->{enabled};
 			$alarm->repeat($params->{repeat}) if defined $params->{repeat};
 

--- a/Slim/Control/Jive.pm
+++ b/Slim/Control/Jive.pm
@@ -789,6 +789,65 @@ sub alarmUpdateMenu {
 	};
 	push @menu, $playlistChoice;
 
+	my $currentShuffleMode = $alarm->shufflemode;
+	my @shuffleMode_menu= (
+		{
+			text    => $client->string('SHUFFLE_OFF'),
+			radio   => ($currentShuffleMode == 0) + 0,
+			onClick => 'refreshOrigin',
+			actions => {
+				do => {
+					player => 0,
+					cmd    => ['alarm', 'update'],
+					params => {
+						id => $params->{id},
+						shufflemode => 0,
+					},
+				},
+			},
+			nextWindow => 'refresh',
+		},
+		{
+			text    => $client->string('SHUFFLE_ON_SONGS'),
+			radio   => ($currentShuffleMode == 1) + 0,
+			onClick => 'refreshOrigin',
+			actions => {
+				do => {
+					player => 0,
+					cmd    => ['alarm', 'update'],
+					params => {
+						id => $params->{id},
+						shufflemode => 1,
+					},
+				},
+			},
+			nextWindow => 'refresh',
+		},
+		{
+			text    => $client->string('SHUFFLE_ON_ALBUMS'),
+			radio   => ($currentShuffleMode == 2) + 0,
+			onClick => 'refreshOrigin',
+			actions => {
+				do => {
+					player => 0,
+					cmd    => ['alarm', 'update'],
+					params => {
+						id => $params->{id},
+						shufflemode => 2,
+					},
+				},
+			},
+			nextWindow => 'refresh',
+		},
+	);
+	my $shuffleMode = {
+		text      => $client->string('SHUFFLE'),
+		count     => scalar(@shuffleMode_menu),
+		offset    => 0,
+		item_loop => \@shuffleMode_menu,
+	};
+	push @menu, $shuffleMode;
+
 	my $repeat = $alarm->repeat();
 	my $repeatOn = {
 		text     => $client->string("ALARM_ALARM_REPEAT"),

--- a/Slim/Utils/Alarm.pm
+++ b/Slim/Utils/Alarm.pm
@@ -643,6 +643,8 @@ sub sound {
 
 		# Set the player shuffle mode prior to loading
 		# playlist
+		my $currentShuffleMode = $prefs->client($client)->get('shuffle');
+		$self->{_originalShuffleMode} = $currentShuffleMode;
 		if (defined $self->shufflemode) {
 		  main::DEBUGLOG && $isDebug && $log->debug('Alarm playlist shufflemode: ' . $self->shufflemode);
 		  $client->execute(['playlist', 'shuffle', $self->shufflemode]);
@@ -921,6 +923,11 @@ sub stop {
 			main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm volume level: ' . $self->{_originalVolume});
 			$client->volume($self->{_originalVolume});
 		}
+
+		# Restore client shuffle mode
+		main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm shuffle mode: ' . $self->{_originalShuffleMode});
+		$client->execute(['playlist', 'shuffle', $self->{_originalShuffleMode}]);
+
 		# Bug: 12760, 9569 - Return power state to that prior to the alarm
 		main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm power state: ' . ($self->{_originalPower} ? 'on' : 'off'));
 		$client->power($self->{_originalPower});

--- a/Slim/Utils/Alarm.pm
+++ b/Slim/Utils/Alarm.pm
@@ -641,6 +641,13 @@ sub sound {
 			$client->execute(['mixer', 'volume', $self->volume]);
 		}
 
+		# Set the player shuffle mode prior to loading
+		# playlist
+		if (defined $self->shufflemode) {
+		  main::DEBUGLOG && $isDebug && $log->debug('Alarm playlist shufflemode: ' . $self->shufflemode);
+		  $client->execute(['playlist', 'shuffle', $self->shufflemode]);
+		}
+
 		# Play alarm playlist, falling back to the current playlist if undef
 		if (defined $self->playlist) {
 			main::DEBUGLOG && $isDebug && $log->debug('Alarm playlist url: ' . $self->playlist);

--- a/Slim/Utils/Alarm.pm
+++ b/Slim/Utils/Alarm.pm
@@ -117,6 +117,7 @@ sub new {
 		_days => (! defined $time || $time < 86400) ? [(1) x 7] : undef,
 		_enabled => 0,
 		_repeat => 1,
+		_shufflemode => 0,
 		_playlist => undef,
 		_title => undef,
 		_volume => undef, # Use default volume
@@ -252,6 +253,24 @@ sub repeat {
 	$self->{_repeat} = $newValue if defined $newValue;
 	
 	return $self->{_repeat};
+}
+=head3 shufflemode ( [0/1/2] )
+
+Sets/returns the shuffle mode that will be used for the playlist for this alarm.
+
+  0 = no shuffling
+  1 = shuffle-by-song
+  2 = shuffle-by-album
+
+=cut
+
+sub shufflemode {
+	my $self = shift;
+	my $newValue = shift;
+
+	$self->{_shufflemode} = $newValue if defined $newValue;
+
+	return $self->{_shufflemode};
 }
 
 =head3 time( [ $time ] )
@@ -1069,6 +1088,7 @@ sub _createSaveable {
 		_days => $self->{_days},
 		_enabled => $self->{_enabled},
 		_repeat => $self->{_repeat},
+		_shufflemode => $self->{_shufflemode},
 		_playlist => $self->{_playlist},
 		_title => $self->{_title},
 		_volume => $self->{_volume},
@@ -1359,6 +1379,7 @@ sub loadAlarms {
 		$alarm->{_days} = $prefAlarm->{_days};
 		$alarm->{_enabled} = $prefAlarm->{_enabled};
 		$alarm->{_repeat} = $prefAlarm->{_repeat};
+		$alarm->{_shufflemode} = $prefAlarm->{_shufflemode};
 		$alarm->{_playlist} = $prefAlarm->{_playlist};
 		$alarm->{_title} = $prefAlarm->{_title};
 		$alarm->{_volume} = $prefAlarm->{_volume};

--- a/Slim/Web/Settings/Player/Alarm.pm
+++ b/Slim/Web/Settings/Player/Alarm.pm
@@ -163,6 +163,7 @@ sub saveAlarm {
 	$alarm->time($t);
 	$alarm->enabled( $paramRef->{'alarm_enable' . $id} );
 	$alarm->repeat( $paramRef->{'alarm_repeat' . $id} );
+	$alarm->shufflemode( $paramRef->{'alarm_shufflemode' . $id} );
 
 	for my $day (0 .. 6) {
 


### PR DESCRIPTION
This change enhances the alarm settings to include the playlist shuffle mode (none/song/album). This means that you can have a player set to (for example) no shuffling normally, but ensure that your morning alarm plays a random selection from your wakeup playlist.

This enhancement has the following key features:
- Supports shuffle modes of _none_, _shuffle-by-song_ and _shuffle-by-album_.
- Supports setting this preference via the following means:
  - Web settings.
  - Jive-based players settings menu (SB Touch, Radio and Controller).
  - 'Old' players' settings menu (SB1, SB1G, SB2, SB3, Transporter and Boom).
- The original shuffle mode is restored when the alarm is cancelled.
