### PR TITLE
Fix bug 16506: Honor read access given by ACLs (for 7.7)

### DIFF
--- a/Changelog7.html
+++ b/Changelog7.html
@@ -10,6 +10,7 @@
 	<li>Bug Fixes:</li>
 	<ul>
 		<li><a href="http://bugs.slimdevices.com/show_bug.cgi?id=6040">#6040</a> - Need different description for Title Format in Players settings</li>
+		<li><a href="http://bugs.slimdevices.com/show_bug.cgi?id=16506">#16506</a> - Honor read access given by ACLs.</li>
 		<li><a href="http://bugs.slimdevices.com/show_bug.cgi?id=18045">#18045</a> - Additional Playlist Buttons not shown in search results</li>
 		<li><a href="http://bugs.slimdevices.com/show_bug.cgi?id=18046">#18046</a> - Perl 5.18 breaks functionality in Info.pm</li>
 		<li><a href="http://bugs.slimdevices.com/show_bug.cgi?id=18050">#18050</a> - Duration is not shown correctly</li>

--- a/Slim/Utils/Misc.pm
+++ b/Slim/Utils/Misc.pm
@@ -844,8 +844,11 @@ sub fileFilter {
 	
 	return 0 unless (-l _ || -d _ || -f _);
 
-	# Make sure we can read the file.
-	return 0 if !-r _;
+	# Make sure we can read the file, honoring ACLs.
+	{
+		use filetest 'access';
+		return 0 if ! -r $fullpath;
+	}
 
 	my $target;
  


### PR DESCRIPTION
For this, use "access" instead of stat.
