### PR TITLE
Automatically detect multi-disc sets with support to override name.

### DIFF
--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -208,6 +208,8 @@ sub readTags {
 			$tags->{'DISCC'} = int($2) if defined $2;
 		}
 
+		Slim::Utils::Misc::checkForBoxSet($tags);
+
 		if (!defined $tags->{'TITLE'}) {
 
 			main::INFOLOG && $log->is_info && $log->info("No title found, using plain title for $file");


### PR DESCRIPTION
Look for album names that contain cd or disc numbers with optional number of discs.  Examples:

"Still Live - Disc 1"
"Alone Together: The Best of The Mercury Years (Disc 1 of 2)"
"At the Half Note Café 1960 - CD 1"

If a Disc # is found, set the tag "DISC" automatically (only if DISC isn't already set).

If an optional number of cds is found, set the tag "DISCC".

Once found, try to clean up the album name so that all albums from the same set have identical names (so LMS combines them).  Do this by removing the cd pattern located earlier and any (now) extraneous or dangling punctuation, and extra white space.

Remove any leading zeros in the disc number (not really necessary, but nice).

Finally, flag the album as being part of a multi-disc set by appending " - Box".

Some multi-disc sets have strange albums names which defeat this approach.  Allow the user to optionally/explicitly set the name by adding a new BOXSET tag.  This works with or without the user explicitly adding DISC/DISCC tags.

Examples of non-conforming albums and how BOXSET is used:

"At The Blue Note, The Complete Recordings IV":
   Would require both DISC and BOXSET to be set.

"Unearthed (Disc 1: Who's Gonna Cry)"
"Unearthed (Disc 2: Trouble in Mind)":
   Would only require setting BOXSET, DISC would be set automatically.
