### PR TITLE
Add ALBUMARTIST tag support for Cue files

### DIFF
--- a/Slim/Formats/Playlists/CUE.pm
+++ b/Slim/Formats/Playlists/CUE.pm
@@ -74,6 +74,7 @@ sub parse {
 		} elsif ($line =~ /^PERFORMER\s+\"(.*)\"/i) {
 
 			$cuesheet->{'ARTIST'} = $1;
+			$cuesheet->{'ALBUMARTIST'} = $1;
 			
 		} elsif ($line =~ /^(?:REM\s+)?(YEAR|GENRE|COMMENT|ARTISTSORT|ALBUMSORT|COMPILATION)\s+\"(.*)\"/i) {
 
@@ -131,6 +132,12 @@ sub parse {
 		} elsif (defined $currtrack and $line =~ /^\s*PERFORMER\s+\"(.*)\"/i) {
 
 			$tracks->{$currtrack}->{'ARTIST'} = $1;
+
+			# Automatically flag a compilation album (if it hasn't been already)
+			# since we are setting the album artist.
+			if (defined($cuesheet->{'ALBUMARTIST'}) and ($1 ne $cuesheet->{'ALBUMARTIST'})) {
+				$cuesheet->{'COMPILATION'} = '1' if not defined($cuesheet->{'COMPILATION'});
+			}
 
 		} elsif (defined $currtrack and $line =~ /^(?:\s+REM\s+)?REPLAYGAIN_TRACK_GAIN\s+(.*)dB/i) {
 
@@ -226,7 +233,7 @@ sub parse {
 
 		# Also - check the original file for any information that may
 		# not be in the cue sheet. Bug 2668
-		for my $file_attribute (qw(CONTENT_TYPE ARTIST ALBUM YEAR GENRE DISC DISCNUMBER DISCC DISCTOTAL TOTALDISCS REPLAYGAIN_ALBUM_GAIN REPLAYGAIN_ALBUM_PEAK ARTISTSORT ALBUMSORT COMPILATION)) {
+		for my $file_attribute (qw(CONTENT_TYPE ALBUMARTIST ARTIST ALBUM YEAR GENRE DISC DISCNUMBER DISCC DISCTOTAL TOTALDISCS REPLAYGAIN_ALBUM_GAIN REPLAYGAIN_ALBUM_PEAK ARTISTSORT ALBUMSORT COMPILATION)) {
 
 			my $attribute = $file_attribute;
 			if ($file_attribute eq 'DISCNUMBER') {
@@ -300,7 +307,7 @@ sub parse {
 		}
 
 		# Merge in file level attributes
-		for my $attribute (qw(CONTENT_TYPE ARTIST ALBUM YEAR GENRE DISC DISCC COMMENT REPLAYGAIN_ALBUM_GAIN REPLAYGAIN_ALBUM_PEAK ARTISTSORT ALBUMSORT COMPILATION)) {
+		for my $attribute (qw(CONTENT_TYPE ALBUMARTIST ARTIST ALBUM YEAR GENRE DISC DISCC COMMENT REPLAYGAIN_ALBUM_GAIN REPLAYGAIN_ALBUM_PEAK ARTISTSORT ALBUMSORT COMPILATION)) {
 
 			if (!exists $track->{$attribute} && defined $cuesheet->{$attribute}) {
 


### PR DESCRIPTION
Interpret and export the top-level PERFORMER in the Cue file as the ALBUMARTIST tag.  If the per-track PERFORMER (e.g. track artist) is different, flag this album as a compilation.

This also helps LMS recognize multi-disc sets of compilations (when using cue sheets).
