### PR TITLE
Add support for global virtual library handling.

### DIFF
--- a/SQL/mysql/schema_19_down.sql
+++ b/SQL/mysql/schema_19_down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS library_track;

--- a/SQL/mysql/schema_19_up.sql
+++ b/SQL/mysql/schema_19_up.sql
@@ -1,0 +1,10 @@
+--
+-- Table: library_track
+--
+DROP TABLE IF EXISTS library_track;
+CREATE TABLE library_track (
+  track  int(10) unsigned,
+  library char(8),
+  PRIMARY KEY (track,library),
+  FOREIGN KEY (`track`) REFERENCES `tracks` (`id`) ON DELETE CASCADE
+);


### PR DESCRIPTION
BrowseModes would read a pref library_id whenever called to limit results to subsets of the complete library.
The library_id can be a per-player pref or globally set. There's no code yet to set any of this values.

Run a full rescan for this change to work.
