### PR TITLE
Option to scrobble only first artist

### DIFF
--- a/Slim/Plugin/AudioScrobbler/HTML/EN/plugins/AudioScrobbler/settings/basic.html
+++ b/Slim/Plugin/AudioScrobbler/HTML/EN/plugins/AudioScrobbler/settings/basic.html
@@ -40,4 +40,15 @@
 		</select>
 	[% END %]
 
+        [% WRAPPER setting title="SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY" desc="SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY_DESC" %]
+                <select class="stdedit" name="pref_scrobble_first_artist_only" id="scrobble_first_artist_only">
+                        <option [% IF prefs.pref_scrobble_first_artist_only == 1 %]selected="selected" [% END %]value="1">
+                                [% 'SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY_YES' | string %]
+                        </option>
+                        <option [% IF prefs.pref_scrobble_first_artist_only == 0 %]selected="selected" [% END %]value="0">
+                                [% 'SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY_NO' | string %]
+                        </option>
+                </select>
+        [% END %]
+
 [% PROCESS settings/footer.html %]

--- a/Slim/Plugin/AudioScrobbler/Plugin.pm
+++ b/Slim/Plugin/AudioScrobbler/Plugin.pm
@@ -74,9 +74,10 @@ sub initPlugin {
 	
 	# init scrobbling prefs
 	$prefs->init({
-		enable_scrobbling => 1,
-		include_radio     => 0,
-		account           => 0,
+		enable_scrobbling 		=> 1,
+		include_radio     		=> 0,
+		scrobble_first_artist_only	=> 0,
+		account           		=> 0,
 	});
 	
 	# Subscribe to new song events
@@ -929,7 +930,12 @@ sub _getMetadata {
 				};
 			}
 			
-			$meta->{artist}   = $meta2->{artist};
+			if ($prefs->get('scrobble_first_artist_only')) {
+				$meta->{artist} = $meta2->{artistA}[0]->{name} ? $meta2->{artistA}[0]->{name} : $meta2->{artist};
+			}
+			else {
+				$meta->{artist} = $meta2->{artist};
+			}
 			$meta->{album}    = $meta2->{album} || '';
 			$meta->{title}    = $meta2->{title};
 			$meta->{tracknum} = $meta2->{tracknum} || '';

--- a/Slim/Plugin/AudioScrobbler/Settings.pm
+++ b/Slim/Plugin/AudioScrobbler/Settings.pm
@@ -25,7 +25,7 @@ sub page {
 }
 
 sub prefs {
-	return ( $prefs, qw(accounts enable_scrobbling include_radio) );
+	return ( $prefs, qw(accounts enable_scrobbling include_radio scrobble_first_artist_only) );
 }
 
 sub handler {

--- a/Slim/Plugin/AudioScrobbler/strings.txt
+++ b/Slim/Plugin/AudioScrobbler/strings.txt
@@ -433,3 +433,14 @@ PLUGIN_AUDIOSCROBBLER_TRACK_LOVED
 	RU	Эта дорожка понравилась.
 	SV	Spåret har registrerats som älskat.
 
+SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY
+	EN	Multiple artists tags
+
+SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY_DESC
+	EN	How should multiple artist tags be scrobbled? E.g. the track of "Artist A feat. Artist B" might be tagged with "Artist A; Artist B". If enabled, only scrobble "Artist A". If disabled, the artist is scrobbled as "Artist A, Artist B". Last.fm sees this as one artist, not as two separate artists.
+
+SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY_YES
+	EN	Scrobble only the first artist
+
+SETUP_PLUGIN_AUDIOSCROBBLER_SCROBBLE_FIRST_ARTIST_ONLY_NO
+	EN	Concatenate multiple artists into one


### PR DESCRIPTION
This adds an option to only scrobble the first artist in case of multiple artists. E.g. Spotify tags tracks with "Artist A, Artist B" if multiple artists collaborate on the same track. This is send to Last.fm as artist="Artist A, Artist B" (a concatenated string). Last.fm does not recognise that as two separate artists, but sees it as one unknown artist. With this option, it will only send the first artist, "Artist A" in this case, keeping the scrobbles to Last.fm clean and correct.
The default option is the current option to concatenate artists. A user must manually change this settings.
