### PR TITLE
Information screen enhancement

### DIFF
--- a/Slim/Menu/SystemInfo.pm
+++ b/Slim/Menu/SystemInfo.pm
@@ -148,6 +148,7 @@ sub _getPlayerInfo {
 	my $info = [
 #		{ INFORMATION_PLAYER_NAME_ABBR       => $client->name },
 		{ INFORMATION_PLAYER_MODEL           => $client->modelName },
+		{ PLAYER_TYPE                        => $client->model },
 		{ INFORMATION_FIRMWARE_ABBR          => $client->revision },
 		{ INFORMATION_PLAYER_IP              => $client->ip },
 #		{ INFORMATION_PLAYER_PORT            => $client->port },


### PR DESCRIPTION
This line will add model (=type) information to various screens.
The type information is essential for applets if they need to distinguish between several models.
Ege. SqueezePlay with different screen resolutions (and/or other  SoftPlayer) implementations.
Unfortunately the model (not model name) is currently nowhere displayed.
