### PR TITLE
Only disable randomplay if the alarm has its own playlist

### DIFF
--- a/Slim/Utils/Alarm.pm
+++ b/Slim/Utils/Alarm.pm
@@ -559,6 +559,12 @@ sub sound {
 		# Sound an Alarm (HWV 63)
 		main::DEBUGLOG && $isDebug && $log->debug('Sounding alarm');
 
+		# we need to disable randomplay or we can't change shuffle mode
+		if (defined $self->{_playlist})
+		{
+			$client->execute(['randomplay', 'disable']);
+		}
+
 		# Stop any other current alarm
 		if ($client->alarmData->{currentAlarm}) {
 			main::DEBUGLOG && $log->debug('Stopping other current alarm');

--- a/Slim/Utils/Alarm.pm
+++ b/Slim/Utils/Alarm.pm
@@ -559,9 +559,6 @@ sub sound {
 		# Sound an Alarm (HWV 63)
 		main::DEBUGLOG && $isDebug && $log->debug('Sounding alarm');
 
-		# we need to disable randomplay or we can't change shuffle mode
-		$client->execute(['randomplay', 'disable']);
-
 		# Stop any other current alarm
 		if ($client->alarmData->{currentAlarm}) {
 			main::DEBUGLOG && $log->debug('Stopping other current alarm');


### PR DESCRIPTION
If you had random play on previously and an alarm goes off whatever is left on the playlist will play but random play won't add any new tracks. 
