### PR TITLE
Remove the link parameter from Podcasts

### DIFF
--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -25,6 +25,7 @@ sub parse {
 
 		next unless $item->{enclosure} && keys %{$item->{enclosure}};
 		
+		$item->{link} = '';
 		$item->{line1} = $item->{title} || $item->{name};
 		$item->{line2} = Slim::Utils::DateTime::longDateF(str2time($item->{pubdate})) if $item->{pubdate};
 		$item->{'xmlns:slim'} = 1;


### PR DESCRIPTION
Remove the link parameter from the Podcasts plugin. Per the discussion here:

http://forums.slimdevices.com/showthread.php?100446-Podcasts-resuming-under-7-8&p=831331&viewfull=1#post831331

the link parameter is causing certain podcasts to be treated as web links instead of redirects.

Thanks to bpa for the fix!
