### PR TITLE
send Accept-Ranges header when streaming files

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -1426,6 +1426,7 @@ sub sendStreamingFile {
 	$response->header('Content-Disposition', 
 		sprintf('attachment; filename="%s"', Slim::Utils::Misc::unescape(basename($file)))
 	) unless $showInBrowser;
+	$response->header('Accept-Ranges', 'bytes');
 	
 	my $fh = FileHandle->new($file);
 	


### PR DESCRIPTION
Some HTTP-based UPnP players will not send Range requests unless the
server explicitly indicates that Range requests are supported.  The HTTP
spec says that clients may make Range requests without explicitly
receiving support from the server, but for these clients, they have
chosen to be more conservative in sending Range requests.
