### PR TITLE
Fix bitrate info for converted WAV/AIFF/PCM output HD streams.

### DIFF
--- a/Slim/Menu/TrackInfo.pm
+++ b/Slim/Menu/TrackInfo.pm
@@ -1016,6 +1016,11 @@ sub infoBitrate {
 				&& ($streambitrate = $song->streambitrate())
 				&& $sourcebitrate != $streambitrate)
 			{
+					if ( $song->streamformat() =~ /wav|aif|pcm/ 
+						 && (my $samplesize = $track->samplesize)
+						 && (my $sampleRate = $track->samplerate) ) {
+						$streambitrate = $sampleRate * $samplesize * 2;
+					}
 					$convert = sprintf( ' (%s %s%s %s)', 
 						cstring($client, 'CONVERTED_TO'), 
 						sprintf( "%d", $streambitrate / 1000 ),


### PR DESCRIPTION
Currently it just assumes 44100Hz 16bit stream bitrate which is confusing when eg. HD FLAC is converted to AIFF.
