### PR TITLE
Updated fix for crossfade across sample rates

### DIFF
--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -958,11 +958,11 @@ sub stream_s {
 		# songs differ. This avoids some unpleasant white
 		# noise from (at least) the Squeezebox Touch when
 		# using the analogue outputs. This might be bug#1884.
-		if (!Slim::Player::ReplayGain->trackSampleRateMatch($master, -1)
-		    ||
-		    !Slim::Player::ReplayGain->trackSampleRateMatch($master, 1)) {
+		if (!Slim::Player::ReplayGain->trackSampleRateMatch($master, -1)) {
 			main::INFOLOG && $log->info('Overriding transition due to differing sample rates');
 			$transitionType = 0;
+		 } else {
+			main::INFOLOG && $log->info('Sample rates do not require a transition restriction');
 		 }
 
 	}


### PR DESCRIPTION
This is an updated fix for temporarily disabling crossfade (if enabled)
between tracks that have different sample rates. As in the original PR
for this, this appears necessary for (at least) the Squeezebox Touch
which will produce an alarming blast of white noise in such a situation.

As reported in PR#3 (https://github.com/Logitech/slimserver/pull/3),
this fix didn't work correctly when near the end of a playlist, for
example when Random Play is adding a track at a time.

The bug was caused because as well has looking between the new track and
previous track to compare for a compatible sample rate, it was actually
looking back even earlier in the playlist for no reason. This was
because I didn't understand the meaning of the offset at this point in
the code.
