### PR TITLE
Fix for utf8 and temp table

### DIFF
--- a/SQL/mysql/schema_11_up.sql
+++ b/SQL/mysql/schema_11_up.sql
@@ -4,5 +4,5 @@ CREATE TABLE scanned_files (
   url TEXT NOT NULL,
   timestamp int(10),
   filesize int(10)
-) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+) ENGINE=InnoDB CHARACTER SET utf8;
 CREATE INDEX scannedUrlIndex ON scanned_files (url(255));


### PR DESCRIPTION
COLLATE utf8_unicode_ci; causes creation of temp table 'diskonly' to fail.
Tried creating diskonly with UTF8 COLLATE ... but that causes the same scanning problem we tried to fix in the first place.

Just using utf8; without COLLATE works fine.
