### PR TITLE
Fix system sleep prevention on Mac OS X 10.9 and above

### DIFF
--- a/Slim/Plugin/PreventStandby/OSX.pm
+++ b/Slim/Plugin/PreventStandby/OSX.pm
@@ -25,7 +25,7 @@ sub new {
 	my ($class, $i) = @_;
 
 	if ( $command = Slim::Utils::Misc::findbin('caffeinate') ) {
-		$command .= ' -s';
+		$command .= ' -i';
 	}
 	elsif ( $command = Slim::Utils::Misc::findbin('pmset') ) {
 		$command .= ' noidle';


### PR DESCRIPTION
Must use 'caffeinate -i' instead of 'caffeinate -s' because OS X 10.9 dropped support for the kIOPMAssertionTypePreventSystemSleep assertion.

See [http://www.opensource.apple.com/source/IOKitUser/IOKitUser-907.1.13/pwr_mgt.subproj/IOPMLib.h](url) for more info.
