### PR TITLE
function _advertise: Add a check if server announces with 0.0.0.0. 

### DIFF
--- a/Slim/Plugin/UPnP/Discovery.pm
+++ b/Slim/Plugin/UPnP/Discovery.pm
@@ -484,7 +484,7 @@ sub _advertise {
 					last;
 				}
 			}
-			if ( !$local_addr ) {
+			if ( !$local_addr || $local_addr eq '0.0.0.0' ) {
 				$local_addr = Slim::Utils::Network::serverAddr(); # default
 			}
 			


### PR DESCRIPTION
This is necessary on solaris based systems. The server sends an url containing 0.0.0.0 and no client can connect to this address. From my understanding this should not break other system as they seem to advertise correctly. So this patch can also be seen as a safety for in case problems...

I can also add a OS check...

BTW: What especially do the Slim/Utils/OS/x files do??
