### PR TITLE
Allow dirsFor('update') directory to be defined other that $cacheDir …

### DIFF
--- a/Slim/Utils/Light.pm
+++ b/Slim/Utils/Light.pm
@@ -200,7 +200,8 @@ sub getPref {
 
 sub checkForUpdate {
 	
-	$versionFile ||= catfile( scalar($os->dirsFor('updates')), 'server.version' );
+	my @tmp= $os->dirsFor('updates');
+	$versionFile ||= catfile( $tmp[-1], 'server.version' );
 	
 	open(UPDATEFLAG, $versionFile) || return '';
 	

--- a/Slim/Utils/OS.pm
+++ b/Slim/Utils/OS.pm
@@ -179,7 +179,6 @@ sub dirsFor {
 		
 		return unless $updateDir;
 		
-		mkdir $updateDir unless -d $updateDir;
 		push @dirs, $updateDir;
 	}
 	

--- a/Slim/Utils/Update.pm
+++ b/Slim/Utils/Update.pm
@@ -185,9 +185,12 @@ sub getUpdate {
 	my $params = $os->getUpdateParams($url);
 	
 	return unless $params;
-	
-	$params->{path} ||= scalar ( $os->dirsFor('updates') );
-	
+	my @tmp = $os->dirsFor('updates');
+   
+	$params->{path} ||=  $tmp[-1] ;
+        
+	mkdir $params->{path} unless -d $params->{path};
+            	
 	cleanup($params->{path}, 'tmp');
 
 	if ( $url && Slim::Music::Info::isURL($url) ) {
@@ -308,7 +311,9 @@ sub setUpdateInstaller {
 }
 
 sub getVersionFile {
-	$versionFile ||= catdir( scalar($os->dirsFor('updates')), 'server.version' );
+	my @tmp= $os->dirsFor('updates');
+	mkdir $tmp[-1] unless -d $tmp[-1];
+	$versionFile ||= catdir( $tmp[-1], 'server.version' );
 	return $versionFile;
 }
 


### PR DESCRIPTION
…by Custom.pm

Also moved the creation of the update directory, so it only creates the subdir when it's trying to update.
