### PR TITLE
Only display disc count if there are more than 1 discs

### DIFF
--- a/HTML/EN/html/SqueezeJS/Base.js
+++ b/HTML/EN/html/SqueezeJS/Base.js
@@ -632,7 +632,7 @@ SqueezeJS.SonginfoParser = {
 				title = result.playlist_loop[0].title;
 
 			else
-				title = (result.playlist_loop[0].disc ? result.playlist_loop[0].disc + '-' : '')
+				title = (result.playlist_loop[0].disc && result.playlist_loop[0].disccount > 1 ? result.playlist_loop[0].disc + '-' : '')
 						+ (result.playlist_loop[0].tracknum ? result.playlist_loop[0].tracknum + ". " : '')
 						+ result.playlist_loop[0].title;
 


### PR DESCRIPTION
If the metadata of a track has a disc count, but there is only 1 disc, the track number is still displayed as 1-1. This hide the disc count if there is just 1 disc.
