### PR TITLE
Updated fix for crossfade across sample rates

### DIFF
--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -122,6 +122,19 @@
 				
 				</select>
 			[% END %]
+
+			[% WRAPPER settingGroup title="SETUP_TRANSITIONSAMPLERESTRICTION" desc="SETUP_TRANSITIONSAMPLERESTRICTION_DESC" %]
+				<select class="stdedit" name="pref_transitionSampleRestriction" id="pref_transitionSampleRestriction">
+
+				[% FOREACH option = {
+					'0' => 'SETUP_TRANSITIONSAMPLERESTRICTION_OFF',
+					'1' => 'SETUP_TRANSITIONSAMPLERESTRICTION_ON',
+				} %]
+					<option [% IF prefs.pref_transitionSampleRestriction == option.key %]selected [% END %]value="[% option.key %]">[% option.value | string %]</option>
+				[%- END -%]
+
+				</select>
+			[% END %]
 	
 			[% WRAPPER settingGroup title="SETUP_TRANSITIONDURATION" desc="SETUP_TRANSITIONDURATION_DESC" %]
 				<input type="text" class="stdedit sliderInput_0_10" name="pref_transitionDuration" id="pref_transitionDuration" value="[% prefs.pref_transitionDuration %]" size="5">

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -958,11 +958,15 @@ sub stream_s {
 		# songs differ. This avoids some unpleasant white
 		# noise from (at least) the Squeezebox Touch when
 		# using the analogue outputs. This might be bug#1884.
-		if (!Slim::Player::ReplayGain->trackSampleRateMatch($master, -1)) {
-			main::INFOLOG && $log->info('Overriding transition due to differing sample rates');
+		# Whether to implement this restriction is controlled
+		# by a player preference.
+		my $transitionSampleRestriction = $prefs->client($master)->get('transitionSampleRestriction') || 0;
+
+		if (!Slim::Player::ReplayGain->trackSampleRateMatch($master, -1) && $transitionSampleRestriction) {
+			main::INFOLOG && $log->info('Overriding crossfade due to differing sample rates');
 			$transitionType = 0;
-		 } else {
-			main::INFOLOG && $log->info('Sample rates do not require a transition restriction');
+		 } elsif ($transitionSampleRestriction) {
+			main::INFOLOG && $log->info('Crossfade sample rate restriction enabled but not needed for this transition');
 		 }
 
 	}

--- a/Slim/Web/Settings/Player/Audio.pm
+++ b/Slim/Web/Settings/Player/Audio.pm
@@ -42,7 +42,7 @@ sub prefs {
 	}
 
 	if ($client->maxTransitionDuration()) {
-		push @prefs,qw(transitionType transitionDuration transitionSmart);
+		push @prefs,qw(transitionType transitionDuration transitionSmart transitionSampleRestriction);
 	}
 	
 	if ($client->hasDigitalOut()) {

--- a/strings.txt
+++ b/strings.txt
@@ -5942,6 +5942,18 @@ SETUP_TRANSITIONSMART_OFF
 	RU	Откл. интеллект. перекрестное затухание
 	SV	Avaktivera smart korstoning
 
+SETUP_TRANSITIONSAMPLERESTRICTION
+	EN	Crossfade Across Different Sample Rates
+
+SETUP_TRANSITIONSAMPLERESTRICTION_DESC
+	EN	It may be appropriate to disable crossfading between tracks with different sample rates. This may be required if this player produces a burst of noise during such transitions.
+
+SETUP_TRANSITIONSAMPLERESTRICTION_OFF
+	EN	Yes
+
+SETUP_TRANSITIONSAMPLERESTRICTION_ON
+	EN	No
+
 SETUP_TITLEFORMAT
 	CS	Formát názvu
 	DA	Titelformat


### PR DESCRIPTION
This is an update to the previous pull request #65.

It has been reported that not all players have a problem when crossfading between tracks with a different sample rate and therefore this adds web and player preference (within the "audio" settings, alongside the existing crossfade settings) to choose whether to enable or disable crossfading in this scenario.

It defaults to "disabled", so won't apply this workaround unless explicitly configured to do so.

See here for the request to make this configurable:
https://github.com/Logitech/slimserver/pull/65#issuecomment-226743852
