### PR TITLE
Correct arguments to rpm command for RedHat-like linux.

### DIFF
--- a/HTML/EN/html/docs/linux-update.html
+++ b/HTML/EN/html/docs/linux-update.html
@@ -18,5 +18,5 @@ These currently are available for .rpm and .deb based systems.<p>
 <ul style="direction: ltr;">
 	<li>Log in to your server machine using your username and password.</li>
 	<li>Run the following command to execute the installer</li>
-	<li><code>sudo [% distro == 'rpm' ? 'rpm -uvh' : 'dpkg -i' %] [% installerFile %]</code></li>
+	<li><code>sudo [% distro == 'rpm' ? 'rpm -Uvh' : 'dpkg -i' %] [% installerFile %]</code></li>
 </ul>

--- a/HTML/EN/html/docs/linux-update.html.de
+++ b/HTML/EN/html/docs/linux-update.html.de
@@ -18,5 +18,5 @@ Dies ist derzeit auf RPM und Debian basierenden Systemen der Fall.<p>
 <ul style="direction: ltr;">
 	<li>Melde dich auf deinem Linux-Rechner an.</li>
 	<li>F&uuml;hre folgenden Befehl in einem Terminal aus:</li>
-	<li><code>sudo [% distro == 'rpm' ? 'rpm -uvh' : 'dpkg -i' %] [% installerFile %]</code></li>
+	<li><code>sudo [% distro == 'rpm' ? 'rpm -Uvh' : 'dpkg -i' %] [% installerFile %]</code></li>
 </ul>


### PR DESCRIPTION
small letter `u` does nothing. Big letter `U` updates the package.