### PR TITLE
Handle Devuan as Debian flavor

### DIFF
--- a/Slim/Utils/OS/Linux.pm
+++ b/Slim/Utils/OS/Linux.pm
@@ -51,7 +51,7 @@ sub getFlavor {
 	
 		return 'SqueezeOS';
 	
-	} elsif (-f '/etc/debian_version') {
+	} elsif (-f '/etc/debian_version' || -f '/etc/devuan_version') {
 	
 		return 'Debian';
 	


### PR DESCRIPTION
I'm using the server on a [Devuan](https://devuan.org/) system on my Raspberry Pi. Unfortunately it did not find the required CPAN modules, because it did not consider the path `/usr/share/squeezeboxserver/CPAN`.

My workaround was to create a symlink from `/etc/debian_version` to `/etc/devuan_version`, but I think it might be a better solution, to treat Devuan as a Debian system since it is a fork.