### PR TITLE
use only year while parsing flac cue sheet tracks

### DIFF
--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -779,6 +779,9 @@ sub _getCUEinVCs {
 			}
 		}
 
+		# only use year instead of the full date
+		$tracks->{$key}->{'YEAR'}=~ s/.*(\d\d\d\d).*/$1/;
+
 		$class->_doTagMapping($tracks->{$key});
 
 		$items++;


### PR DESCRIPTION
If you have an album as a single FLAC file with an embedded cue sheet which is used for the metadata during scanning and this cue sheet contains a full date and not only the year then no year is added to the database.
This changes the full date to year only (like it's already done in another location in FLAC.pm) and the year is now correctly stored to the database.