### PR TITLE
getClient OoO calls

### DIFF
--- a/Slim/Player/Client.pm
+++ b/Slim/Player/Client.pm
@@ -512,10 +512,10 @@ sub getClient {
 	# Try a brute for match for the client.
 	if (!defined($ret)) {
    		 for my $value ( values %clientHash ) {
-			return $value if (ipport($value) eq $id);
-			return $value if (ip($value) eq $id);
-			return $value if (name($value) eq $id);
-			return $value if (id($value) eq $id);
+			return $value if ($value->ipport) eq $id);
+			return $value if ($value->ip) eq $id);
+			return $value if ($value->name) eq $id);
+			return $value if ($value->id) eq $id);
 		}
 		# none of these matched, so return undef
 		return undef;


### PR DESCRIPTION
It seems that getClient does not do an OoO calls, preventing subclassing of ipport, ip, name and id methods