### PR TITLE
pluginData works with undef

### DIFF
--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -811,6 +811,7 @@ sub _cliQuery_done {
 						item        => $item,
 						subFeed     => $subFeed,
 						noFavorites => 1,
+						item_id		=> scalar @crumbIndex ? join('.', @crumbIndex) : undef,
 						subItemId   => $xmlbrowserPlayControl,
 						playalbum   => 1,	# Allways add play-all item
 					})
@@ -1790,7 +1791,7 @@ sub _playlistControlContextMenu {
 	
 	# We only add playlist-control items for an item which is playable
 	if (hasAudio($item)) {
-		my $item_id = $request->getParam('item_id') || '';
+		my $item_id = $args->{item_id} || $request->getParam('item_id') || '';
 		my $mode    = $request->getParam('mode');
 		my $sub_id  = $args->{'subItemId'};
 		my $subFeed = $args->{'subFeed'};

--- a/Slim/Player/Client.pm
+++ b/Slim/Player/Client.pm
@@ -1241,7 +1241,7 @@ sub pluginData {
 		return $client->_pluginData->{$namespace};
 	}
 	
-	if ( defined $value ) {
+	if ( @_ > 2 ) {
 		if ( $namespace ) {
 			$client->_pluginData->{$namespace}->{$key} = $value;
 		}

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -693,7 +693,7 @@ sub pluginData {
 		$ret = $self->_pluginData($key);
 	}
 	else {
-		if ( defined $value ) {
+		if ( @_ > 2 ) {
 			$self->_pluginData()->{$key} = $value;
 		}
 		


### PR DESCRIPTION
https://github.com/Logitech/slimserver/blob/3625c6d3f2cc77a00e64d2ba7ef803538d998af2/Slim/Plugin/SongScanner/Plugin.pm#L278

I've seen a few times some plugins doing that and looking at the pluginData method in Slim::Player::Client.pm, I don't understand how it can work because if the value parameter is undef, then the function returns the current value, doesn't it? I needed to do that same on my Groups plugin but could not. This (I think) sets the key to whatever the caller asks, even undef but still returns the value if no $value parameter is given