### PR TITLE
adding crumb to list when defeatTTP

### DIFF
--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -1839,7 +1839,6 @@ sub _playlistControlContextMenu {
 			},
 		}
 		
-		if ($addPlayAll && ($action = _makePlayAction($subFeed, $item, 'playall', 'nowPlaying', $query, $mode, $request->getParam('item_id'), $sub_id))) {
 			push @contextMenu, {
 				text => $request->string('JIVE_PLAY_ALL_SONGS'),
 				style => $canIcons ? 'item_playall' : 'itemNoAction',

--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -1839,6 +1839,7 @@ sub _playlistControlContextMenu {
 			},
 		}
 		
+		if ($addPlayAll && ($action = _makePlayAction($subFeed, $item, 'playall', 'nowPlaying', $query, $mode, $args->{item_id} || $request->getParam('item_id'), $sub_id))) {
 			push @contextMenu, {
 				text => $request->string('JIVE_PLAY_ALL_SONGS'),
 				style => $canIcons ? 'item_playall' : 'itemNoAction',

--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -811,6 +811,7 @@ sub _cliQuery_done {
 						item        => $item,
 						subFeed     => $subFeed,
 						noFavorites => 1,
+						item_id		=> scalar @crumbIndex ? join('.', @crumbIndex) : undef,
 						subItemId   => $xmlbrowserPlayControl,
 						playalbum   => 1,	# Allways add play-all item
 					})
@@ -1790,7 +1791,7 @@ sub _playlistControlContextMenu {
 	
 	# We only add playlist-control items for an item which is playable
 	if (hasAudio($item)) {
-		my $item_id = $request->getParam('item_id') || '';
+		my $item_id = $args->{item_id} || $request->getParam('item_id') || '';
 		my $mode    = $request->getParam('mode');
 		my $sub_id  = $args->{'subItemId'};
 		my $subFeed = $args->{'subFeed'};


### PR DESCRIPTION
A a proposal to fix the problem of wrong contextMenu creation (missing crumb) when defeatTTP is in action). I've checked that it works for both Spotty and YouTube and does not seem to create regression on other browsing (at least when there is no search). I assume more tests are needed and I cannot guarantee it's the right solution, but I believe it only impacts the contextMenu when there is a search 