### PR TITLE
only use synchronized volume players

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -639,14 +639,18 @@ sub mixerCommand {
 			}
 	
 			$client->fade_volume($fade, \&_mixer_mute, [$client]);
-	
-			for my $eachclient (@buddies) {
 
-				if ($prefs->client($eachclient)->get('syncVolume')) {
+			# Bug 18165: do not sync volume if client's volume itself is not synced			
+			if ($prefs->client($client)->get('syncVolume')) {		
+			
+				for my $eachclient (@buddies) {
 
-					$eachclient->fade_volume($fade, \&_mixer_mute, [$eachclient]);
+					if ($prefs->client($eachclient)->get('syncVolume')) {
+
+						$eachclient->fade_volume($fade, \&_mixer_mute, [$eachclient]);
+					}
 				}
-			}
+			}	
 		}
 
 	} else {
@@ -675,13 +679,16 @@ sub mixerCommand {
 			$newval = $client->$entity($newval);
 		}
 
-		for my $eachclient (@buddies) {
-			if ($prefs->client($eachclient)->get('syncVolume')) {
-				$prefs->client($eachclient)->set($entity, $newval);
-				$eachclient->$entity($newval);
-				$eachclient->mixerDisplay('volume') if $entity eq 'volume';
+		# Bug 18165: do not sync volume if client's volume itself is not synced
+		if ($prefs->client($client)->get('syncVolume')) {		
+			for my $eachclient (@buddies) {
+				if ($prefs->client($eachclient)->get('syncVolume')) {
+					$prefs->client($eachclient)->set($entity, $newval);
+					$eachclient->$entity($newval);
+					$eachclient->mixerDisplay('volume') if $entity eq 'volume';
+				}
 			}
-		}
+		}	
 	}
 		
 	if (defined $controllerSequenceId) {

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -1240,7 +1240,13 @@ sub _Stream {				# play -> Buffering, Streaming
 	$paused ||= ($fadeIn > 0);
 	
 	my $setVolume = $self->{'playingState'} == STOPPED;
-	my $masterVol = abs($prefs->client($self->master())->get("volume") || 0);
+	# Bug 18165: master's volume might not be the right one to use
+	my $masterVol;
+	foreach my $player (@{$self->{'players'}}) {
+		next unless $prefs->client($player)->get('syncVolume');
+		$masterVol = abs($prefs->client($player)->get("volume") || 0);
+		last;
+	}	
 	
 	my $startedPlayers = 0;
 	my $reportsTrackStart = 0;


### PR DESCRIPTION
Synchronize volume only amongst players which have the sync volume attribute set, including at stream startup (i.e. the sync master is not always used as the reference volume)