### PR TITLE
Allow jive based players to save and play all 10 presets LMS supports

### DIFF
--- a/IR/Default.map
+++ b/IR/Default.map
@@ -98,18 +98,26 @@ trebleup.repeat			= treble_up
 volume					= volume
 volumemode				= volumemode
 home					= home
+preset_0.single			= playPreset_0
 preset_1.single			= playPreset_1
 preset_2.single			= playPreset_2
 preset_3.single			= playPreset_3
 preset_4.single			= playPreset_4
 preset_5.single			= playPreset_5
 preset_6.single			= playPreset_6
+preset_7.single			= playPreset_7
+preset_8.single			= playPreset_8
+preset_9.single			= playPreset_9
+preset_0.hold			= favorites_add0
 preset_1.hold			= favorites_add1
 preset_2.hold			= favorites_add2
 preset_3.hold			= favorites_add3
 preset_4.hold			= favorites_add4
 preset_5.hold			= favorites_add5
 preset_6.hold			= favorites_add6
+preset_7.hold			= favorites_add7
+preset_8.hold			= favorites_add8
+preset_9.hold			= favorites_add9
 
 # playing display modes
 now_playing				= playdisp_toggle

--- a/Slim/Control/Jive.pm
+++ b/Slim/Control/Jive.pm
@@ -2520,7 +2520,7 @@ sub jivePresetsMenu {
 
 	my $presets = $prefs->client($client)->get('presets');
 	my @presets_menu;
-	for my $preset (0..5) {
+	for my $preset (0..9) {
 		my $jive_preset = $preset + 1;
 		# is this preset currently set?
 		my $set = ref($presets) eq 'ARRAY' && defined $presets->[$preset] ? 1 : 0;
@@ -2613,6 +2613,9 @@ sub jiveFavoritesCommand {
 	if ( $command eq 'set_preset' ) {
 		# XXX: why do we use a favorites_ prefix here but not above?
 		my $preset = $request->getParam('key');
+		if ( $preset == 0 ) {
+			$preset = 10;
+		}
 		my $title  = $request->getParam('favorites_title');
 		my $url    = $request->getParam('favorites_url');
 		my $type   = $request->getParam('favorites_type');


### PR DESCRIPTION
Adds jive support for presets 7-10 to LMS. I've applied the required player side changes to my jivelite and squeezeplay sources. So this pull request is only for software jive players.  However, I've tested the server side change with a Radio, Touch and Boom and did not have any issues saving or playing the original 6 presets that the firmware supports.
Ralphy