### PR TITLE
Fix Windows 8.3 file name handling

### DIFF
--- a/Slim/Utils/OS/Win32.pm
+++ b/Slim/Utils/OS/Win32.pm
@@ -307,7 +307,7 @@ sub getFileName {
 	}
 
 	# display full name if we got a Windows 8.3 file name
-	if ($path =~ /~/) {
+	if ($path =~ /~\d$/) {
 
 		if (my $n = Win32::GetLongPathName($path)) {
 			$n = File::Basename::basename($n);


### PR DESCRIPTION
The filename who has multi-byte characters that contain 0x7e is garbled.
(ex. {0x83, 0x7e} expresses "ミ" in Shift-JIS, and this regular expression will catch the character.)
This change fixes the issue that showing garbled file name in "Browse Music Folder".