### PR TITLE
Remove Audio::Scan version check at load time and fix...

### DIFF
--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -79,7 +79,7 @@ sub init {
 		'xpf' => 'Slim::Formats::Playlists::XSPF',
 	);
 
-	if ($Audio::Scan::VERSION =~ /^0\.9[45]$/) {
+	if ($Audio::Scan::VERSION >= 0.94) {
 		$tagClasses{'dff'} = 'Slim::Formats::DFF';
 		$tagClasses{'dsf'} = 'Slim::Formats::DSF';
 	}

--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -16,6 +16,7 @@ use Slim::Music::Info;
 use Slim::Utils::Log;
 use Slim::Utils::Misc;
 use Slim::Utils::Unicode;
+use Slim::Utils::Versions;
 
 # Map our tag functions - so they can be dynamically loaded.
 our (%tagClasses, %loadedTagClasses);
@@ -79,7 +80,7 @@ sub init {
 		'xpf' => 'Slim::Formats::Playlists::XSPF',
 	);
 
-	if ($Audio::Scan::VERSION >= 0.94) {
+	if (Slim::Utils::Versions->compareVersions($Audio::Scan::VERSION,'0.94') >= 0) {
 		$tagClasses{'dff'} = 'Slim::Formats::DFF';
 		$tagClasses{'dsf'} = 'Slim::Formats::DSF';
 	}

--- a/lib/Audio/Scan.pm
+++ b/lib/Audio/Scan.pm
@@ -2,8 +2,21 @@ package Audio::Scan;
 
 use strict;
 
-use XSLoader;
-XSLoader::load 'Audio::Scan';
+our $VERSION;
+
+require XSLoader;
+
+BEGIN {
+	foreach ('0.99', '0.93', '0.95', '0.94') {
+		eval { XSLoader::load('Audio::Scan', $_); };
+		
+		if (!$@) {
+			$VERSION = $_;
+			last;
+		}
+	}
+}
+
 
 use constant FILTER_INFO_ONLY => 1;
 use constant FILTER_TAGS_ONLY => 2;

--- a/lib/Audio/Scan.pm
+++ b/lib/Audio/Scan.pm
@@ -2,21 +2,8 @@ package Audio::Scan;
 
 use strict;
 
-our $VERSION;
-
-require XSLoader;
-
-BEGIN {
-	foreach ('0.99', '0.93', '0.95', '0.94') {
-		eval { XSLoader::load('Audio::Scan', $_); };
-		
-		if (!$@) {
-			$VERSION = $_;
-			last;
-		}
-	}
-}
-
+use XSLoader;
+XSLoader::load 'Audio::Scan';
 
 use constant FILTER_INFO_ONLY => 1;
 use constant FILTER_TAGS_ONLY => 2;

--- a/modules.conf
+++ b/modules.conf
@@ -5,7 +5,7 @@
 # <module> <min_version> [ <max_version> ]
 
 AnyEvent 5.202
-Audio::Scan 0.93 0.99
+Audio::Scan 0.93 1.99
 CGI::Cookie 1.27
 Class::Data::Inheritable 0.04
 Class::Inspector 1.16

--- a/modules.conf
+++ b/modules.conf
@@ -5,7 +5,6 @@
 # <module> <min_version> [ <max_version> ]
 
 AnyEvent 5.202
-Audio::Scan 0.93 1.99
 CGI::Cookie 1.27
 Class::Data::Inheritable 0.04
 Class::Inspector 1.16


### PR DESCRIPTION
DSD file formats disabled when using Audio::Scan versions newer than 0.95.