### PR TITLE
Fix suprious error message relating to SSL_verify_mode

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -101,7 +101,7 @@ sub new_socket {
 			# Failed. Try again with an explicit SNI.
 			my %args = @_;
 			$args{SSL_hostname} = $args{Host};
-			$args{SSL_verify_mode} = 0x00;
+			$args{SSL_verify_mode} = Net::SSLeay::VERIFY_NONE();
 			return Slim::Networking::Async::Socket::HTTPS->new( %args );
 		}
 		else {

--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -31,7 +31,7 @@ sub new {
 		PeerAddr => $server,
 		PeerPort => $port,
 		SSL_startHandshake => 1,
-		SSL_verify_mode => 0x00		# SSL_VERIFY_NONE isn't recognized on some platforms?!?
+		SSL_verify_mode => Net::SSLeay::VERIFY_NONE()		# SSL_VERIFY_NONE isn't recognized on some platforms?!?, and 0x00 isn't always "right"
 	) or do {
 
 		$log->error("Couldn't create socket binding to $main::localStreamAddr with timeout: $timeout - $!");


### PR DESCRIPTION
So SSL_VERIFY_NONE was the old default in IO::Socket::SSL however
at one point they started warning that this was a rather insecure
thing to do.  The workaround was to explicitly set
SSL_verify_mode => SSL_VERIFY_NONE from the same package.  This
posed some oddities, both because SSL_VERIFY_NONE as a bare word
wasn't exported well into slimserver, and because it's not
entirely obvious where that's coming from.  It was eventually
noticed that SSL_VERIFY_NONE didn't always work and 0x00 was
hard coded, EXCEPT this doesn't work on some other systems
where SSL_VERIFY_NONE is not 0x00.

Since the check in question comes out of IO::Socket::SSL and it
follows:
	! $is_server
        and ! $arg_hash->{SSL_reuse_ctx}
        and ! exists $arg_hash->{SSL_verify_mode}
        and $default_args{SSL_verify_mode} == SSL_VERIFY_NONE

where SSL_VERIFY_NONE is defined as:
	use constant SSL_VERIFY_NONE => Net::SSLeay::VERIFY_NONE();

This patch just accepts that Net::SSLeay::VERIFY_NONE() is what we should
have been setting this too all along.

As stated in a previous commit SSL_VERIFY_NONE

Signed-off-by: John 'Warthog9' Hawley <warthog9@eaglescrag.net>