### PR TITLE
Fix logic for non-keepalive connections

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -438,9 +438,7 @@ sub _http_read {
 		# Body might also be empty but a keep-alive with no content-length in the response is an error
 		# if everything has already been read, _http_body_read will unsubscribe to event loop 
 		# we just subscrive above ... a bit unefficient 
-		_http_read_body( $self->socket, $self, $args ) if ( !($self->response->headers->header('Connection') =~ /close/i || 
-															  $headers->header('Connection') !~ /keep-alive/i ) && 
-															$self->socket->_rbuf_length == ($headers->content_length || 0));
+		_http_read_body( $self->socket, $self, $args ) if ( $self->response->headers->header('Connection') =~ /keep-alive/i && $self->socket->_rbuf_length == ($headers->content_length || 0));
 	}
 }
 

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -438,9 +438,9 @@ sub _http_read {
 		# Body might also be empty but a keep-alive with no content-length in the response is an error
 		# if everything has already been read, _http_body_read will unsubscribe to event loop 
 		# we just subscrive above ... a bit unefficient 
-		_http_read_body( $self->socket, $self, $args ) if ( ($self->response->headers->header('Connection') =~ /close/i || 
-															 $headers->header('Connection') !~ /keep-alive/i ) && 
-															 $self->socket->_rbuf_length == ($headers->content_length || 0));
+		_http_read_body( $self->socket, $self, $args ) if ( !($self->response->headers->header('Connection') =~ /close/i || 
+															  $headers->header('Connection') !~ /keep-alive/i ) && 
+															$self->socket->_rbuf_length == ($headers->content_length || 0));
 	}
 }
 


### PR DESCRIPTION
This fixes a problem that occurs on non-keepalive HTTP connections under certain timing conditions.  The logic around deciding if a connection is keepalive is reversed in the case that the fix deals with.  Because of this, the code will sometimes call _http_read_body with a zero length body on non-keepalive connections. A zero length read within _http_read_body is treated as end of data and the connection gets closed.

Since it is timing dependent, I've only noticed this on certain podcasts and not every time.  Sometimes retrying the podcast will make it work.  I've also noticed that with logging enabled it sometimes does not repo.  Here's some podcasts I've noticed the problem:

http://sleepwithmepodcast.libsyn.com/rss
http://feeds.feedburner.com/thornmorris

