### PR TITLE
Add Audio::Scan 1.02 to Scan.pm Version checks

### DIFF
--- a/lib/Audio/Scan.pm
+++ b/lib/Audio/Scan.pm
@@ -7,7 +7,7 @@ our $VERSION;
 require XSLoader;
 
 BEGIN {
-	foreach ('0.99', '0.93', '0.95', '0.94') {
+	foreach ('1.02', '0.99', '0.93', '0.95', '0.94') {
 		eval { XSLoader::load('Audio::Scan', $_); };
 		
 		if (!$@) {


### PR DESCRIPTION
Add 1.02 to version checks in Scan.pm. Audio::Scan in slimserver-vendor has been updated to 1.02 which is ignored by the selective loader in Scan.pm.