### PR TITLE
Some minor podcast parsing issues

### DIFF
--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -416,8 +416,11 @@ sub parseRSS {
 		
 		$feed{'image'} = $url;
 	}
-	elsif ( $xml->{'itunes:image'} ) {
+	elsif ( ref $xml->{'itunes:image'} eq 'HASH' ) {
 		$feed{'image'} = $xml->{'itunes:image'}->{'href'};
+	}
+	elsif ( ref $xml->{'channel'}->{'itunes:image'} eq 'HASH' ) {
+		$feed{'image'} = $xml->{'channel'}->{'itunes:image'}->{'href'};
 	}
 
 	# some feeds (slashdot) have items at same level as channel

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -397,7 +397,14 @@ sub parseRSS {
 		'xmlns:slim'     => unescapeAndTrim($xml->{'xmlsns:slim'}),
 	);
 	
-	# look for an image
+	# Look for an image
+
+	# Note: we take special care to ensure that "$feed{'image'}" is only ever
+	# populated with a *scalar* value. Anything else will break Jive browsing
+	# (SlimBrowserApplet) when it attempts to fetch artwork.
+	# E.g. If a broken podcast provides an empty 'url' tag, 'XMLin' would interpret it
+	# as an empty hash ref. So we explicitly guard against such occurrences.
+
 	if ( ref $xml->{'channel'}->{'image'} ) {
 		
 		my $image = $xml->{'channel'}->{'image'};
@@ -417,13 +424,15 @@ sub parseRSS {
 			$url = $image->{'link'};
 		}
 		
-		$feed{'image'} = $url;
+		$feed{'image'} = $url unless ref $url; # scalar value only !
 	}
 	elsif ( ref $xml->{'itunes:image'} eq 'HASH' ) {
-		$feed{'image'} = $xml->{'itunes:image'}->{'href'};
+		my $href = $xml->{'itunes:image'}->{'href'};
+		$feed{'image'} = $href unless ref $href;
 	}
 	elsif ( ref $xml->{'channel'}->{'itunes:image'} eq 'HASH' ) {
-		$feed{'image'} = $xml->{'channel'}->{'itunes:image'}->{'href'};
+		my $href = $xml->{'channel'}->{'itunes:image'}->{'href'};
+		$feed{'image'} = $href unless ref $href;
 	}
 
 	# some feeds (slashdot) have items at same level as channel

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -402,12 +402,15 @@ sub parseRSS {
 		
 		my $image = $xml->{'channel'}->{'image'};
 		my $url = "";
-		if (ref $image eq 'ARRAY') {
-		  $url   = $image->[0]->{'url'};
+		if (ref $image eq 'HASH') {
+			# conventional RSS feeds simply provide one image element
+			$url = $image->{'url'};
 		}
-		else {
-		  $url   = $image->{'url'};
-    }
+		elsif (ref $image eq 'ARRAY') {
+			# some RSS feeds provide several variant image elements
+			# we pick the first one
+			$url = $image->[0]->{'url'};
+		}
 		
 		# some Podcasts have the image URL in the link tag
 		if ( !$url && $image->{'link'} && $image->{'link'} =~ /(jpg|gif|png)$/i ) {

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -465,6 +465,13 @@ sub parseRSS {
 			$item{'duration'} = unescapeAndTrim($itemXML->{'itunes:duration'});
 			$item{'explicit'} = unescapeAndTrim($itemXML->{'itunes:explicit'});
 
+			# Use episode specific image if there is one.
+			if (ref $itemXML->{'itunes:image'} eq 'HASH') {
+				my $href = $itemXML->{'itunes:image'}->{'href'};
+				# We only want a non null scalar
+				$item{'image'} = $href if $href && ! ref $href;
+			}
+
 			# don't duplicate data
 			if ( $itemXML->{'itunes:subtitle'} && $itemXML->{'title'} && 
 				$itemXML->{'itunes:subtitle'} ne $itemXML->{'title'} ) {


### PR DESCRIPTION
Herewith three proposed changes to Formats::XML to fix up some podcast browsing issues that I have encountered.

- Formats::XML - Podcasts: Fix iTunes image tag recognition

The RSS parser has the ability to use an iTunes image tag if an RSS image tag is not present. Except that it currently looks in the wrong place.

- Formats::XML - Podcasts: Badly formed RSS image URL breaks Jive

I encountered this about 15 months ago, and it was very confusing while it lasted. This change adds a sanitization check to the discovered feed image tag to ensure that we have not been misled by a poorly formed podcast feed and XMLin's interpretation of it.

Try forcing `$feed{'image'}={}` if you wish to observe Jive's curious, and unwelcome, behaviour in this circumstance. It makes a mess of the feed display.

- Formats::XML - Podcasts: Use episode specific image

A minor enhancement (depending on your point of view) to make use of iTunes' episode specific images if they are present in the feed. Not many podcasts that I have encountered make use of this, but, where they do, we have the possibility of adding a little variety to Jive's display of the feed. But at the expense of a little more image processing during  the rendering phase.

 
