### PR TITLE
DSF vs DFF in sample_size

### DIFF
--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -710,7 +710,7 @@ sub stream_s {
 	} elsif ($format eq 'dff' || $format eq 'dsf') {
 
 		$formatbyte      = 'd';
-		$pcmsamplesize   = '?';
+		$pcmsamplesize   = $format eq 'dsf' ? 0 : 1;
 		$pcmsamplerate   = '?';
 		$pcmendian       = '?';
 		$pcmchannels     = '?';


### PR DESCRIPTION
This small patch uses sample_size of strms message with 'd' codec to differentiate between DSF and DFF format, instead of requiring player to open the actual audio data. It's the same re-use of sample_size as of 'a' codec.
It's required for UPnPBridge while not being specific to the plugin (it's just additional information) and should not create any compatibility issue (I've checked squeezelite code) 