### PR TITLE
Expand range for alarm timout to 240 minutes

### DIFF
--- a/HTML/EN/settings/player/alarm.html
+++ b/HTML/EN/settings/player/alarm.html
@@ -150,7 +150,7 @@
 	[% END %]
 
 	[% WRAPPER setting title="SETUP_ALARM_TIMEOUT" desc="SETUP_ALARM_TIMEOUT_DESC" %]
-		<input type="text" class="stdedit sliderInput_0_90" name="pref_alarmTimeoutMinutes" id="pref_alarmTimeoutMinutes" value="[% prefs.pref_alarmTimeoutMinutes %]" size="3">
+		<input type="text" class="stdedit sliderInput_0_240" name="pref_alarmTimeoutMinutes" id="pref_alarmTimeoutMinutes" value="[% prefs.pref_alarmTimeoutMinutes %]" size="3">
 	[% END %]
 
 	[% WRAPPER setting title="ALARM_FADE" desc="" %]


### PR DESCRIPTION
I'd like the maximum time the alarm music can play to be longer than the current 90 minutes which I feel is not enough. Not sure what enough is but 4 hours felt like an OK value to me.

Inspired by https://www.mail-archive.com/discuss@lists.slimdevices.com/msg126165.html