### PR TITLE
fade correction when play/transition single track + webUI logic

### DIFF
--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -127,8 +127,8 @@
 				<select class="stdedit" name="pref_transitionSampleRestriction" id="pref_transitionSampleRestriction">
 
 				[% FOREACH option = {
-					'0' => 'NO',
-					'1' => 'YES',
+					'1' => 'NO',
+					'0' => 'YES',
 				} %]
 					<option [% IF prefs.pref_transitionSampleRestriction == option.key %]selected [% END %]value="[% option.key %]">[% option.value | string %]</option>
 				[%- END -%]

--- a/Slim/Player/ReplayGain.pm
+++ b/Slim/Player/ReplayGain.pm
@@ -198,7 +198,7 @@ sub trackSampleRateMatch {
 	my $offset = shift;
 
 	my ($current_track, $compare_track) = $class->findTracksByIndex($client, $offset);
-	return if (!$current_track || !$compare_track);
+	return 1 if (!$current_track || !$compare_track);
 
 	if (!blessed($current_track) || !blessed($compare_track)) {
 


### PR DESCRIPTION
line 965 of Squeezebox.pm
```
if (!Slim::Player::ReplayGain->trackSampleRateMatch($master, -1) && $transitionSampleRestriction) {
   main::INFOLOG && $log->info('Overriding crossfade due to differing sample rates');
   $transitionType = 0;
   } elsif ($transitionSampleRestriction) {
   main::INFOLOG && $log->info('Crossfade sample rate restriction enabled but not needed for this transition');
   }

```
The UI says 'Crossfade Across Different Sample Rates' Yes/No. When set to No, it sets transitionSampleRestriction to '0', which means no restriction and I don't think this is the intent. It should be when Yes/1 (allow Crossfade) then restriction should be 0 (no restrction).
Then it was 2-in-1 issue because when starting to play a playlist with a single track, the trackSampleRateMatch is returning false where it should return true (previous track == self), so the decision to cancel transition was left to transitionSampleRestriction which was inverted logic. Normally, of course when playing a single track, the restriction shall not apply

line 201 of ReplayGain.pm
`return if (!$current_track || !$compare_track);`
should be
`return 1 if (!$current_track || !$compare_track);`

As function trackSampleRateMatch shall not return false if there is no next track, I would think. This can be debated or refined, i.e. it might return 0 if not current and 1 if not compare, but I can't say "not matching" where there is only one track: it should matches with itself