### PR TITLE
allow fade when possible

### DIFF
--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -127,8 +127,8 @@
 				<select class="stdedit" name="pref_transitionSampleRestriction" id="pref_transitionSampleRestriction">
 
 				[% FOREACH option = {
-					'0' => 'NO',
-					'1' => 'YES',
+					'1' => 'NO',
+					'0' => 'YES',
 				} %]
 					<option [% IF prefs.pref_transitionSampleRestriction == option.key %]selected [% END %]value="[% option.key %]">[% option.value | string %]</option>
 				[%- END -%]

--- a/Slim/Player/ReplayGain.pm
+++ b/Slim/Player/ReplayGain.pm
@@ -198,7 +198,7 @@ sub trackSampleRateMatch {
 	my $offset = shift;
 
 	my ($current_track, $compare_track) = $class->findTracksByIndex($client, $offset);
-	return if (!$current_track || !$compare_track);
+	return 1 if (!$current_track || !$compare_track);
 
 	if (!blessed($current_track) || !blessed($compare_track)) {
 

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -964,7 +964,7 @@ sub stream_s {
 		# by a player preference.
 		my $transitionSampleRestriction = $prefs->client($master)->get('transitionSampleRestriction') || 0;
 
-		if (!Slim::Player::ReplayGain->trackSampleRateMatch($master, -1) && $transitionSampleRestriction) {
+		if (!Slim::Player::ReplayGain->trackSampleRateMatch($master, -1) && $transitionSampleRestriction && ($transitionType == 1 || $transitionType == 5)) {
 			main::INFOLOG && $log->info('Overriding crossfade due to differing sample rates');
 			$transitionType = 0;
 		 } elsif ($transitionSampleRestriction) {


### PR DESCRIPTION
fade in/out/in-out should not be disabled when sample rate don't match, regardless of crossfade option