### PR TITLE
complete play/resume fade-in + true crossfade

### DIFF
--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -139,6 +139,10 @@
 			[% WRAPPER settingGroup title="SETUP_TRANSITIONDURATION" desc="SETUP_TRANSITIONDURATION_DESC" %]
 				<input type="text" class="stdedit sliderInput_0_10" name="pref_transitionDuration" id="pref_transitionDuration" value="[% prefs.pref_transitionDuration %]" size="5">
 			[% END %]
+			
+			[% WRAPPER settingGroup title="SETUP_FADEINDURATION" desc="SETUP_FADEINDURATION_DESC" %]
+				<input type="text" class="stdedit sliderInput_0_10" name="pref_fadeInDuration" id="pref_fadeInDuration" value="[% prefs.pref_fadeInDuration %]" size="5">
+			[% END %]
 
 		[% END %]
 	[% END %]

--- a/Slim/Player/ReplayGain.pm
+++ b/Slim/Player/ReplayGain.pm
@@ -198,7 +198,7 @@ sub trackSampleRateMatch {
 	my $offset = shift;
 
 	my ($current_track, $compare_track) = $class->findTracksByIndex($client, $offset);
-	return 1 if (!$current_track || !$compare_track);
+	return if (!$current_track || !$compare_track);
 
 	if (!blessed($current_track) || !blessed($compare_track)) {
 

--- a/Slim/Web/Settings/Player/Audio.pm
+++ b/Slim/Web/Settings/Player/Audio.pm
@@ -31,7 +31,7 @@ sub needsClient {
 sub prefs {
 	my ($class, $client) = @_;
 
-	my @prefs = qw(powerOnResume lameQuality maxBitrate);
+	my @prefs = qw(powerOnResume lameQuality maxBitrate fadeInDuration);
 
 	if ($client->hasPowerControl()) {
 		push @prefs,'powerOffDac';

--- a/strings.txt
+++ b/strings.txt
@@ -5798,6 +5798,14 @@ SETUP_TRANSITIONDURATION_DESC
 	RU	Введите временной интервал для перекрестного затухания между песнями (в секундах). Максимум — 10 с.
 	SV	Ange varaktighet för korstoningen i sekunder. Maximalt värde är 10 sekunder.
 	ZH_CN	请以秒为单位输入在歌曲之间音频同时淡出淡入的持久时间。最大值为10秒。
+	
+SETUP_FADEINDURATION
+	EN	Play or Resume fade-in duration
+	FR	Durée de montée en volume 
+
+SETUP_FADEINDURATION_DESC
+	EN	When a track is played or resumed, volume can be progressively increased. This is not like crossfade which only happen between tracks
+	FR	Lors du démarrage or de la reprise de la lecture, le volume peut être augmenté progressivement. Ce n'est pas la transition entre pistes
 
 TRANSITION_NONE
 	CS	Žádný


### PR DESCRIPTION
This one is probably going to scare you :-)

After better looking at the crossfading code, I do think that there was some confusion between cross-fading which is really supposed to happen *between* tracks and fading-in when starting to play or resume

For sure, the issue with inverted logic of transitionSampleRestriction was real, but the trackDurationMatch correction was wrong, or not needed. When playing a single track, it's correct to say that sample rate don't match as we probably don't want to cross-fade with ourself, but I don't think that was the point. 

In fact, no crossfade shall be done at all unless the player is really playing, regardless of any restriction, because it is *cross* fade.

Now the incorrect logic made fade-in work when starting a track that was not #1, when it as not killed by the wrong restriction, hence I believe users were confused with a true fade-in feature versus the cross fade.

I've tried to clean the cross fading to make it a true crossfade and then added a new parameter that is a true play/resume fade-in feature which works when your start a track, resume from pause