### PR TITLE
Additional fade-in separated from crossfade

### DIFF
--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -139,6 +139,10 @@
 			[% WRAPPER settingGroup title="SETUP_TRANSITIONDURATION" desc="SETUP_TRANSITIONDURATION_DESC" %]
 				<input type="text" class="stdedit sliderInput_0_10" name="pref_transitionDuration" id="pref_transitionDuration" value="[% prefs.pref_transitionDuration %]" size="5">
 			[% END %]
+			
+			[% WRAPPER settingGroup title="SETUP_FADEINDURATION" desc="SETUP_FADEINDURATION_DESC" %]
+				<input type="text" class="stdedit sliderInput_0_10" name="pref_fadeInDuration" id="pref_fadeInDuration" value="[% prefs.pref_fadeInDuration %]" size="5">
+			[% END %]
 
 		[% END %]
 	[% END %]

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -70,6 +70,7 @@ our $defaultPrefs = {
 	'packetLatency'        => 2,	# ms
 	'startDelay'           => 0,	# ms
 	'playDelay'            => 0,	# ms
+	'fadeInDuration'	   => 0,
 };
 
 $prefs->setChange( sub { $_[2]->volume($_[1]); }, 'volume');
@@ -357,7 +358,10 @@ sub fade_volume {
 
 	my $int = 0.05; # interval between volume updates
 
-	my $vol = abs($prefs->client($client)->get("volume"));
+	# start from current position if still ramping up
+	my $vol = $fade < 0 && abs($client->volume) < abs($prefs->client($client)->get("volume")) ?
+			abs($client->volume) : abs($prefs->client($client)->get("volume"));
+				
 	my $now = Time::HiRes::time();
 	
 	Slim::Utils::Timers::killHighTimers($client, \&_fadeVolumeUpdate);

--- a/Slim/Player/ReplayGain.pm
+++ b/Slim/Player/ReplayGain.pm
@@ -198,7 +198,7 @@ sub trackSampleRateMatch {
 	my $offset = shift;
 
 	my ($current_track, $compare_track) = $class->findTracksByIndex($client, $offset);
-	return 1 if (!$current_track || !$compare_track);
+	return if (!$current_track || !$compare_track);
 
 	if (!blessed($current_track) || !blessed($compare_track)) {
 

--- a/Slim/Web/Settings/Player/Audio.pm
+++ b/Slim/Web/Settings/Player/Audio.pm
@@ -31,7 +31,7 @@ sub needsClient {
 sub prefs {
 	my ($class, $client) = @_;
 
-	my @prefs = qw(powerOnResume lameQuality maxBitrate);
+	my @prefs = qw(powerOnResume lameQuality maxBitrate fadeInDuration);
 
 	if ($client->hasPowerControl()) {
 		push @prefs,'powerOffDac';

--- a/strings.txt
+++ b/strings.txt
@@ -5798,6 +5798,14 @@ SETUP_TRANSITIONDURATION_DESC
 	RU	Введите временной интервал для перекрестного затухания между песнями (в секундах). Максимум — 10 с.
 	SV	Ange varaktighet för korstoningen i sekunder. Maximalt värde är 10 sekunder.
 	ZH_CN	请以秒为单位输入在歌曲之间音频同时淡出淡入的持久时间。最大值为10秒。
+	
+SETUP_FADEINDURATION
+	EN	Play or Resume fade-in duration
+	FR	Durée de montée en volume 
+
+SETUP_FADEINDURATION_DESC
+	EN	When a track is played or resumed, volume can be progressively increased. This is not like crossfade which only happen between tracks
+	FR	Lors du démarrage or de la reprise de la lecture, le volume peut être augmenté progressivement. Ce n'est pas la transition entre pistes
 
 TRANSITION_NONE
 	CS	Žádný


### PR DESCRIPTION
Well, I think I have something consistent now:

Crossfade is limited to between-songs fading, in other words it only applies when LMS is moving automatically from one track to the other in a playlist

When a player is stopped an user starts to play a track, crossfade fade-in does not kick-in, but fade-out or crossmix will at the end of the track (if setup to do so).
When LMS will move to next track, then fade-in (if selected) will be applied. When crossfade fade-in-out is selected, 1st track will only fade out, then further track will fade-in and fade-out.
When user pauses or repositions a track, crossfade fade-in will not kick-in either.
Fade rules are applied by the player, as specified by slimproto, LMS does not uses volume commands to simulate it.

The new "Play or resume fade-in duration" option, applies only when player was stopped/paused and a track starts/resumes or when user repositions in a track.
Such fade-in is made by LMS sending a serie of volume commands (using fade_volume). It nevers applies when LMS automatically moves to next playlist track (crossfade settings apply then)

As fadeIn is also an option of command line play/resume, value set there will take precedence

Previously, crossfade fade-in was not applied when starting 1st track, but might have been when starting another track in a playlist or sometimes when resuming/repositioning, all depending on timing of request

I've tried to minimize changes and when this new fade-in options is disabled, there should be not impact. Having said that, I had to change fade_volume a bit although I don't think there are side effects this is probably a watchitem. 

One thing that surprises me is that the master of the group decides if crossfade is applied or not. Knowing that users usually don't know who is the master, I don't understand why this is not a per-player decision, but I've adopted the same logic in the fade-in new feature.

I hope it satisfies users who want a smooth "start" when they play/resume but don't want crossfade between tracks, or want a different cross-fade. I personally feels that this new fade-in option should have a short duration but setting crossfade longer sounds better ... anyway I'm not sure these fade options are widely used.

(and I messed up with pull requests & forks ... but it should be fine now, sorry)