### PR TITLE
Support playback restore after player power loss

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -379,7 +379,13 @@ sub clientForgetCommand {
 		main::INFOLOG && $log->info($client->id . ': not forgetting as connected again');
 		return;
 	}
-	
+
+	# Persist playback state like we would do when turning off a player, that is, treat a vanishing
+	# player that's still playing the same way as a player that's turned off while still playing, so
+	# we can make it start playing again if it reappears and the user told us to resume playing
+	# when powering on.
+	$client->persistPlaybackStateForPowerOff();
+
 	$client->controller()->playerInactive($client);
 
 	$client->forgetClient();

--- a/Slim/Formats/Playlists/Base.pm
+++ b/Slim/Formats/Playlists/Base.pm
@@ -23,6 +23,7 @@ sub _updateMetaData {
 	my $playlistUrl = shift;
 
 	my $attributes = {};
+	my $playlist = 0;
 	
 	if ( Slim::Music::Info::isVolatile($playlistUrl) ) {
 		$entry =~ s/^file/tmp/;
@@ -39,6 +40,13 @@ sub _updateMetaData {
 		}
 	}
 	
+	# Treat radio stream as playlist, because that's what they are.
+	# If we don't do this, we'll end up attempting to play the served m3u.
+
+	if ($entry =~ m{^http[s]?://opml\.(?:radiotime|tunein)\.com}) {
+		$playlist = 1;
+	}
+
 	# Bug 6294, only updateOrCreate the track if the track
 	# doesn't already exist in the database.  $attributes will be
 	# set if it's a remote playlist and we want to update the metadata
@@ -55,6 +63,7 @@ sub _updateMetaData {
 			'url'        => $entry,
 			'attributes' => $attributes,
 			'readTags'   => 1,
+			'playlist'   => $playlist,
 		} );
 	}
 	

--- a/Slim/Player/Client.pm
+++ b/Slim/Player/Client.pm
@@ -561,6 +561,15 @@ sub forgetClient {
 	}
 }
 
+sub persistPlaybackStateForPowerOff {
+	my $client = shift;
+
+	if ($client->power()) {
+		my $playing = $client->controller()->isPlaying(1);
+		$prefs->client($client)->set('playingAtPowerOff', $playing);
+	}
+}
+
 sub startup {
 	my $client = shift;
 	my $syncgroupid = shift;

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -110,8 +110,8 @@ sub init {
 	Slim::Buttons::Home::updateMenu($client);
 
 	# fire it up!
-	$client->power($prefs->client($client)->get('power'));
 	$client->startup($syncgroupid);
+	$client->power($prefs->client($client)->get('power'));
 
 	return if $client->display->isa('Slim::Display::NoDisplay');
 		

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -111,7 +111,7 @@ sub init {
 
 	# fire it up!
 	$client->startup($syncgroupid);
-	$client->power($prefs->client($client)->get('power'));
+	$client->power($prefs->client($client)->get('power'), 0, 1);
 
 	return if $client->display->isa('Slim::Display::NoDisplay');
 		
@@ -202,11 +202,12 @@ sub power {
 	my $client = shift;
 	my $on     = shift;
 	my $noplay = shift;
+	my $force  = shift;
 	
 	my $currOn = $prefs->client($client)->get('power') || 0;
 
 	return $currOn unless defined $on;
-	return unless (!defined(Slim::Buttons::Common::mode($client)) || ($currOn != $on));
+	return unless (!defined(Slim::Buttons::Common::mode($client)) || ($currOn != $on)) || $force;
 
 	my $resume = $prefs->client($client)->get('powerOnResume');
 	$resume =~ /(.*)Off-(.*)On/;


### PR DESCRIPTION
The commits in this PR are meant to support correctly restoring playback (especially radio station playback) after the player disappeared after losing power. Previously radio station playback didn't resume after restoring power.
My use case is a SB receiver I've mounted in some cabinet in my bathroom whose power supply is switched by a wall (light) switch. I usually use this one with radio stations, so want to turn it off via wall switch and want it to continue playback when I turn it on via wall switch again.

For rationale on each part of the change, please see the commit messages.