### PR TITLE
Scanner: Add playlist logging to the Media Scanning log set

### DIFF
--- a/Slim/Utils/Log.pm
+++ b/Slim/Utils/Log.pm
@@ -820,6 +820,7 @@ sub logGroups {
 				'database.info'          => 'DEBUG',
 				'plugin.itunes'          => 'DEBUG',
 				'plugin.musicip'         => 'DEBUG',
+				'formats.playlists'      => 'DEBUG',
 			},
 			label => 'DEBUG_SCANNER_CHOOSE',
 		},

--- a/Slim/Utils/Log.pm
+++ b/Slim/Utils/Log.pm
@@ -820,7 +820,9 @@ sub logGroups {
 				'database.info'          => 'DEBUG',
 				'plugin.itunes'          => 'DEBUG',
 				'plugin.musicip'         => 'DEBUG',
-				'formats.playlists'      => 'DEBUG',
+				'database.virtuallibraries' => 'DEBUG'
+				'formats.audio'          => 'ERROR',
+				'formats.playlists'      => 'ERROR',
 			},
 			label => 'DEBUG_SCANNER_CHOOSE',
 		},


### PR DESCRIPTION
This proposed change adds the playlist parsers to the Media Scanning log set in order to facilitate, in particular, debugging cue list parsing.

When run as a separate process by Slim::Music::Import::launchScan[1], the scanner logs according to:

a) The persistent log settings (those active as a result of "Save logging settings for use at next application restart"),

but overridden by:

b) The current log settings actually in force for the scanner log group.

Currently, playlist parsers are not included in the scanner log group.

So to debug, for example, cue list parsing, it is necessary to set the desired log level for 'formats.playlists', save log settings "for use at next application restart"", and then run the scanner. After which one must remember to put the log levels back to what they were before.

This user does not find the process intuitive, repeatedly forgets all about it, and becomes frustrated.

The difficulty can be overcome by adding the playlist parsers to the scanner log group. These parsers log to the 'formats.playlists' category.

We must also, however, assign a default log level. This only comes into play if the user should select the pre-defined default Media Scanner log set for use. I have proposed 'DEBUG', for consistency with the other default log settings. It could equally well be, say, 'ERROR' if 'DEBUG' is felt to be too noisy for the average use case. The important thing is that playlist logging be added to the scanner log group.

[1] This appears to be standard behaviour on my Debian based system when I manually choose to "Rescan Media Library". Probably a very good thing, the system is not exactly overpowered.
