### PR TITLE
Various minor fixes to LMS logging

### DIFF
--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -22,7 +22,7 @@ use Slim::Utils::Versions;
 our (%tagClasses, %loadedTagClasses);
 
 my $init = 0;
-my $log  = logger('formats');
+my $log  = logger('formats.audio');
 
 =head1 NAME
 

--- a/Slim/Networking/Async.pm
+++ b/Slim/Networking/Async.pm
@@ -111,6 +111,7 @@ sub connect {
 	
 	# Bug 5673, avoid a crash if socket is undef
 	if ( !defined $socket ) {
+		$log->error("Failed to connect to $host:$port, because\n$@");
 		_connect_error( $socket, $self, $args );
 		return;
 	}

--- a/Slim/Plugin/InternetRadio/Plugin.pm
+++ b/Slim/Plugin/InternetRadio/Plugin.pm
@@ -10,7 +10,12 @@ use Slim::Plugin::InternetRadio::TuneIn;
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 
-my $log   = logger('plugin.radio');
+my $log = Slim::Utils::Log->addLogCategory({
+	'category'     => 'plugin.radio',
+	'defaultLevel' => 'ERROR',
+	'description'  => 'RADIO',
+});
+
 my $prefs = preferences('server');
 
 sub initPlugin {

--- a/Slim/Schema/RemoteTrack.pm
+++ b/Slim/Schema/RemoteTrack.pm
@@ -389,8 +389,9 @@ sub fetchById {
 sub get {
 	my ($self, $attribute) = @_;
 
-	main::DEBUGLOG && $log->is_debug && $log->debug($self->_url, ', ', $attribute, '->', $self->$attribute());
-	
+	main::DEBUGLOG && $log->is_debug &&
+		$log->debug($self->_url, ', ', $attribute, '->', $self->$attribute() || "* undefined value *");
+
 	return($self->$attribute());
 }
 

--- a/Slim/Utils/Log.pm
+++ b/Slim/Utils/Log.pm
@@ -919,6 +919,7 @@ sub logLevels {
 		'player.sync'                => 'ERROR',
 		'player.text'                => 'ERROR',
 		'player.ui'                  => 'ERROR',
+		'player.ui.screensaver'      => 'ERROR',
 
 		'scan'                       => 'ERROR',
 		'scan.auto'                  => 'DEBUG', # XXX forced on because there will be problems


### PR DESCRIPTION
From time to time I have come across various small deficiencies in LMS's logging output, which I have been motivated enough to correct. So I am offering them up in case they are seen to have any value.

**Slim::Formats**
Logging fails to work because the predefined log category 'formats' has not been set up.
In reality, this log output is probably better served up under the 'formats.audio' category, and this change gives effect to that. The predefined 'formats.audio' category does exist.

This issue appears to have been in existence since the adoption of Log4perl debugging.
Refer commit 6f27c52f 'Implement Log::Log4perl debugging'.

**Internet Radio Plugin**
Its log category, 'plugin.radio', does not exist, so log output is not available. This change sets it up.

**Slim::Networking::Async**
Adds some diagnostic output if there is a socket creation or connection failure. I have found that it helps in diagnosing the problem.

**Slim::Buttons::ScreenSaver/Slim::Utils::Log**
Logging fails to work because the predefined log category 'player.ui.screensaver' has not been set up. This change sets up the expected predefined category with a default log level of 'ERROR'.

The issue appears to have been in existence since the adoption of Log4perl debugging.

**Slim::Schema::RemoteTrack::get**
There is a debug trace that reports the getting of an attribute and its value. It doesn't handle undefined values prettily, this change improves that.


