### PR TITLE
strings.txt: Descriptions for player.ui.screensaver log category

### DIFF
--- a/strings.txt
+++ b/strings.txt
@@ -20499,6 +20499,21 @@ DEBUG_PLAYER_UI
 	RU	Информация о пользовательском интерфейсе плеера
 	SV	Information om användargränssnitt för spelaren
 
+DEBUG_PLAYER_UI_SCREENSAVER
+	CS	Protokolování spořič obrazovky
+	DA	Logføring af pauseskærm
+	DE	Bildschirmschoner-Protokollierung
+	EN	Player Screensaver Logging
+	ES	Registro de protector de pantalla
+	FI	Näytönsäästäjänä kirjaaminen
+	FR	Journalisation d'écran de veille
+	IT	Registrazione del salvaschermo del lettore
+	NL	Registratie van schermbeveiliger
+	NO	Loggføring av spiller skjermsparer
+	PL	Rejestrowanie wygaszacz ekranu
+	RU	Ведение журнала экранной заставка
+	SV	Loggning för skärmsläckare
+
 DEBUG_PLAYER_DISPLAY
 	CS	Informace na displeji přehrávače
 	DA	Oplysninger om afspillerens display


### PR DESCRIPTION
This proposed change adds (translated) descriptive texts for the newly created 'player.ui.screensaver' log category.

They were omitted from the relevant commit 3c6b8599: 'Slim::Utils::Log: Missing log category player.ui.screensaver'. In consequence, the web interface shows the description `DEBUG_PLAYER_UI_SCREENSAVER` in the log setup page.

I made the translations by picking out the relevant  key words from other translated texts in `strings.txt`, and ran the results through Google Translate to identify any obvious errors.

Native speakers may well find fault with my attempt. I don't have the language knowledge.
