### PR TITLE
Non-blocking HTTPS with `Slim::Networking::Async::Socket::HTTPS`

### DIFF
--- a/Slim/Networking/Async/Socket/HTTPS.pm
+++ b/Slim/Networking/Async/Socket/HTTPS.pm
@@ -14,7 +14,7 @@ BEGIN {
 	use IO::Socket::SSL;
 }
 
-use base qw(Net::HTTPS Slim::Networking::Async::Socket);
+use base qw(Net::HTTPS::NB Slim::Networking::Async::Socket);
 
 sub close {
 	my $self = shift;


### PR DESCRIPTION
Addresses #261.

Note that a new dependency is introduced on `Net::HTTPS::NB`.  Should this be copied into the `CPAN/` directory?