### PR TITLE
Add a simple EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.p[lm]]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
Tell text editors that our Perl files use tabs for indentation.  See https://editorconfig.org/ for more details.