### PR TITLE
Non-blocking TLS handshake

### DIFF
--- a/Slim/Networking/Async/Socket/HTTPS.pm
+++ b/Slim/Networking/Async/Socket/HTTPS.pm
@@ -16,6 +16,12 @@ BEGIN {
 
 use base qw(Net::HTTPS::NB Slim::Networking::Async::Socket);
 
+sub new {
+	my ($class, %args) = @_;
+	$args{'Blocking'} = 0;
+	return $class->SUPER::new(%args);
+}
+
 sub close {
 	my $self = shift;
 


### PR DESCRIPTION
This follows on from #261.  Swapping `Net::HTTPS` with `Net::HTTPS::NB` in commit 6cd3812 isn't sufficient to solve the problem entirely, since `Net::HTTPS::NB` performs a blocking TLS handshake by default.