### PR TITLE
Stricter HTTPS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 root = true
 
-[*.p[lm]]
+[*.{html,p[lm]}]
 indent_style = tab
 indent_size = 8

--- a/Changelog8.html
+++ b/Changelog8.html
@@ -12,6 +12,7 @@
 	<li>Server Changes:</li>
 	<ul>
 		<li><a href="https://github.com/Logitech/slimserver/pull/305">PR #305</a> - use ORIGINALYEAR in FLAC files to override YEAR (thanks jcbodnar!)</li>
+                <li><a href="https://github.com/Logitech/slimserver/pull/267">PR #267</a> - HTTPS certificates are now validated when LMS acts as a client.  HTTPS connections to plugin repositories are no-longer retried over HTTP when they fail.  The old insecure behaviour can optionally be re-enabled, although, instead, we recommend working out why HTTPS is broken in your environment and fixing that if possible.</li>
 	</ul>
 	<br />
 	

--- a/HTML/EN/settings/server/security.html
+++ b/HTML/EN/settings/server/security.html
@@ -50,6 +50,10 @@
 		[% WRAPPER settingGroup title="SETUP_CORS_ALLOWED_HOSTS" desc="SETUP_CORS_ALLOWED_HOSTS_DESC" %]
 			<input type="text" class="stdedit" name="pref_corsAllowedHosts" id="corsAllowedHosts" value="[% prefs.pref_corsAllowedHosts %]" size="40">
 		[% END %]
+
+		[% WRAPPER settingGroup title="SETUP_INSECURE_HTTPS" desc="SETUP_INSECURE_HTTPS_DESC" %]
+			<input type="checkbox" name="pref_insecureHTTPS" id="insecureHTTPS" [% IF prefs.pref_insecureHTTPS %] checked="checked" [% END %] />
+		[% END %]
 	[% END %]
 [% PROCESS settings/footer.html %]
 

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -116,6 +116,8 @@ sub new_socket {
 
 			# Failed. Try again with an explicit SNI.
 			$args{SSL_hostname} = $args{Host};
+			$args{SSL_verify_mode} = Net::SSLeay::VERIFY_NONE()
+                            if $prefs->get('insecureHTTPS');
 			if ($self->socks) {
 				return Slim::Networking::Async::Socket::HTTPSSocks->new( %{$self->socks}, %args );
 			}

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -112,19 +112,6 @@ sub new_socket {
 			# So we will probably need to explicitly set "SSL_hostname" if we are to succeed with such
 			# a server.
 
-			# First, try without explicit SNI, so we don't inadvertently break anything.
-			# (This is the 'old' behaviour.) (Probably overly conservative.)
-
-			my $sock;
-
-			if ($self->socks) {
-				$sock = Slim::Networking::Async::Socket::HTTPSSocks->new( %{$self->socks}, @_ );
-			}
-			else {
-				$sock = Slim::Networking::Async::Socket::HTTPS->new( @_ );
-			}
-			return $sock if $sock;
-
 			my %args = @_;
 
 			# Failed. Try again with an explicit SNI.

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -116,7 +116,6 @@ sub new_socket {
 
 			# Failed. Try again with an explicit SNI.
 			$args{SSL_hostname} = $args{Host};
-			$args{SSL_verify_mode} = Net::SSLeay::VERIFY_NONE();
 			if ($self->socks) {
 				return Slim::Networking::Async::Socket::HTTPSSocks->new( %{$self->socks}, %args );
 			}

--- a/Slim/Networking/Repositories.pm
+++ b/Slim/Networking/Repositories.pm
@@ -142,16 +142,9 @@ sub get {
 		my ($http, $error) = @_;
 
 		my $url = $http->url;
-
 		$log->error("Failed to fetch $url: $error");
 
-		if ($url =~ s/^(http)s:/$1:/) {
-			$log->warn("https lookup failed - trying plain text http instead: $url");
-			Slim::Networking::SimpleAsyncHTTP->new($cb, $ecb, $params)->get($url);
-		}
-		else {
-			$ecb->($http, $error)
-		}
+		$ecb->($http, $error);
 	}, $params)->get( $url );
 }
 

--- a/Slim/Networking/Repositories.pm
+++ b/Slim/Networking/Repositories.pm
@@ -144,7 +144,13 @@ sub get {
 		my $url = $http->url;
 		$log->error("Failed to fetch $url: $error");
 
-		$ecb->($http, $error);
+		if ($prefs->get('insecureHTTPS') and $url =~ s/^(http)s:/$1:/) {
+			$log->warn("https lookup failed - trying plain text http instead: $url");
+			Slim::Networking::SimpleAsyncHTTP->new($cb, $ecb, $params)->get($url);
+		}
+		else {
+			$ecb->($http, $error);
+		}
 	}, $params)->get( $url );
 }
 

--- a/Slim/Networking/SqueezeNetwork.pm
+++ b/Slim/Networking/SqueezeNetwork.pm
@@ -439,26 +439,6 @@ sub _createHTTPRequest {
 		return;
 	}
 
-=pod
-	# when dealing with an https url, wrap the error handler in some code to fall back to http on failure
-	if ($url =~ /^https:/) {
-		my $ecb = $self->ecb;
-
-		$self->ecb(sub {
-			my ($self, $error) = @_;
-
-			# XXX - fallback should probably only be used if we failed du to some https issue
-			# Connect timed out: Connection refused - https not available on server
-			$log->error("Failed to fetch $url: $error");
-			$url =~ s/^https:/http:/;
-			$log->warn("https lookup failed - trying plain text http instead: $url");
-
-			$self->ecb($ecb);
-			$self->SUPER::_createHTTPRequest( $type, $url, @args);
-		});
-	}
-=cut
-
 	$self->SUPER::_createHTTPRequest( $type, $url, @args );
 }
 

--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -31,7 +31,6 @@ sub new {
 		PeerAddr => $server,
 		PeerPort => $port,
 		SSL_startHandshake => 1,
-		SSL_verify_mode => Net::SSLeay::VERIFY_NONE()		# SSL_VERIFY_NONE isn't recognized on some platforms?!?, and 0x00 isn't always "right"
 	) or do {
 
 		$log->error("Couldn't create socket binding to $main::localStreamAddr with timeout: $timeout - $!");

--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -31,6 +31,9 @@ sub new {
 		PeerAddr => $server,
 		PeerPort => $port,
 		SSL_startHandshake => 1,
+		( $prefs->get('insecureHTTPS')
+		  ? (SSL_verify_mode => Net::SSLeay::VERIFY_NONE())           # SSL_VERIFY_NONE isn't recognized on some platforms?!?, and 0x00 isn't always "right"
+		  : () ),
 	) or do {
 
 		$log->error("Couldn't create socket binding to $main::localStreamAddr with timeout: $timeout - $!");

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -224,6 +224,7 @@ sub init {
 		'authorize'             => 0,
 		'username'              => '',
 		'password'              => '',
+		'insecureHTTPS'         => 0,
 		# Server Settings - TextFormatting
 		'longdateFormat'        => q(%A, %B |%d, %Y),
 		'shortdateFormat'       => q(%m/%d/%Y),

--- a/Slim/Web/Settings/Server/Security.pm
+++ b/Slim/Web/Settings/Server/Security.pm
@@ -23,7 +23,7 @@ sub page {
 }
 
 sub prefs {
-	return (preferences('server'), qw(filterHosts allowedHosts corsAllowedHosts csrfProtectionLevel authorize username) );
+	return (preferences('server'), qw(filterHosts allowedHosts corsAllowedHosts csrfProtectionLevel authorize username insecureHTTPS) );
 }
 
 sub handler {

--- a/strings.txt
+++ b/strings.txt
@@ -8740,6 +8740,12 @@ SETUP_CSRFPROTECTIONLEVEL_DESC
 	SV	För att skydda dig mot så kallade CSRF-säkerhetshot (Cross Site Request Forgery) granskas varje HTTP-begäran extra noggrant om den gäller funktioner där datorn, spelarna eller spellistorna kan manipuleras. Du kan själv välja hur noggrant granskningen ska utföras. Standardnivån är Ingen. Mer information <a href="/html/docs/http.html#csrf">finns i hjälpavsnittet</a>.
 	ZH_CN	为了免受&quot;CSRF&quot;安全威胁，Logitech Media Server会向那些可能变动您的系统或操作播放表的HTTP请求特别察视。您可以选择此察视的严密程度。缺省为中等。详情请参阅<a href="/html/docs/http.html#csrf">帮助部分</a>。
 
+SETUP_INSECURE_HTTPS
+	EN	Insecure HTTPS
+
+SETUP_INSECURE_HTTPS_DESC
+	EN	Turning on this option switches off TLS certificate verification when Logitech Media Server acts as an HTTPS client. It also causes HTTPS requests to plugin repositories which fail for any reason to be retried over HTTP. <b>Enabling this option is discouraged!</b>
+
 SETUP_IPFILTER_HEAD
 	CS	Blokovat příchozí spojení
 	DA	Blokér indgående forbindelser


### PR DESCRIPTION
For an explanation of the motivation of these changes, see the individual commits.

I expect that, nowadays, lax handing of TLS is no-longer needed; so many more things in the world require it, so any problems are likely to have been fixed.

I think it’s reasonable to merge this with a view to reverting it if it turns out to cause serious issues for nightly users.