### PR TITLE
Change to detect MPEG-4 files with leading mdat. These files have the…

### DIFF
--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -59,8 +59,10 @@ sub init {
 		'wmap' => 'Slim::Formats::WMA',
 		'wmal' => 'Slim::Formats::WMA',
 		'alc' => 'Slim::Formats::Movie',
+		'alcx' => 'Slim::Formats::Movie',
 		'aac' => 'Slim::Formats::Movie',
 		'mp4' => 'Slim::Formats::Movie',
+		'mp4x' => 'Slim::Formats::Movie',
 		'sls' => 'Slim::Formats::Movie',
 		'shn' => 'Slim::Formats::Shorten',
 		'mpc' => 'Slim::Formats::Musepack',
@@ -253,6 +255,11 @@ sub readTags {
 	if (-e $filepath) {
 		# cache the file size & date
 		($tags->{'FILESIZE'}, $tags->{'TIMESTAMP'}) = (stat(_))[7,9];
+	}
+
+	if ($tags->{'LEADING_MDAT'}) {
+		$type = 'mp4x';
+		$tags->{'CONTENT_TYPE'} = 'alcx' if ($tags->{'CONTENT_TYPE'} eq 'alc')
 	}
 
 	# Only set if we couldn't read it from the file.

--- a/Slim/Formats/Movie.pm
+++ b/Slim/Formats/Movie.pm
@@ -50,7 +50,7 @@ sub getTag {
 	
 	my $info = $s->{info};
 	my $tags = $s->{tags};
-	
+
 	return unless $info->{song_length_ms};
 	
 	# skip files with video tracks
@@ -67,6 +67,7 @@ sub getTag {
 	$tags->{SECS}         = $info->{song_length_ms} / 1000;
 	$tags->{BITRATE}      = $info->{avg_bitrate};
 	$tags->{DLNA_PROFILE} = $info->{dlna_profile} || undef;
+	$tags->{LEADING_MDAT} = $info->{leading_mdat} || undef;
 	
 	if ( my $track = $info->{tracks}->[0] ) {
 		# MP4 file

--- a/convert.conf
+++ b/convert.conf
@@ -89,6 +89,10 @@ mp4 mp3 * *
 	# FB:{BITRATE=--abr %B}T:{START=-j %s}U:{END=-e %u}
 	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [lame] --silent -q $QUALITY$ $BITRATE$ - -
 
+mp4x mp3 * *
+	# FB:{BITRATE=--abr %B}T:{START=-j %s}U:{END=-e %u}
+	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [lame] --silent -q $QUALITY$ $BITRATE$ - -
+
 aac mp3 * *
 	# IFB:{BITRATE=--abr %B}
 	[faad] -q -w -f 1 $FILE$ | [lame] --silent -q $QUALITY$ $BITRATE$ - -
@@ -98,6 +102,10 @@ sls mp3 * *
 	[sls] $FILE$ - -s | [lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 alc mp3 * *
+	# FB:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}T:{START=-j %s}U:{END=-e %u}
+	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
+
+alcx mp3 * *
 	# FB:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}T:{START=-j %s}U:{END=-e %u}
 	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
@@ -215,12 +223,20 @@ mpc aif * *
 alc pcm * *
 	# FT:{START=-j %s}U:{END=-e %u}
 	[faad] -q -w -f 2 $START$ $END$ $FILE$
+	
+alcx pcm * *
+	# FT:{START=-j %s}U:{END=-e %u}
+	[faad] -q -w -f 2 $START$ $END$ $FILE$
 
 wvp pcm * *
 	# FT:{START=--skip=%t}U:{END=--until=%v}
 	[wvunpack] $FILE$ -rq $START$ $END$ -o -
 
 mp4 pcm * *
+	# FT:{START=-j %s}U:{END=-e %u}
+	[faad] -q -w -f 2 -b 1 $START$ $END$ $FILE$
+
+mp4x pcm * *
 	# FT:{START=-j %s}U:{END=-e %u}
 	[faad] -q -w -f 2 -b 1 $START$ $END$ $FILE$
 
@@ -285,6 +301,10 @@ mp4 flc * *
 	# FT:{START=-j %s}U:{END=-e %u}
 	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [flac] -cs --totally-silent --compression-level-0 --ignore-chunk-sizes -
 
+mp4x flc * *
+	# FT:{START=-j %s}U:{END=-e %u}
+	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [flac] -cs --totally-silent --compression-level-0 --ignore-chunk-sizes -
+
 aac flc * *
 	# IF
 	[faad] -q -w -f 1 $FILE$ | [flac] -cs --totally-silent --compression-level-0 --ignore-chunk-sizes -
@@ -296,6 +316,11 @@ sls flc * *
 alc flc * *
 	# FT:{START=-j %s}U:{END=-e %u}D:{RESAMPLE=-r %d}
 	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [sox] -q -t wav - -t flac -C 0 $RESAMPLE$ -
+
+alcx flc * *
+	# FT:{START=-j %s}U:{END=-e %u}D:{RESAMPLE=-r %d}
+	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [sox] -q -t wav - -t flac -C 0 $RESAMPLE$ -
+
 
 wvp flc * *
 	# FT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}

--- a/strings.txt
+++ b/strings.txt
@@ -11599,7 +11599,7 @@ ALC
 	SV	Apple Lossless
 
 ALCX
-	EN	Apple Lossless leading mdat
+	EN	Apple Lossless leading audio
 
 MOV
 	CS	Film QuickTime
@@ -11647,7 +11647,7 @@ MP4
 	SV	MPEG-4
 
 MP4X
-	EN	MPEG-4 leading mdat
+	EN	MPEG-4 leading audio
 
 SLS
 	CS	MPEG-4 SLS / HD-AAC

--- a/strings.txt
+++ b/strings.txt
@@ -11598,6 +11598,9 @@ ALC
 	RU	Apple Lossless
 	SV	Apple Lossless
 
+ALCX
+	EN	Apple Lossless leading mdat
+
 MOV
 	CS	Film QuickTime
 	DA	QuickTime-film
@@ -11642,6 +11645,9 @@ MP4
 	PL	MP4
 	RU	MPEG-4
 	SV	MPEG-4
+
+MP4X
+	EN	MPEG-4 leading mdat
 
 SLS
 	CS	MPEG-4 SLS / HD-AAC

--- a/types.conf
+++ b/types.conf
@@ -10,6 +10,7 @@
 #########################################################################
 aif     aif,aiff        audio/x-aiff                    audio
 alc     -               audio/x-m4a-lossless            audio
+alcx     -              -                               audio
 ape     ape             audio/monkeys-audio             audio
 app     app,class       application/x-java-applet       -
 asx     asx,wax         video/asx,application/asx,application/vnd.ms-asf,video/x-ms-asf,audio/x-ms-wax,audio/x-ms-asf,video/x-ms-wvx   playlist 
@@ -35,6 +36,7 @@ lnk     lnk             application/windowsshortcut     list
 m3u     m3u,m3u8        audio/mpegurl,audio/x-mpegurl   playlist
 aac     aac             audio/aac,audio/aacp            audio
 mp4     m4a,mp4,m4b     audio/m4a,audio/x-m4a,audio/mp4 audio
+mp4x    -               -                               audio
 mp3     mp2,mp3         audio/mpeg,audio/mp3,audio/mp3s,audio/x-mpeg,audio/mpeg3,audio/mpg audio
 mpc     mpc,mp+         audio/x-musepack                audio
 ogg     ogg,oga         audio/x-ogg,application/ogg,audio/ogg,application/x-ogg       audio


### PR DESCRIPTION
… audio index at the

end of the file and so cannot be played streaming. Player with native AAC/ALAC such as
Radio, Touch, squeezelite when trying to play these file will log LMS error
"Decoder does not support file format, code 0".
This change creates new audio types alcx and mp4x for these files and so will always
be transcoded. The new types appear in FileTypes settings as "MP-4 leading mdat"
"Apple Lossless leading mdat"

Users can "fix" these files by using ffmpeg "movflags +faststart" option.