### PR TITLE
Initial attempt to sort 'All Songs' using album years (if set to do so)

### DIFF
--- a/HTML/EN/html/docs/cli-api.html
+++ b/HTML/EN/html/docs/cli-api.html
@@ -6906,6 +6906,18 @@ in the saved playlists folder.</p>
 		playback will start with the indicated track.
 		</td>
 	</tr>
+
+	<tr>
+		<td>sort</td>
+		<td>
+			Album sort order. One of &quot;album&quot;, (the default),
+			&quot;new&quot; (sort by change date in descending order),
+			&quot;artflow&quot; which sorts by artist, year, album for use with
+			artwork-centric interfaces,	&quot;artistalbum&quot;, &quot;yearalbum&quot;,
+			&quot;yearartistalbum&quot;, &quot;random&quot;. Only of relevance
+			if genre_id, artist_id or year|year_id is supplied.
+		</td>
+	</tr>
 </table>
 <p>Returned tagged parameters:</p>
 <table border="0" spacing="50">

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -3259,7 +3259,6 @@ sub _playlistXtracksCommand_parseSearchTerms {
 	my $client = shift;
 	my $what   = shift;
 	my $cmd    = shift;
-	my $sortParam = shift;
 
 	# if there isn't an = sign, then change the first : to a =
 	if ($what !~ /=/) {

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -3411,7 +3411,6 @@ sub _playlistXtracksCommand_parseSearchTerms {
 			$sort = $albumYearSort;
 		} elsif ($value ne 'artistalbum' && $value ne 'new' && $value ne 'random') {
 			# Only use sort value if it is **not** an album sort.
-			# TODO: Better way to check this?
 			$sort = $value;
 		}
 	}

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -2050,7 +2050,7 @@ sub playlistcontrolCommand {
 			$what->{'year.id'} = $year_id;
 		}
 		
-		@tracks = _playlistXtracksCommand_parseSearchTerms($client, $what, $cmd);
+		@tracks = _playlistXtracksCommand_parseSearchTerms($client, $what, $cmd, $request->getParam('sort'));
 	}
 
 	# don't call Xtracks if we got no songs
@@ -3255,6 +3255,7 @@ sub _playlistXtracksCommand_parseSearchTerms {
 	my $client = shift;
 	my $what   = shift;
 	my $cmd    = shift;
+	my $sortParam = shift;
 
 	# if there isn't an = sign, then change the first : to a =
 	if ($what !~ /=/) {
@@ -3271,9 +3272,10 @@ sub _playlistXtracksCommand_parseSearchTerms {
 	my $sqlHelperClass = Slim::Utils::OSDetect->getOS()->sqlHelperClass();
 	
 	my $collate = $sqlHelperClass->collate();
-	
-	my $albumSort 
-		= $sqlHelperClass->append0("album.titlesort") . " $collate"
+
+	my $sortAlbumsByYear = $sortParam eq 'artflow' || $sortParam eq 'yearalbum' || $sortParam eq 'yearartistalbum';
+	my $albumSort = $sortAlbumsByYear ? $sqlHelperClass->append0("album.year") . ", " : "";
+	$albumSort = $albumSort . $sqlHelperClass->append0("album.titlesort") . " $collate"
 		. ', me.disc, me.tracknum, '
 		. $sqlHelperClass->append0("me.titlesort") . " $collate";
 		

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -3407,8 +3407,10 @@ sub _playlistXtracksCommand_parseSearchTerms {
 		my $value = $terms->{'sort'};
 
 		if ($value eq 'artflow' || $value eq 'yearartistalbum' || $value eq 'yearalbum') {
-			# If its an album sort where year takes precendence, then sort by year first
-			$sort = $albumYearSort;
+			# If its an album sort where year takes precedence, then sort by year first
+			if ($sort eq $albumSort) {
+				$sort = $albumYearSort;
+			}
 		} elsif ($value ne 'artistalbum' && $value ne 'new' && $value ne 'random') {
 			# Only use sort value if it is **not** an album sort.
 			$sort = $value;


### PR DESCRIPTION
Tested, and works with git/master version of Material. Applications need to send "sort:<abum sort>" when requesting to load/add all album's for an artist, etc.