### PR TITLE
OggFlac playback from remote playlist silently fails

### DIFF
--- a/types.conf
+++ b/types.conf
@@ -40,6 +40,8 @@ mp4x    -               -                               audio
 mp3     mp2,mp3         audio/mpeg,audio/mp3,audio/mp3s,audio/x-mpeg,audio/mpeg3,audio/mpg audio
 mpc     mpc,mp+         audio/x-musepack                audio
 ogg     ogg,oga         audio/x-ogg,application/ogg,audio/ogg,application/x-ogg       audio
+# Special content type for Ogg FLAC streams (which use a different decode path)
+ogf     -               -                               audio
 ops     opus            audio/opus,audio/ogg;codecs=opus audio
 pcm     pcm             audio/L16,audio/x-pcm           audio
 pdf     pdf             application/pdf                 -


### PR DESCRIPTION
At present, LMS supports playback of remote OggFlac streams directly. But it does not support playback of an OggFlac stream listed in a remote playlist. Playback silently fails. This has been observed with both 'PLS' and 'M3U' remote playlist formats.

This proposed change remedies matters by adding an ```ogf``` content type id to LMS's global ```types.conf``` file. Only the _ID_ and _Server File Type_ fields are relevant, _Suffix_ and _Mime Content-Type_ fields are left inactive.

Cause of failure:
Without an entry in ```types.conf``` covering ```ogf```, ```Slim::Music::Info::isSong``` does not recognize an ```ogf``` format track as an audio type. ```Slim::Schema::RemotePlaylist::getNextEntry``` therefore silently skips over the track, as it is not recognized as being an audio item. Hence playback of the remote playlist fails.

The issue was reported in this forum post: [Is there way to allow LMS to parse certain playlist files containing Ogg FLAC streams?](https://forums.slimdevices.com/showthread.php?109615-Local-ogg-flac-stream-no-longer-plays-after-update-to-latest-7-9-2-nightly&p=949042&viewfull=1#post949042)

Since that report, the publishers have retired the streams quoted therein, so they can no longer be used for testing.

However, this stream is active (at 13 November 2019), and has been used to test the issue:
_ht<span>tp://</span>rod.frequence3.net/frequence3.flac.m3u_

OggFlac streaming support was added to LMS in 2012. One feature of the change is that a new audio type id, ```ogf```, was created to distinguish the flac variant, which uses a different decode path.

The original change may be found here: [bug 12893: Support OggFLAC - server support](https://github.com/Logitech/slimserver/commit/a8464b42)
