### PR TITLE
HTTP 1.1 enablement

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -293,7 +293,9 @@ sub _format_request {
 	}
 
 	# XXX until we support chunked encoding, force 1.0
-	$self->socket->http_version('1.0');
+	# $self->socket->http_version('1.0');
+	$self->socket->http_version($self->request->protocol =~ m|HTTP/(\S*)|i);
+	$self->socket->keep_alive($self->request->header('Connection') =~ /keep-alive/i);
 
 	my $request = $self->socket->format_request(
 		$self->request->method,

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -294,7 +294,9 @@ sub _format_request {
 
 	# XXX until we support chunked encoding, force 1.0
 	# $self->socket->http_version('1.0');
-	$self->socket->http_version($self->request->protocol =~ m|HTTP/(\S*)|i);
+	my ($version) = $self->request->protocol =~ m|HTTP/(\S*)|i;
+	$version = '1.0' if $version ne '1.1';
+	$self->socket->http_version($version);
 	
 	my $request = $self->socket->format_request(
 		$self->request->method,

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -295,8 +295,7 @@ sub _format_request {
 	# XXX until we support chunked encoding, force 1.0
 	# $self->socket->http_version('1.0');
 	$self->socket->http_version($self->request->protocol =~ m|HTTP/(\S*)|i);
-	$self->socket->keep_alive($self->request->header('Connection') =~ /keep-alive/i);
-
+	
 	my $request = $self->socket->format_request(
 		$self->request->method,
 		$fullpath,


### PR DESCRIPTION
This patch propagates the settings made in HTTP::request to Net::HTTP for the HTTP version and Connection header. This allows application to really use HTTP 1.1. 
Normally, default should not change as if nothing is set, it defaults to HTTP 1.0. I know changing HTTP behaviour is scary ...