### PR TITLE
Suspend/Resume option for HTTP streaming

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -321,6 +321,22 @@ sub read_body {
 	Slim::Networking::Select::addRead( $self->socket, \&_http_read_body );
 }
 
+sub suspendStream {
+	my $self = shift;
+
+	Slim::Utils::Timers::killTimers( $self->socket, \&_http_read_timeout );
+	Slim::Networking::Select::removeRead( $self->socket );
+}
+
+sub resumeStream {
+	my $self = shift;
+
+	my $timeout = $self->timeout || $prefs->get('remotestreamtimeout');
+	
+	Slim::Utils::Timers::setTimer( $self->socket, Time::HiRes::time() + $timeout, \&_http_read_timeout, $self->socket->get('passthrough') );
+	Slim::Networking::Select::addRead( $self->socket, \&_http_read_body );
+}
+
 sub _http_socket_error {
 	my ( $socket, $self, $args ) = @_;
 


### PR DESCRIPTION
Per the discussion on the LMS forum, this would allow Suspend/Resume of HTTP download/streaming and better use of the 'onStream' option
```
my $data;
my $session;
my $streamUrl;

sub startStreaming {
	$session = Slim::Networking::Async::HTTP->new;
	my $request = HTTP::Request->new( GET => $streamUrl ); 

	$session->send_request( {
			request     => $request,
			onStream => sub {
				my ($self, $buffer) = @_;
				$log->warn("got data ", length $$buffer);
				$data .= $$buffer;
				# assumption is that $data is being consumed by another part of the code
				if ( length $data > 128*1024 ) {
					$log->warn("too much data, need to pause");
					$self->suspendStream;
					Slim::Utils::Timers::setTimer( $self, time() + 10, \&emptyBuffer);
				}
				return 1;
			},	
			onError  => sub { 
				$log->error("some error happened $_[1]");
			},
	} );
}

sub emptyBuffer {
	my $self = shift;
	$data = '';
	$log->warn("time to empty buffer and resume");
	$self->resumeStream;
}	
```