### PR TITLE
ICY metadata extra space

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -696,8 +696,7 @@ sub getMetadataFor {
 	if ( my $currentTitle = Slim::Music::Info::getCurrentTitle( $client, $url ) ) {
 		my @dashes = $currentTitle =~ /( - )/g;
 		if ( scalar @dashes == 1 ) {
-			($artist, $title) = split / - /, $currentTitle;
-		}
+			($artist, $title) = $currentTitle =~ /(.+)[ ]+-[ ]+(.+)/s;
 
 		else {
 			$title = $currentTitle;


### PR DESCRIPTION
A small thing that I saw with RP: the ICY metadata is in the format StreamTitle='\<artist\> - \<title\>' and the [ - ] only exist if there is both artist and title. RP sends 2 spaces between \<title\> and [-] and 2 between [-] and \<artist\>, so display on the screen has a leading un-necessary space because LMS only trims one.

No big deal, but I thought a regex would be better than the split to extract items.

My regex capabilities are still minimal, but I assume you saw the point and may have a better regex option