### PR TITLE
Do keep-alive when no "connection" response header

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -487,9 +487,10 @@ sub _http_read {
 		# Body might also be empty but a keep-alive with no content-length in the response is an error
 		# if everything has already been read, _http_body_read will unsubscribe to event loop 
 		# we just subscrive above ... a bit unefficient 
-		_http_read_body( $self->socket, $self, $args ) if ( (!defined $self->response->headers->header('Connection') || 
-															 $self->response->headers->header('Connection') =~ /keep-alive/i) && 
-															 $self->socket->_rbuf_length == ($headers->content_length || 0));
+		if ( (!defined $self->response->headers->header('Connection') ||  $self->response->headers->header('Connection') =~ /keep-alive/i) && 
+			$self->socket->_rbuf_length == ($headers->content_length || 0) ) {
+			_http_read_body( $self->socket, $self, $args ) 
+		}
 	}
 }
 

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -485,9 +485,11 @@ sub _http_read {
 		# must be forced. But if nothing has been read yet, attempting to force body reading can lead to
 		# a false empty body result, so let it to the event loop.
 		# Body might also be empty but a keep-alive with no content-length in the response is an error
-		# if everything has already been read, _http_body_read will unsubscribe to event loop
-		# we just subscrive above ... a bit unefficient
-		_http_read_body( $self->socket, $self, $args ) if ( $self->response->headers->header('Connection') =~ /keep-alive/i && $self->socket->_rbuf_length == ($headers->content_length || 0));
+		# if everything has already been read, _http_body_read will unsubscribe to event loop 
+		# we just subscrive above ... a bit unefficient 
+		_http_read_body( $self->socket, $self, $args ) if ( (!defined $self->response->headers->header('Connection') || 
+															 $self->response->headers->header('Connection') =~ /keep-alive/i) && 
+															 $self->socket->_rbuf_length == ($headers->content_length || 0));
 	}
 }
 


### PR DESCRIPTION
This is an old patch I forgot to submit a while ago. When the requestor wants a "keep-alive", the responsder might ommit a "connection" header in which case the "keep-alive" should be granted. The current version accidentally assumes a "close" response