### PR TITLE
Allow fade-in for squeezeplay client that don't handle it locally 

### DIFF
--- a/Slim/Player/SqueezePlay.pm
+++ b/Slim/Player/SqueezePlay.pm
@@ -239,7 +239,7 @@ sub pcm_sample_rates {
 sub fade_volume {
 	my ($client, $fade, $callback, $callbackargs) = @_;
 
-	if (abs($fade) > 1 ) {
+	if (abs($fade) > 1 || $client->model !~ /baby|fab4/) {
 		# for long fades do standard behavior so that sleep/alarm work
 		$client->SUPER::fade_volume($fade, $callback, $callbackargs);
 	} else {


### PR DESCRIPTION
The squeezeplay model has a special version of fade_volume that let the device take care of fade-in if duration is below 1s (prior model don't overload fade_volume). Unfortunately squeezelite, although a squeezeplay model, does not do this local fade-in so short fade-in do not work.