### PR TITLE
Skip version/revision check for jivelite as all releases support the …

### DIFF
--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -1923,7 +1923,7 @@ sub _defeatDestructiveTouchToPlay {
 	my $pref;
 	
 	if ($client && (my $agent = $client->controllerUA)) {
-		if ($agent =~ /squeezeplay/i) {
+		if ($agent =~ /squeezeplay/i && $agent !~ /jivelite/i) {
 			my ($version, $revision) = ($agent =~ m%/(\d+(?:\.\d+)?)[.\d]*-r(\d+)%);
 			
 			return 0 if $version < 7.6;


### PR DESCRIPTION
Jivelite doesn't report the version-revision pair like squeezeplay causing _defeatDestructiveTouchToPlay to always returns 0 regardless of the player setting.

Squeezeplay returns "SqueezePlay-squeezeplay/7.8.0-r1188 (i686)"
Jivelite returns "SqueezePlay-jivelite/0.1.0 (i686)"

Jivelite has always supported the Defeat destructive Touch-To-Play feature, so skip the check.