### PR TITLE
enable non-blocking HTTPS on Windows

### DIFF
--- a/Slim/Networking/Async.pm
+++ b/Slim/Networking/Async.pm
@@ -15,7 +15,7 @@ use base qw(Slim::Utils::Accessor);
 
 use Scalar::Util qw(blessed weaken);
 use Socket qw(inet_ntoa);
-use Errno qw(EWOULDBLOCK);
+use Errno qw(EWOULDBLOCK EAGAIN);
 
 use Slim::Networking::Async::DNS;
 use Slim::Networking::Async::Socket::HTTP;
@@ -167,7 +167,7 @@ sub _async_connect {
 
 	# check that we are actually connected
 	if ( !$socket->connected ) {
-		if ( ref $socket eq 'Slim::Networking::Async::Socket::HTTPS' and $! == EWOULDBLOCK ) {
+		if ($socket->isa('Slim::Networking::Async::Socket::HTTPS') && ($! == EWOULDBLOCK || $! == EAGAIN)) {
 			# The TLS handshake is not yet complete.  Retry later.
 			return;
 		}

--- a/Slim/Networking/Async/Socket/HTTPS.pm
+++ b/Slim/Networking/Async/Socket/HTTPS.pm
@@ -17,9 +17,7 @@ use base qw(Net::HTTPS::NB Slim::Networking::Async::Socket);
 
 sub new {
 	my ($class, %args) = @_;
-	# unfortunately Windows crashes when using non-blocking handshaking, but a timeout occurs
-	# let's disable this until somebody has figured out what's wrong with it on Windows - mh
-	$args{'Blocking'} = main::ISWINDOWS || 0;
+	$args{'Blocking'} = 0;
 	return $class->SUPER::new(%args);
 }
 


### PR DESCRIPTION
I think I've found why non-blocking sockets did not work on Windows. I'm less sure why ref() was use instead of isa(), but that change can be discarded, the important one is that EAGAIN is used on Windows. My understanding is that isa returns true if any of the ascendant is the class we are checking, which I think was what we want vs ref that only talks about the current (latest) bless. I don't know Perl enough ...