### PR TITLE
clear $! before check SSL connection (needed on Windows)

### DIFF
--- a/Slim/Networking/Async.pm
+++ b/Slim/Networking/Async.pm
@@ -165,6 +165,11 @@ sub _connect_error {
 sub _async_connect {
 	my ( $socket, $self, $args ) = @_;
 
+	# on Windows $! might not be cleared when socket is not yet connected
+	# and whatever was previous value is kept, making the test below fail
+	# by clearing it, we force underlying to redefine it.
+	$! = undef;
+	
 	# check that we are actually connected
 	if ( !$socket->connected ) {
 		if ($socket->isa('Slim::Networking::Async::Socket::HTTPS') && ($! == EWOULDBLOCK || $! == EAGAIN)) {


### PR DESCRIPTION
So ... it seems a pretty contorted Windows crap, but in a nutshell, on Windows, when calling $socket->connected, in some cases (probably a race condition with SSL layers) $! is not set if it is already set to something. So we end up testing whatever was the latest value of errno was, which is totally irrelevant and we believe that the SSL connection failed. 

By clearing $!, the underlying layers are forced to set it to something relevant, EGAIN or EWOULDBLOCK for that matter.

This is in addition of testing EAGAIN