### PR TITLE
if connection fails, remove ourselves from select

### DIFF
--- a/Slim/Networking/Async.pm
+++ b/Slim/Networking/Async.pm
@@ -145,7 +145,7 @@ sub _connect_error {
 	
 	# Kill the timeout timer
 	Slim::Utils::Timers::killTimers( $socket, \&_connect_error );
-
+	
 	# close the socket
 	if ( defined $socket ) {
 		$socket->close;
@@ -177,6 +177,9 @@ sub _async_connect {
 			return;
 		}
 		else {
+			# remove our initial selects
+			Slim::Networking::Select::removeError($socket);
+			Slim::Networking::Select::removeWrite($socket);
 			return _connect_error( $socket, $self, $args );
 		}
 	}


### PR DESCRIPTION
Another (last) one, but don't think it's me this time ... 

If a connection fails, we call _connect_error() that properly kills the timeout, but it leaves the callback on the socket and closes it. On my Windows version that does not end well (at least when I "manually" run Slimserver.pl) as it causes a libev crash because there is a write_attempt made

Shouldn't we always remove ourselves from the loop in case of error. 