### PR TITLE
application/octet-stream handling

### DIFF
--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -372,7 +372,7 @@ sub readRemoteHeaders {
 	}
 
 	# Is this an audio stream or a playlist?
-	if ( Slim::Music::Info::isSong( $track, $type ) ) {
+	if ( $type = Slim::Music::Info::isSong( $track, $type ) ) {
 		main::INFOLOG && $log->is_info && $log->info("This URL is an audio stream [$type]: " . $track->url);
 
 		$track->content_type($type);


### PR DESCRIPTION
Looking at this https://forums.slimdevices.com/showthread.php?112286-Stream-not-working-after-update is seems that when the content-type of a remote stream is application/octet-stream, nothing is done in readRemoteHeaders to set it to a type that makes sense. 

I could add one of the elif but I realized that isSong() in fact does the job of detecting application/octet-stream and guessing from the path, so it sounded more logical to me to re-force the $type from the result of isSong. It does not seam that if nothing is returned (i.e. it's not audio or a it's a playlist), the fact that $type is now undef matters as it is not used further down.