### PR TITLE
ogg container clarification

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -328,9 +328,12 @@ sub parseDirectHeaders {
 	my ( $self, $client, $url, @headers ) = @_;
 
 	my $isDebug = main::DEBUGLOG && $directlog->is_debug;
-
+	my $oggType;
+	
 	# May get a track object
 	if ( blessed($url) ) {
+		($oggType) = $url->content_type =~ /(ogf|ogg|ops)/;
+
 		$url = $url->url;
 	}
 
@@ -432,7 +435,7 @@ sub parseDirectHeaders {
 		$contentType = 'mp3';
 	}
 
-	return ($title, $bitrate, $metaint, $redir, $contentType, $length, $body);
+	return ($title, $bitrate, $metaint, $redir, $oggType || $contentType, $length, $body);
 }
 
 =head2 parseHeaders( @headers )
@@ -450,11 +453,10 @@ sub parseHeaders {
 	my $self    = shift;
 	my $url     = $self->url;
 	my $client  = $self->client;
-	my $isOgf   = Slim::Music::Info::contentType( $url ) eq 'ogf';
 
 	my ($title, $bitrate, $metaint, $redir, $contentType, $length, $body) = $self->parseDirectHeaders($client, $url, @_);
 
-	if ($contentType && !$isOgf) {
+	if ($contentType) {
 		if (($contentType =~ /text/i) && !($contentType =~ /text\/xml/i)) {
 			# webservers often lie about playlists.  This will
 			# make it guess from the suffix.  (unless text/xml)
@@ -483,7 +485,7 @@ sub parseHeaders {
 		}
 	}
 
-	if ($bitrate && !$isOgf) {
+	if ($bitrate) {
 		main::INFOLOG && $log->is_info &&
 				$log->info(sprintf("Bitrate for %s set to %d",
 					$self->infoUrl,

--- a/types.conf
+++ b/types.conf
@@ -40,8 +40,7 @@ mp4x    -               -                               audio
 mp3     mp2,mp3         audio/mpeg,audio/mp3,audio/mp3s,audio/x-mpeg,audio/mpeg3,audio/mpg audio
 mpc     mpc,mp+         audio/x-musepack                audio
 ogg     ogg,oga         audio/x-ogg,application/ogg,audio/ogg,application/x-ogg       audio
-# Special content type for Ogg FLAC streams (which use a different decode path)
-ogf     -               -                               audio
+ogf     -            	audio/ogg;codecs=flac			audio
 ops     opus            audio/opus,audio/ogg;codecs=opus audio
 pcm     pcm             audio/L16,audio/x-pcm           audio
 pdf     pdf             application/pdf                 -


### PR DESCRIPTION
This patch aims at some "clarification" for ogg handling, especially with opus & flac. Mainly, when codecs list were not including "ogg" but only "ogf" and/or "ops" then playback was failing for OggFlac and OggOpus while using direct streaming (it was "accidentally" fine using proxied streaming).

This tries to "normalize" more the usage of ogg as a container, maybe we could add one day oggpcm although I'm not sure of the benefit.

I've tried, as usual, to keep the patch to bare minimum so that it's easier to roll back if it does not work. I've tested with OggFlac, OggVorbis and OggOpus streams just ogf,ops (not ogg) in proxied and direct as well as ogg,ogf,ops in proxied and streaming and did not have issues.

Still, have a look and take it with a grain of salt