### PR TITLE
Fix #350 - small streams handling

### DIFF
--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -735,6 +735,9 @@ sub parseOggHeader {
 sub streamAudioData {
 	my ( $http, $dataref, $track, $args, $url ) = @_;
 
+	return 1 unless defined $$dataref;
+	
+	my $len = length($$dataref);
 	my $first;
 
 	# Buffer data to a temp file, 128K of data by default
@@ -747,7 +750,6 @@ sub streamAudioData {
 		main::DEBUGLOG && $log->is_debug && $log->debug( $track->url . ' Buffering audio stream data to temp file ' . $fh->filename );
 	}
 
-	my $len = length($$dataref);
 	$fh->write( $$dataref, $len );
 
 	if ( $first ) {
@@ -776,10 +778,8 @@ sub streamAudioData {
 
 	$args->{_scanlen} -= $len;
 
-	if ( $args->{_scanlen} > 0 ) {
+	if ( $args->{_scanlen} > 0 && $len) {
 		# Read more data
-		#$log->is_debug && $log->debug( $track->url . ' Bytes left: ' . $args->{_scanlen} );
-
 		return 1;
 	}
 
@@ -839,8 +839,8 @@ sub streamAudioData {
 	delete $args->{_scanbuf};
 	delete $args->{_scanlen};
 
-	# as https for whatever eason didn't allow us to start the stream while scanning
-	# we're no disconnecting to allow the stream to start
+	# as https for whatever reason didn't allow us to start the stream while scanning
+	# we're now disconnecting to allow the stream to start
 	if ( $args->{cb} && $track->url =~ /^https/ ) {
 		$http->disconnect;
 		$args->{cb}->( $track, undef, @{$args->{pt} || []} );


### PR DESCRIPTION
- http_read_body shall return immediately when there is nothing to read instead of proceeding to avoid invoking functions & callbacks with empty content. This happens when using NB sockets
- streamAudioData must be protected when called with no content (in addition of the above) so that the "first" call happens with actual content. Otherwise expected parsing length was not set
- When stream is below 16kB, streamAudioData will never receive enough data, so parsing ID3v2 and bitrate are not done. But worse, when streamAudioData is supposed to launch actual HTTPS streaming connection, then streaming never starts