### PR TITLE
Support WAV as a stream format

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -793,7 +793,7 @@ sub canSeek {
 	my $bitrate = $song->bitrate();
 	my $seconds = $song->duration();
 
-	if ( !$bitrate || !$seconds ) {
+	if ( !$bitrate || !$seconds || $song->streamformat =~ /(pcm|wav)/ ) {
 		#$log->debug( "bitrate: $bitrate, duration: $seconds" );
 		#$log->debug( "Unknown bitrate or duration, seek disabled" );
 		return 0;

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -447,7 +447,8 @@ sub open {
 
 	# TODO work this out for each player in the sync-group
 	my $directUrl;
-	if ($transcoder->{'command'} eq '-' && ($directUrl = $client->canDirectStream($url, $self))) {
+	# Make sure for direct mode that if transcode rule is identity, codec is _really_ supported (e.g. wav vs pcm)
+	if ($transcoder->{'command'} eq '-' && ($directUrl = $client->canDirectStream($url, $self)) && grep {$_ eq $format} Slim::Player::CapabilitiesHelper::supportedFormats($client)) {
 		main::INFOLOG && $log->info( "URL supports direct streaming [$url->$directUrl]" );
 		$self->directstream(1);
 		$self->streamUrl($directUrl);


### PR DESCRIPTION
This patch fixes support of wav file as a streaming format. There are 2 issues

- in Direct or Proxied streaming, the wav header was not read by LMS so the samplerate, size & channels were set to default (44100/16/2) in STRMs messages. For squeezelite players who had the "wav" codec (-W) added, this was working as the player reads the WAV header and overwrites STRMs parameters. But for players without 'wav' codec (just 'pcm'), playback speed could be incorrect (in proxied mode) or fail (in direct mode - see below). The fix is like ogg and aac to parse a small chunk of body bytes to detect the true parameters.

- For players that do not support 'wav' codec, the Direct mode was failing because the transcoding matching engine finds the "wav pcm" rules in convert.conf that return "-" (identity).  As a result, the Song opener, was able to launch direct streaming. The problem is that because the player supports only  'pcm' and not 'wav', then later when checking the stream HTTP headers returned by the player, 'wav' was not detected as part of supported codec which caused the streaming to fail. The fix is to check that, even when transform is identity and direct streaming is possible, the codec is *really* supported by the player(s) *before* launching stream and if not, then proxied streaming will then be activated as it would by by exploring more transcoding rules. 

I'm submitting that as a 8.0 patch as I assume you don't want this sort of things which is borderline bug/feature in 7.9

NB: I think that in Proxied streaming, the wave header (44 bytes) is still sent to the player, even if it has said that it only supports 'pcm'. It does not fail if the header is a multiple of channels*sample_size, but that does not look right to me. I don't know where to take out this header. There might be some sort of "skip N bytes" arguments, but I've not found it