### PR TITLE
add AIF streaming

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -793,7 +793,7 @@ sub canSeek {
 	my $bitrate = $song->bitrate();
 	my $seconds = $song->duration();
 
-	if ( !$bitrate || !$seconds || $song->streamformat =~ /(pcm|wav)/ ) {
+	if ( !$bitrate || !$seconds || $song->streamformat =~ /(pcm|wav|aif)/ ) {
 		#$log->debug( "bitrate: $bitrate, duration: $seconds" );
 		#$log->debug( "Unknown bitrate or duration, seek disabled" );
 		return 0;


### PR DESCRIPTION
To complete these patches, just adding AIF as a streamable format. AFAIK, it was just producing white noise before (on my Boom at least).

Only remaining thing to do would be the possibility to strip out the header when proxied streaming and using pcm (not aif/wav). It's not clean to have it work by chance because header is a multiple of samplesize*channels but I really don't think there is a way to fix that as the audio streaming starts before the header check has been done, so we can't skip (or tell the player to skip in case of Direct). Only option would be to have real convert-conf rules (wav pcm and aif pcm) that are no identity  ... well this works like that and wav/aif streaming is a corner case anyway :-)