### PR TITLE
Allow plugins to determine how to play URLs

### DIFF
--- a/Changelog8.html
+++ b/Changelog8.html
@@ -7,6 +7,7 @@
 	<ul>
 		<li>Online music library integration: list your collection of albums vetted in your favorite streaming service as part of your "My Music" collection.</li>
 		<li>Improved support for Audio Books: automatically create library views and browse modes dealing with Audio Books and Authors.</li>
+		<li>Where plugins provide support, you can now use “Tune In URL” to play audio associated with a webpage.  For example, tune in to <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">https://www.youtube.com/watch?v=dQw4w9WgXcQ</a> to listen to the music for that video.</li>
 	</ul>
 	<br />
 

--- a/Slim/Player/ProtocolHandlers.pm
+++ b/Slim/Player/ProtocolHandlers.pm
@@ -101,8 +101,17 @@ sub handlerForURL {
 	}
 
 	# Load the handler when requested..
-	my $handler = $class->loadHandler($protocol);
-	
+	my $handler;
+	foreach my $key ( keys %protocolHandlers ) {
+		next unless $key =~ m/^\(/;
+		if ( $url =~ $key ) {
+			$handler = $class->loadHandler($key);
+			last;
+		}
+	}
+	$handler = $class->loadHandler($protocol)
+	    unless defined($handler);
+
 	# Handler should be a class, not '1' for rtsp
 	return $handler && $handler =~ /::/ ? $handler : undef;
 }

--- a/Slim/Player/ProtocolHandlers.pm
+++ b/Slim/Player/ProtocolHandlers.pm
@@ -49,11 +49,9 @@ sub isValidHandler {
 		if ($protocolHandlers{$protocol}) {
 			return 1;
 		}
-		elsif (exists $protocolHandlers{$protocol}) {
+	
+		if (exists $protocolHandlers{$protocol}) {
 			return 0;
-		}
-		elsif ($URLHandlers{$protocol}) {
-			return 1;
 		}
 	}
 
@@ -70,18 +68,19 @@ sub isValidRemoteHandler {
 sub registeredHandlers {
 	my $class = shift;
 
-	return keys %protocolHandlers, keys %URLHandlers;
+	return keys %protocolHandlers;
 }
 
 sub registerHandler {
 	my ($class, $protocol, $classToRegister) = @_;
+	
+	$protocolHandlers{$protocol} = $classToRegister;
+}
 
-	if (ref($protocol) eq 'Regexp') {
-		$URLHandlers{$protocol} = $classToRegister;
-	}
-	else {
-		$protocolHandlers{$protocol} = $classToRegister;
-	}
+sub registerURLHandler {
+	my ($class, $regexp, $classToRegister) = @_;
+
+	$URLHandlers{$regexp} = $classToRegister;
 }
 
 sub registerIconHandler {


### PR DESCRIPTION
A number of plugins allow you to give them a webpage URL, and they’ll play the music associated with that webpage, e.g., the Band’s Campout plugin has a “Bandcamp URL” field, the YouTube plugin has a “YouTube URL or Video id” field, etc.  However, it would be more convenient if you could paste the URL into the “Tune In URL” field and have LMS work out for you which plugin to use.

This commit provides a mechanism for a plugin to register a regular expression for the URLs it knows how to play.  It can then supply an `explodePlaylist()` method in it’s protocol handler to convert the webpage URL into playable URLs.

See https://github.com/mavit/LMS-YouTube/commits/rich-url-handler for an example plugin adaptation.

Does this approach seem reasonable, or would you prefer a different API for this?