### PR TITLE
handle wav/aif headers in remote streams

### DIFF
--- a/Slim/Formats/AIFF.pm
+++ b/Slim/Formats/AIFF.pm
@@ -80,6 +80,21 @@ sub getTag {
 	return $tags;
 }
 
+sub getInitialAudioBlock {
+	my ($class, $fh, $track) = @_;
+	my $length = $track->audio_offset() || return undef;
+	
+	open(my $localFh, '<&=', $fh);
+	
+	seek($localFh, 0, 0);
+	main::DEBUGLOG && logger('player.source')->debug("Reading initial audio block: length $length");
+	read ($localFh, my $buffer, $length);
+	seek($localFh, 0, 0);
+	close($localFh);
+	
+	return $buffer;
+}
+
 *getCoverArt = \&Slim::Formats::MP3::getCoverArt;
 
 sub canSeek { 1 }

--- a/Slim/Formats/Wav.pm
+++ b/Slim/Formats/Wav.pm
@@ -60,12 +60,6 @@ sub getTag {
 
 sub getInitialAudioBlock {
 	my ($class, $fh, $track) = @_;
-	
-	# bug 10026: do not provide header when streaming as PCM
-	if (${*$fh}{'streamFormat'} eq 'pcm') {
-		return '';
-	}
-	
 	my $length = $track->audio_offset() || return undef;
 	
 	open(my $localFh, '<&=', $fh);

--- a/Slim/Player/Protocols/File.pm
+++ b/Slim/Player/Protocols/File.pm
@@ -136,7 +136,7 @@ sub open {
 			$streamLength = $song->streamLength();
 			$seekoffset = $seekdata->{restartOffset};
 		} elsif ($seekdata->{sourceStreamOffset}) {						# used for seeking
-			$seekoffset = $seekdata->{sourceStreamOffset};
+			$seekoffset = $seekdata->{sourceStreamOffset} + $seekdata->{sourceHeaderOffset};
 			$streamLength -= $seekdata->{sourceStreamOffset} - $offset;
 		} else {
 			$seekoffset = $offset;										# normal case

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -574,7 +574,7 @@ sub stream_s {
 
 	$format ||= 'mp3';
 
-	if ($format eq 'pcm') {
+	if ($format eq 'pcm' || $format eq 'wav') {
 
 		$formatbyte      = 'p';
 		$pcmsamplesize   = 1;
@@ -587,6 +587,7 @@ sub stream_s {
 			$pcmsamplesize = $client->pcm_sample_sizes($track);
 			$pcmsamplerate = $client->pcm_sample_rates($track);
 			$pcmchannels   = $track->channels() || '2';
+			$pcmendian = 0 if $track->endian == 1;
 		}
 
 	} elsif ($format eq 'aif') {

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -645,8 +645,8 @@ sub directHeaders {
 				# we've got a playlist in all likelyhood, have the player send it to us
 				$client->sendFrame('body', \(pack('N', $length)));
 
-			} elsif ($client->contentTypeSupported($contentType)) {
-				
+			} elsif ($client->contentTypeSupported($controller->song->streamformat)) {
+
 				# If we redirected (Live365), update the original URL with the metadata from the real URL
 				if ( my $oldURL = delete $redirects->{ $url } ) {
 

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -1225,7 +1225,9 @@ sub _Stream {				# play -> Buffering, Streaming
 		$self->{'songStreamController'} = undef;
 	}
 	
+	# create song and re-acquire seekdata as open() can modify/created it 	
 	my ($songStreamController, @error) = $song->open($seekdata);
+	$seekdata = $song->seekdata;
 		
 	if (!$songStreamController) {
 		_errorOpening($self, $song->currentTrack()->url, @error);

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -123,6 +123,7 @@ sub loadConversionTables {
 # I - can transcode from stdin
 # F - can transcode from a named file
 # R - can transcode from a remote URL (URL types unspecified)
+# H - request to strip out header (wav/aif only)
 #
 # O - can seek to a byte offset in the source stream (not yet implemented)
 # T - can seek to a start time offset
@@ -392,13 +393,24 @@ sub getConvertCommand2 {
 			&& $type eq 'wma' && blessed($track) && $track->lossless) {
 				next PROFILE;
 		}
+		
+		my $streamformat = (split (/-/, $profile))[1];
+		
+		# aif/wav oddity #1 (for remote seek)
+		# when seeking a remote track, can't re-send the header, it's lost 
+		if ($type =~ /(wav|aif)/ && !($streamformat eq 'pcm' && $command eq '-' )
+			&& $track->remote && $song->seekdata) {
+			main::DEBUGLOG && $log->is_debug
+				&& $log->debug("Rejecting $command because header is unavailable when seeking");
+			next PROFILE;
+		}							 
 
 		$transcoder = {
 			command          => $command,
 			profile          => $profile,
 			usedCapabilities => [@$need, @$want],
 			streamMode       => $streamMode,
-			streamformat     => (split (/-/, $profile))[1],
+			streamformat     => $streamformat,
 			rateLimit        => $rateLimit || 320,
 			samplerateLimit  => $samplerateLimit || 44100,
 			clientid         => $clientid || 'undefined',
@@ -407,6 +419,12 @@ sub getConvertCommand2 {
 			player           => $player || 'undefined',
 			channels         => $track->channels() || 2,
 			outputChannels   => $clientprefs ? ($clientprefs->get('outputChannels') || 2) : 2,
+			# aif/wav oddity #2 (for '-' rule)
+			# aif - aif: any SB that does not support wav requires aif header stripping
+			# wav/aif - pcm: force header stripping
+			stripHeader      => $caps->{'H'} || ($command eq "-" &&
+                                (($type =~ /(wav|aif)/ && $streamformat eq 'pcm') ||
+                                 ($type eq 'aif' && $streamformat eq 'aif' && !grep {$_ eq 'wav'} @supportedformats))),
 		};
 		
 		# Check for optional profiles

--- a/convert.conf
+++ b/convert.conf
@@ -40,6 +40,7 @@
 # I - can transcode from stdin
 # F - can transcode from a named file
 # R - can transcode from a remote URL (URL types unspecified)
+# H - request to strip out header (wav/aif only)
 # 
 # O - can seek to a byte offset in the source stream (not yet implemented)
 # T - can seek to a start time offset
@@ -153,7 +154,13 @@ mp3 mp3 * *
 # Non-mp3 starts here
 aif aif * *
 	-
+	
+aif pcm * *
+	-
 
+wav wav * *
+	-
+	
 wav pcm * *
 	-
 


### PR DESCRIPTION
These patches should handle header stripping if necessary for remote wav/aiff streaming. Finally, following https://github.com/Logitech/slimserver/issues/361, I've decided to propose a mixed approach. 

============ this is deprecated, see comment https://github.com/Logitech/slimserver/pull/363#issuecomment-641042212 ==============

When the transcoder knows that it is doing aif/wav => pcm on a remote stream *and* the transcoding rule is identity, it *must* self-set the request to strip header. When the transcoding rule is anything else, then we can still force the header removal by setting the 'H' flag in the convert.conf and then the helpers should received a stripped stream. But if the helper wants the full stream with headers, just don't set the 'H' flag and transcoder will not strip anything as the rule is not identity, 

As usual, I've tried to limit the patch as much as possible while improving consistency in wav/aif/pcm management which I think is a little bit all over the place today. 

For remote streams, I've re-used existing $track fields that are not used in remote stream to pass information about offset and length of stream to be downloaded by http, so that it can do a proper range request. One questionable thing is the addition of a field in $seekdata to get the total length to be expected in order to create the right range request. I don't think it will hurt anything as this $seekdata extra field is new and unused anywhere else in this remote stream context.

I also have a solution to add this header removal for files as well in a more consistent way, eliminating a hacky thing in Format::Wav and Format::Aif

The old SB claim to support 'aif' (but not 'wav') but the don't expect in fact to receive an aif header, it's just a way to set acceptable endianness. The squeezelite implementation with -W flag is more consistent and even deal with erroneous LMS streams anyway. Without the -W, I think we probably do what older SB do, which is to claim to support aif but not handle aif header and produce a "blip" at the beginning. 

The last thing I need to do then is to remove aif headers, even for "aif aif" rule so that the old SB/squeezelite -W do not break with this patch. It's not there yet, but I think the easy solution is to set strip header when player does not support wav and supports aif and when we have an aif aif identity rule. Not great but that can be contained at a very specific place

NB: I thought initially that LMS was doing the two downloads in // (one for actual audio data and one for headers, except for HTTPS) but I was wrong. It only does that for mp3 files (or files that do not require a special handling in remote.pm) so that made the patches much easier and much less invasive