### PR TITLE
multiple transcoding rules

### DIFF
--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -89,6 +89,7 @@ sub loadConversionTables {
 				my $clientid   = lc($4);
 				my $profile = "$inputtype-$outputtype-$clienttype-$clientid";
 
+				# if profile is duplicated, find the highest index to create a unique instance
 				if ($commandTable{$profile}) {
 					my @index = sort grep { $_ =~ /\Q$profile\E/ } keys %commandTable;
 					$profile .= '-' . (($index[-1] =~ /-(\d+$)/)[0] + 1);
@@ -363,7 +364,8 @@ sub getConvertCommand2 {
 	PROFILE: foreach (@profiles) {
 		my $instance = 0;
 	INSTANCE:
-		my $profile = $_ . ($instance++ ? '-' . ($instance-1) : '');
+		my $profile = $instance ? "$_-$instance" : $_;
+		$instance++;
 		next PROFILE unless exists $commandTable{$profile}; 
 		
 		my $command = checkBin($profile);


### PR DESCRIPTION
I think I've found a simple way to allow multiple transcoding rules for the same source/target pair. It can be handy per our discussion to have a rule for "R" and one for "IF". 

Currently, rules are being picked by order of appearance. As soon as a rule is a perfect match, process stops. If a rule is a partial match (not all wanted tags), it is stored and if a later rule has a better score (more tags), then it is selected. When partial matching rules have an identical score, the first one will be used.

There is not change to that, the "duplicated" rules are just seen as any other rule with the same  selection logic.