### PR TITLE
socketwrapper: create new window per code's comment in verbose mode

### DIFF
--- a/Slim/Player/Pipeline.pm
+++ b/Slim/Player/Pipeline.pm
@@ -79,7 +79,7 @@ sub new {
 
 			$newcommand .= $log->is_debug ? ' -D ' : ' -d ';       # socketwrapper debugging (-D = verbose)
 
-			$createMode = $priority; # create window so it is seen
+			$createMode = $priority | Win32::Process::CREATE_NEW_CONSOLE(); # create window so it is seen
 		}
 
 		if ($listenWriter) {


### PR DESCRIPTION
This one is really not important, but I stumble on it while doing some debug. It seems that what the code wants is a new window to popup in -D (verbose), but the attribute where left to default so you could not see it and could not see the transcoder in action, which can be handy