### PR TITLE
podcast last position fix proposal

### DIFF
--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -106,6 +106,12 @@ sub parse {
 					url    => $url,
 				},
 				duration => $item->{duration},
+				play => sub {
+						my ($client, $cb) = @_;
+						$client->pluginData(goto => 1);
+						delete $item->{items}->[0]->{play};
+						$cb->( $item->{items}->[0] );
+					},
 			},{
 				title => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),
 				name  => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -110,8 +110,8 @@ sub songChangeCallback {
 
 	my $url = Slim::Player::Playlist::url($client);
 
-	if ( $request->isCommand([['playlist'], ['newsong']]) && !($client->pluginData('goto') && $client->pluginData('goto') eq $url) && Slim::Music::Info::isRemoteURL($url) ) {
-		$client->pluginData( goto => $url );
+	if ( $request->isCommand([['playlist'], ['newsong']]) && $client->pluginData('goto') && Slim::Music::Info::isRemoteURL($url) ) {
+		$client->pluginData( goto => 0 );
 
 		if ( my $newPos = $cache->get("podcast-$url") ) {
 			Slim::Player::Source::gototime($client, $newPos);


### PR DESCRIPTION
This PR tries to fix podcast "resume from last position" behavior. This features does not work today when stopping track#1, starting #2, stopping #2 and then trying to start #1 at memorized position. This is because the songChangeCallBack has no way to differentiate a call with a jump from a call from the beginning. By adding a CODE in the play field, it allows that difference to be made. 