### PR TITLE
loop syntax error

### DIFF
--- a/Slim/Utils/Network.pm
+++ b/Slim/Utils/Network.pm
@@ -322,7 +322,7 @@ sub sysreadline(*;$) {
 
 			my $err = $!;
 
-			next CHAR if (!defined($result) and $err == EINTR);
+			goto CHAR if (!defined($result) and $err == EINTR);
 
 			blocking($handle, $was_blocking);
 


### PR DESCRIPTION
There is a syntax error in Slim::Utils::Network.pm where a next statement refers to a label outside the loop, so it throws an error. It should be a goto, not a next