### PR TITLE
progress fix + last recent

### DIFF
--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -90,7 +90,6 @@ sub parse {
 					$client->pluginData(goto => 1);
 					$cb->( $item->{items}->[0] );
 				},	
-				#duration => $item->{duration},				
 			},{
 				title => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),
 				name  => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),
@@ -99,7 +98,6 @@ sub parse {
 					length => $enclosure->{length},
 					url    => $enclosure->{url},
 				},
-				#duration => $item->{duration},				
 			}];
 
 			$item->{type} = 'link';

--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -9,6 +9,8 @@ use Slim::Utils::Cache;
 use Slim::Utils::DateTime;
 use Slim::Utils::Strings qw(cstring);
 
+tie our %recentlyPlayed, 'Tie::Cache::LRU', 50;
+
 my $cache = Slim::Utils::Cache->new;
 
 my $fetching;
@@ -50,14 +52,8 @@ sub parse {
 		# track progress of our listening
 		my $key = 'podcast-' . $item->{enclosure}->{url};
 		my $position = $cache->get($key);
-		if ( !$position ) {
-			if ( my $redirect = $cache->get("$key-redirect") ) {
-				$position = $cache->get("podcast-$redirect");
-			}
-
-			$cache->set($key, $position || 0, '30days');
-		}
-
+		$cache->set($key, $position || 0, '30days') unless $position;
+		
 		# do we have duration stored from previous playback?
 		if ( !$item->{duration} ) {
 			my $trackObj = Slim::Schema->objectForUrl( { url => $item->{enclosure}->{url} } );
@@ -72,27 +68,21 @@ sub parse {
 		}
 
 		$cache->set("$key-duration", $item->{duration}, '30days');
-
-		# sometimes the URL would redirect - store data for the real URL, too
-		# only check when we're seeing this URL for the first time!
-		if ( !(scalar grep { $_->{key} eq $key } @scanQueue) && !defined $cache->get("$key-redirect") ) {
-			push @scanQueue, {
+		
+		my $recent = { 
 				url      => $item->{enclosure}->{url},
+				type     => $item->{enclosure}->{type},
+				title    => $item->{line1},
+				cover    => $item->{image},
 				duration => $item->{duration},
-				position => $position,
-				key      => $key,
-			};
-
-			_scanItem();
-		}
+		};		
 
 		# if we've played this podcast before, add a menu level to ask whether to continue or start from scratch
 		if ( $position && $position < $item->{duration} - 15 ) {
 			delete $item->{description};     # remove description, or xmlbrowser would consider this to be a RSS feed
 
 			my $enclosure = delete $item->{enclosure};
-			my $url       = $cache->get("$key-redirect") || $enclosure->{url};
-			$position     = $cache->get("podcast-$url");
+			$position     = $cache->get('podcast-' . $enclosure->{url});
 
 			$position = Slim::Utils::DateTime::timeFormat($position);
 			$position =~ s/^0+[:\.]//;
@@ -103,15 +93,10 @@ sub parse {
 				enclosure => {
 					type   => $enclosure->{type},
 					length => $enclosure->{length},
-					url    => $url,
+					url    => $enclosure->{url},
 				},
-				duration => $item->{duration},
-				play => sub {
-						my ($client, $cb) = @_;
-						$client->pluginData(goto => 1);
-						delete $item->{items}->[0]->{play};
-						$cb->( $item->{items}->[0] );
-					},
+				play => sub { playItem($item->{items}->[0], $recent, 1, @_) },
+				#duration => $item->{duration},				
 			},{
 				title => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),
 				name  => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),
@@ -120,10 +105,13 @@ sub parse {
 					length => $enclosure->{length},
 					url    => $enclosure->{url},
 				},
-				duration => $item->{duration},
+				play => sub { playItem($item->{items}->[1], $recent, 0, @_) },
+				#duration => $item->{duration},				
 			}];
 
 			$item->{type} = 'link';
+		} else {
+			$item->{play} = sub { playItem($item, $recent, 0, @_) };
 		}
 
 		if ( $item->{duration} && (!$duration || $duration !~ /:/) ) {
@@ -153,48 +141,61 @@ sub parse {
 	return $feed;
 }
 
-sub _scanItem {
-	return if $fetching;
+sub playItem {
+	my ($item, $recent, $goto, $client, $cb) = @_;
+	$client->pluginData(goto => $goto);
+	delete $item->{play};
+	$recentlyPlayed{$recent->{url}} = $recent if $recent;
+	$cb->( $item );
+}	
 
-	if ( my $item = shift @scanQueue ) {
-		my $handler = Slim::Player::ProtocolHandlers->handlerForURL($item->{url});
+sub recentHandler {
+	my ($client, $cb) = @_;
+	my @menu;
 
-		if ($handler && $handler->can('scanUrl')) {
-			$fetching = 1;
+	foreach my $item(reverse values %recentlyPlayed) {
+		my $entry;
+		my $position = $cache->get("podcast-$item->{url}");
+		
+		if ( $position && $position < $item->{duration} - 15 ) {
 
-			$handler->scanUrl($item->{url}, {
-				client => $client,
-				cb     => \&_gotUrl,
-				pt => [$item]
-			} );
-		}
+			$position = Slim::Utils::DateTime::timeFormat($position);
+			$position =~ s/^0+[:\.]//;		
+
+			$entry = {
+				title => $item->{title},
+				image => $item->{cover},
+				type => 'link',
+				items => [ {
+					title => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_POSITION_X', $position),
+					enclosure => {
+						type   => 'audio',
+						url   => $item->{url},
+					},	
+					play => sub { playItem($entry->{items}->[0], undef, 1, @_) },
+					#duration => $item->{duration},					
+				},{
+					title => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),
+					url   => $item->{url},
+					type  => 'audio',
+					#duration => $item->{duration},
+				}],
+			};		
+		}	
+		else {
+			$entry = {
+				title => $item->{title},
+				image => $item->{cover},
+				url   => $item->{url},				
+				type  => 'audio',
+			};
+		}	
+		
+		unshift @menu, $entry;
 	}
-	else {
-		$fetching = 0;
-	}
+
+	$cb->({ items => \@menu });
 }
 
-sub _gotUrl {
-	my ( $newTrack, $error, $pt ) = @_;
 
-	if ( $pt && $pt->{url} && $newTrack && blessed($newTrack) && (my $url = $newTrack->url) ) {
-		my $key = $pt->{key} || '';
-
-		if ($pt->{url} ne $url) {
-			my $key = 'podcast-' . $url;
-			my $position = $cache->get($key);
-			if ( !defined $position ) {
-				$cache->set($key, $pt->{position} || 0, '30days');
-			}
-
-			$cache->set("$key-duration", $pt->{duration}, '30days') if $pt->{duration};
-		}
-
-		$cache->set("$key-redirect", $url || '', '30days');
-	}
-
-	# check next item
-	$fetching = 0;
-	_scanItem();
-}
 1;

--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -85,7 +85,7 @@ sub parse {
 					length => $enclosure->{length},
 					url    => $enclosure->{url},
 				},
-				play => sub { 
+				url => sub { 
 					my ($client, $cb) = @_;
 					$client->pluginData(goto => 1);
 					delete $item->{items}->[0]->{play};

--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -88,7 +88,6 @@ sub parse {
 				url => sub { 
 					my ($client, $cb) = @_;
 					$client->pluginData(goto => 1);
-					delete $item->{items}->[0]->{play};
 					$cb->( $item->{items}->[0] );
 				},	
 				#duration => $item->{duration},				

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -142,12 +142,10 @@ sub recentHandler {
 							$client->pluginData(goto => 1);
 							$cb->( $entry->{items}->[0] );
 					},
-					#duration => $item->{duration},					
 				},{
 					title => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_BEGINNING'),
 					url   => $item->{url},
 					type  => 'audio',
-					#duration => $item->{duration},
 				}],
 			};		
 		}	
@@ -194,7 +192,7 @@ sub songChangeCallback {
 					duration => $song->duration,
 				};		
 		
-		main::DEBUGLOG && $log->debug('Setting up timer to track podcast progress...' . Data::Dump::dump($recentlyPlayed{$url}));	
+		main::DEBUGLOG && $log->is_debug && $log->debug('Setting up timer to track podcast progress...' . Data::Dump::dump($recentlyPlayed{$url}));	
 		Slim::Utils::Timers::killTimers( $client, \&_trackProgress );
 		Slim::Utils::Timers::setTimer(
 			$client,

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -137,7 +137,7 @@ sub recentHandler {
 						type   => 'audio',
 						url   => $item->{url},
 					},	
-					play => sub { 
+					url => sub { 
 							my ($client, $cb) = @_;
 							$client->pluginData(goto => 1);
 							delete $entry->{items}->[0]->{play};

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -140,7 +140,6 @@ sub recentHandler {
 					url => sub { 
 							my ($client, $cb) = @_;
 							$client->pluginData(goto => 1);
-							delete $entry->{items}->[0]->{play};
 							$cb->( $entry->{items}->[0] );
 					},
 					#duration => $item->{duration},					

--- a/Slim/Plugin/Podcast/strings.txt
+++ b/Slim/Plugin/Podcast/strings.txt
@@ -242,3 +242,8 @@ PLUGIN_PODCAST_SKIP_BACK
 	NL	Spring %s seconden terug
 	NO	Hopp %s sekunder tilbake
 	PL	Przewiń do tyłu o %s sekund
+	
+PLUGIN_PODCAST_RECENTLY_PLAYED
+	EN	Recently played
+	FR	Piste récentes
+	


### PR DESCRIPTION
So... following discussion here https://forums.slimdevices.com/showthread.php?112541-Podcasts&p=981239&viewfull=1#post981239, I tried to provide a fix for memorizing progress. 

The issue with the current version is that it memorizes redirected URL and it does that only once. Unfortunately, some feeds have changing redirections for the same podcast episodes and so tracking does not work. We can't either re-scan the feed every time as it would be very onerous. The current version already scans once the complete feed, even if it's not in a playlist and that is not great for example for long mp4 podcasts.

I've also added a "most recently played" item to try to make that PR more appealing... as unfortunately these are a lot of changes