### PR TITLE
Use "Common::escape" from correct plugin.

### DIFF
--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -876,7 +876,7 @@ sub getMix {
 
 	my $mixArgs = join('&', map {
 		my $id = !main::ISWINDOWS && ($validMixTypes{$for} eq 'song' || $validMixTypes{$for} eq 'album') ? Slim::Utils::Unicode::utf8decode_locale($_) : $_;
-		$validMixTypes{$for} . '=' . Plugins::MIPMixer::Common::escape($id);
+		$validMixTypes{$for} . '=' . Plugins::MusicMagic::Common::escape($id);
 	} @ids);
 
 	main::DEBUGLOG && $log->debug("Request http://localhost:$MMSport/api/mix?$mixArgs\&$argString");


### PR DESCRIPTION
My fixes broke the MusicMagic plugin, as it refers to Common::escape from my MIPMixer plugin. This pull request resolves that. Sorry.