### PR TITLE
Podcast more

### DIFF
--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -132,7 +132,7 @@ sub new {
 		handler         => $handler,
 		_track          => $track,
 		streamUrl       => $url,	# May get updated later, either here or in handler
-		originUrl       => $url,	# Keep track of the non-redirected urm
+		originUrl       => $url,	# Keep track of the non-redirected url
 	);
 
 	$self->seekdata($seekdata) if $seekdata;

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -286,6 +286,8 @@ sub getNextSong {
 						}
 
 						$track = $newTrack;
+						# need to replace streamUrl if we have been redirected/updated
+						$self->streamUrl($track->url);
 					}
 
 					# maybe we just found or scanned a playlist

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -42,7 +42,7 @@ my $_liveCount = 0;
 my @_playlistCloneAttributes = qw(
 	index
 	_track _currentTrack _currentTrackHandler
-	streamUrl
+	streamUrl originUrl
 	owner
 	_playlist _scanDone
 
@@ -132,6 +132,7 @@ sub new {
 		handler         => $handler,
 		_track          => $track,
 		streamUrl       => $url,	# May get updated later, either here or in handler
+		originUrl       => $url,	# Keep track of the non-redirected urm
 	);
 
 	$self->seekdata($seekdata) if $seekdata;

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -176,7 +176,7 @@ sub songChangeCallback {
 	}
 
 	return unless $client->streamingSong;
-	my $url = $client->streamingSong->streamUrl;
+	my $url = $client->streamingSong->originUrl;
 
 	if ( defined $cache->get("podcast-$url") && $request->isCommand([['playlist'], ['newsong']]) ) {
 		if ( $client->pluginData('goto') ) {
@@ -186,9 +186,9 @@ sub songChangeCallback {
 		
 		my $song = $client->streamingSong;
 		
-		$recentlyPlayed{$url} = { 
-					url      => $recentlyPlayed{$url}->{url} || $url,
-					title    => $recentlyPlayed{$url}->{title} || $song->track->title,
+		$recentlyPlayed{$url} ||= { 
+					url      => $url,
+					title    => $song->track->title,
 					cover    => Slim::Player::ProtocolHandlers->iconForURL($url, $client),
 					duration => $song->duration,
 				};		
@@ -211,12 +211,12 @@ sub _trackProgress {
 	my $key = 'podcast-' . $url;
 
 	Slim::Utils::Timers::killTimers( $client, \&_trackProgress );
-	return unless (($client->streamingSong && $client->streamingSong->streamUrl eq $url) || 
-				   ($client->playingSong && $client->playingSong->streamUrl eq $url)) && 
+	return unless (($client->streamingSong && $client->streamingSong->originUrl eq $url) || 
+				   ($client->playingSong && $client->playingSong->originUrl eq $url)) && 
 				    defined $cache->get($key);
 
 	# start recording position once we are actually playing
-	if ($client->isPlaying && $client->playingSong && $client->playingSong->streamUrl eq $url) {	
+	if ($client->isPlaying && $client->playingSong && $client->playingSong->originUrl eq $url) {	
 		$cache->set($key, Slim::Player::Source::songTime($client), '30days');
 		
 		# track objects aren't persistent across server restarts - keep our own list of podcast durations in the cache

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -185,13 +185,13 @@ sub songChangeCallback {
 		}
 		
 		my $song = $client->streamingSong;
-		
 		$recentlyPlayed{$url} ||= { 
-					url      => $url,
-					title    => $song->track->title,
-					cover    => Slim::Player::ProtocolHandlers->iconForURL($url, $client),
-					duration => $song->duration,
-				};		
+				url      => $url,
+				title    => $song->track->title,
+				cover    => Slim::Player::ProtocolHandlers->iconForURL($url, $client),
+				duration => $song->duration,
+		};		
+		Slim::Music::Info::setCurrentTitle($song->track->url, $recentlyPlayed{$url}->{title});				
 		
 		main::DEBUGLOG && $log->is_debug && $log->debug('Setting up timer to track podcast progress...' . Data::Dump::dump($recentlyPlayed{$url}));	
 		Slim::Utils::Timers::killTimers( $client, \&_trackProgress );


### PR DESCRIPTION
The current version was using the fact that $song->streamUrl always points to the original url, even when a redirect was happening. I was not sure why it was not updated and candidly, it bothered me a bit. Unfortunately, that does not work with direct streaming because streamUrl *is* updated with the actual (potentially redirected) url to be used direclty by the player.

Now, for podcasts position tracking, the solution is to keep a proper trace of the original url in a separated $song field and although I was a bit afraid that it would be a specific need of podcast, I now think that using $song->streamUrl as I was doing before only worked because of a bug in Player::Song::getNextSong.

In getNextSong, scanUrl is called and there (unless plugins overwrites it) the url is scanned and optionally the $song->track object is updated with the actualized/redirected url. But then, I do think that $song->streamUrl should also be updated by getNextSong as the url for streaming actually has changed!

It was not causing an issue so far because, when Player::Song::Open finds a transcoder that can accept direct streaming, it then calls the $client->canDirectStream with the $track->url and sets $song->streamUrl with return value (if exist). One $client canDirectStream handler is Squeezebox2::canDirectStream which checks for $handler::canDirectStreamSong and if not found calls $handler::canDirectStream and passes the *$track->url* object. Well, HTTP::canDirectStreamSong did not exist before I added my remote stream headers so $handler->canDirectStream was HTTP::canDirectStream that was checking against and returning $track->url (the redirected one), so so far so good.

But when I added HTTP::canDirectStreamSong, in there, I used $song->streamUrl and *not* $song->track->url to pass it to HTTP::canDirectStream, which I think is he right thing to do. Suddenly, that HTTP::canDirectStreamSong was the one called by Squeezebox2::canDirectStream and then HTTP::canDirectStream started to check and return $song->streamUrl that *was not* updated by scanUrl. As a result, Player::Song::Open was setting back the original url in direct streaming, causing it to fail (failed when more than one redirection level).

I know this is headsplitting and I wish we could whiteboard that more, but I thing this is the right changed to do, update streamUrl when scanUrl detects a change/redirect *and* add an originUrl if we want to access to what was passed at $song object creation, it seems more consistent.

In addition, all (?) plugins overload scanUrl method so in fact there will be no change to their current behavior. In fact, the first thing that most plugins do is to update streamUrl to the url they want to be the real streamed url in their getNextTrack, which is called by Player::Song::getNextSong, which tends to confort the idea that streamUrl shall reflect the actual url to be streamed, not the "original" one. When the plugin does not do the update, LMS core should