### PR TITLE
Added missing options "Broadcast" and "ReuseAddr" to UDP socket

### DIFF
--- a/Slim/Networking/UDP.pm
+++ b/Slim/Networking/UDP.pm
@@ -33,7 +33,9 @@ sub init {
 	$udpsock = IO::Socket::INET->new(
 		Proto     => 'udp',
 		LocalPort => SERVERPORT,
-		LocalAddr => $main::localClientNetAddr
+		LocalAddr => $main::localClientNetAddr,
+		Broadcast => 1,
+		ReuseAddr => 1
 
 	) or do {
 


### PR DESCRIPTION
This pull request provides a solution [to a bug](https://github.com/oweitman/ioBroker.squeezeboxrpc/issues/21) I triggered in the ioBroker.squeezeboxrpc repository.

Problem:
- On my system, both the slimserver and the ioBroker software run on the same server. Port 3483 UDP is used by both entities in order to find each other.
- While the ioBroker adapter uses the "ReuseAddr" socket option on the UDP socket, the slimserver does not (yet).
- As a consequence, as the slimserver is started first on my server, the ioBroker adapter fails as it is not able to bind to UDP port 3483 despite setting the ReuseAddr socket option.

Solution:
- This pull request adds the "ReuseAddr" to the UDP socket. This allows both entities to coexist on the same system.
- It also adds the "Broadcast" socket option, but I'm not 100% sure whether this is a good or bad idea. The ioBroker does that, so I thought that it might be a good idea to add that here in the slimserver as well. If this is wrong, please tell me, then (a) I'm going to change this pull request and (b) will discuss that in the bug tracker of the adapter.

Regards,
Florian