### PR TITLE
consistent FLAC header read

### DIFF
--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -939,6 +939,22 @@ sub scanBitrate {
 	return (-1, undef);
 }
 
+sub parseStream {
+	my ( $class, $dataref, $args ) = @_;
+
+	$args->{_scanbuf} .= $$dataref;
+	return -1 if length $args->{_scanbuf} < 32*1024;
+	
+	my $fh = File::Temp->new();
+	$fh->write($args->{_scanbuf});
+	$fh->seek(0, 0);
+	
+	my $info = Audio::Scan->scan_fh( flac => $fh )->{info};
+	$info->{fh} = $fh;
+		
+	return $info;
+}
+
 sub initiateFrameAlign {
 	my $context = { aligned => 0 };
 	return (\&frameAlign, $context);
@@ -978,14 +994,16 @@ sub frameAlign {
 		my $blockSize = ($tag >> 12) & 0x0f;		
 		if ($blockSize == 6) {
 			$offset += 2;
-		} elsif ($blockSize == 7) {
+		} 
+		elsif ($blockSize == 7) {
 			$offset += 1;
 		}
 		
 		my $samplerate = ($tag >> 8) & 0x0f;
 		if ($samplerate == 12) {
 			$offset += 1;
-		} elsif ($samplerate > 12 && $samplerate < 15) {
+		} 
+		elsif ($samplerate > 12 && $samplerate < 15) {
 			$offset += 2;
 		}
 		
@@ -1007,7 +1025,8 @@ sub frameAlign {
 			$_[1] = substr($context->{inbuf}, 0, $length - $chunkSize - 1);
 			$context->{inbuf} = substr($context->{inbuf}, $length - $chunkSize - 1);
 			return $chunkSize + 1;
-		} else {
+		} 
+		else {
 			$_[1] = $context->{inbuf};
 			$context->{inbuf} = '';
 			return 0;

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -65,7 +65,7 @@ sub request {
 	}
 
 	# obtain initial audio block if missing and adjust seekdata then
-	if (!defined $song->initialAudioBlock && $track->original_content_type && Slim::Formats->loadTagFormatForType($track->original_content_type)) {
+	if (!defined $song->initialAudioBlock && Slim::Formats->loadTagFormatForType($track->original_content_type)) {
 		my $formatClass = Slim::Formats->classForFormat($track->original_content_type);
 		my $seekdata = $song->seekdata || {};
 		

--- a/Slim/Plugin/WiMP/ProtocolHandler.pm
+++ b/Slim/Plugin/WiMP/ProtocolHandler.pm
@@ -277,12 +277,9 @@ sub _gotTrack {
 		my $http = Slim::Networking::Async::HTTP->new;
 		$http->send_request( {
 			request     => HTTP::Request->new( GET => $info->{url} ),
-			onStream    => $format =~ /fla?c/i
-				? sub {
-					my ($http, $dataref, $track, $args) = @_;
-					Slim::Utils::Scanner::Remote::parseFlacHeader($http, $track, $args);
-				}
-				: \&Slim::Utils::Scanner::Remote::parseMp4Header,
+			onStream    => $format =~ /fla?c/i ? 
+						   \&Slim::Utils::Scanner::Remote::parseFlacHeader :
+						   \&Slim::Utils::Scanner::Remote::parseMp4Header,
 			onError     => sub {
 				my ($self, $error) = @_;
 				$log->warn( "could not find $format header $error" );


### PR DESCRIPTION
- forgot to do what I said I'd do wrt header acquisition on Remote.pm => consistently use the same mode of use 'onStream' and have the 'parseStream' in the Format::XXX.pm file. It's less important for FLAC, but I really prefer having the same structure all the time. That patches fixes this and also allows the WiMP::ProtocolHandler to have the same call structure whether it's flac or mp4
- set $track->content_type in Remote.pm so that HTTP::request does not fail as it, rightfully, expects it to be set
- respect LMS' if/elsif/else style