### PR TITLE
use client's setAnalogueMode, not hardcoded Boom

### DIFF
--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -567,7 +567,7 @@ sub init {
 
 	$prefs->setChange( sub {
 		my $client = $_[2] || return;
-		Slim::Player::Boom::setAnalogOutMode($client);
+		$client->setAnalogOutMode if $client->can('setAnalogOutMode');
 	}, 'analogOutMode');
 
 	$prefs->setChange( sub {


### PR DESCRIPTION
I've better integrated SqueezeESP32 in LMS so headset/line-out management can be done from the main UI (as well as Bass/Treble - although the SetChange does not seem to work here, I have to click apply, not sure why).

While doing that, I tripped on the fact that SetChange when changing the analogue output prefs was not calling the client's method, but forcing the Boom's method. I've searched and no other player enable AnalogueOut, except Boom, so that SetChange was only called in a  Boom's context. So it seems more logical to not hardcode a call to the Boom's method but to client's method, if any.