### PR TITLE
pipeline must now check EINTR as well

### DIFF
--- a/Slim/Player/Pipeline.pm
+++ b/Slim/Player/Pipeline.pm
@@ -290,7 +290,7 @@ sub sysread {
 					delete ${*$self}{'pipeline_source'};
 					$writer->close();
 					last STUFF_PIPE;
-				} elsif ($! == EWOULDBLOCK) {
+				} elsif ($! == EWOULDBLOCK || $! == EINTR) {
 					last STUFF_PIPE;		
 				} else {
 					return undef; # reflect error to caller


### PR DESCRIPTION
This fixes issue [here](https://forums.slimdevices.com/showthread.php?110228-Scala-Radio-Stream-URL) which was introduced by me. I've scanned for other possibility of EWOULDBLOCK issue, I don't think there are others left, but I will re-check