### PR TITLE
close remote header parsing!

### DIFF
--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -734,6 +734,7 @@ sub parseFlacHeader {
 
 	# All done
 	$args->{cb}->( $track, undef, @{$args->{pt} || []} );
+	return 0;
 }
 
 sub parseMp4Header {


### PR DESCRIPTION
Now that parseFlac moved to onStream instead of onBody, LMS must be told to close the stream by returning 0 when done