### PR TITLE
flac header optimization

### DIFF
--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -950,6 +950,8 @@ sub parseStream {
 	$fh->seek(0, 0);
 	
 	my $info = Audio::Scan->scan_fh( flac => $fh )->{info};
+	return undef unless $info->{samplerate};
+
 	$info->{fh} = $fh;
 	$info->{avg_bitrate} = int(8*1000 * ($length - $info->{audio_offset}) / $info->{song_length_ms}) if $info->{song_length_ms} && $length;
 		

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -716,12 +716,14 @@ sub parseFlacHeader {
 	my $info = $formatClass->parseStream($dataref, $args, $http->response->content_length);
 	
 	return 1 if ref $info ne 'HASH' && $info;
-	
-	$track->initial_block_type( Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS );
+
 	$track->audio_initiate( \&Slim::Formats::FLAC::initiateFrameAlign );
 	$track->content_type('flc');
 	
 	if ($info) {
+		# we have valid header, means there will be no alignment unless we seek
+		$track->initial_block_type(Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
+		
 		# don't set audio_offset & audio_size as these are not reliable here
 		$track->samplerate( $info->{samplerate} );
 		$track->samplesize( $info->{bits_per_sample} );
@@ -730,6 +732,9 @@ sub parseFlacHeader {
 		my $bitrate = $info->{avg_bitrate} || int($info->{samplerate} * $info->{bits_per_sample} * $info->{channels} * 0.6);	
 		Slim::Music::Info::setBitrate( $track, $bitrate );
 		Slim::Music::Info::setDuration( $track, $info->{song_length_ms} / 1000 );
+	} else {
+		# if we don't have an header, need to always process
+		$track->initial_block_type( Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS );
 	}	
 
 	# All done


### PR DESCRIPTION
Discussion with @ralph-irving pushed me to think a bit more to flac handling and I came with a couple of improvement, the main one is that we don't need to force proxy of flac streams when there is a proper header in the stream. We'd only proxy streaming when we're seeking or there is no STREAMINFO header