### PR TITLE
better control of direct streaming when processing header

### DIFF
--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -987,7 +987,7 @@ sub frameAlign {
 		next unless ($tag & 0xfff80000) == 0xfff80000;
 		
 		# try to identify non-valid frame combination (see flac specifications)
-		return unless (($tag >> 12) & 0x0f) && ((($tag >> 8) & 0x0f) != 0x0f) && ((($tag >> 4) & 0x0f) < 11) &&
+		next unless (($tag >> 12) & 0x0f) && ((($tag >> 8) & 0x0f) != 0x0f) && ((($tag >> 4) & 0x0f) < 11) &&
 					  ((($tag >> 1) & 0x07) != 0x03) && ((($tag >> 1) & 0x07) != 0x07);
 		
 		my $offset = 4;

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -354,7 +354,7 @@ sub canDirectStreamSong {
 	return $direct if $song->stripHeader || !defined $song->track->initial_block_type;
 	
 	# with dynamic header 2, always go direct otherwise only when not seeking
-	if ($song->track->initial_block_type == Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS || $song->seekdata || $song->track->audio_initiate) {
+	if ($song->track->initial_block_type == Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS || $song->seekdata) {
 		main::INFOLOG && $directlog->info("Need to add header, cannot stream direct");
 		return 0;
 	}	

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -721,9 +721,6 @@ sub parseFlacHeader {
 	$track->content_type('flc');
 	
 	if ($info) {
-		# we have valid header, means there will be no alignment unless we seek
-		$track->initial_block_type(Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
-		
 		# don't set audio_offset & audio_size as these are not reliable here
 		$track->samplerate( $info->{samplerate} );
 		$track->samplesize( $info->{bits_per_sample} );
@@ -732,6 +729,9 @@ sub parseFlacHeader {
 		my $bitrate = $info->{avg_bitrate} || int($info->{samplerate} * $info->{bits_per_sample} * $info->{channels} * 0.6);	
 		Slim::Music::Info::setBitrate( $track, $bitrate );
 		Slim::Music::Info::setDuration( $track, $info->{song_length_ms} / 1000 );
+
+		# we have valid header, means there will be no alignment unless we seek
+		$track->initial_block_type(Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
 	} else {
 		# if we don't have an header, need to always process
 		$track->initial_block_type( Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS );


### PR DESCRIPTION
When deciding to allow direct streaming or not, HTTP::CanDirectStreamSong was checking the flag for header insertion *and* the reference to an audio processing method. This is a bit redundant and was preventing flac, that only needs to be proxied when seeking (but needs to set a processing method at $track scanning time for potential frame alignement) to be streamed direct. A bit unfortunate to force proxy as most of the time user's dont seek.

The trade-off is that developers need to set flag for header insertion to INITIAL_BLOCK_ALWAYS if processing methods need to always been executed - no big deal and was already the case for mp4

