### PR TITLE
fix bitrate with icy data

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -569,7 +569,7 @@ sub parseDirectHeaders {
 
 		elsif ($header =~ /^(?:icy-br|x-audiocast-bitrate):\s*(.+)/i) {
 			$bitrate = $1;
-			$bitrate *= 1000 if $bitrate < 1000;
+			$bitrate *= 1000 if $bitrate < 8000;
 		}
 
 		elsif ($header =~ /^icy-metaint:\s*(.+)/i) {

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -549,6 +549,12 @@ sub parseDirectHeaders {
 		($oggType) = $url->content_type =~ /(ogf|ogg|ops)/;
 		$url = $url->url;
 	}
+	
+	my $song = ${*$self}{'song'} if blessed $self;
+
+	if (!$song && $client->controller()->songStreamController()) {
+		$song = $client->controller()->songStreamController()->song();
+	}
 
 	my ($title, $bitrate, $metaint, $redir, $contentType, $length, $body);
 	my ($rangeLength, $startOffset);
@@ -567,9 +573,11 @@ sub parseDirectHeaders {
 			$title = Slim::Utils::Unicode::utf8decode_guess($1);
 		}
 
-		elsif ($header =~ /^(?:icy-br|x-audiocast-bitrate):\s*(.+)/i) {
-			$bitrate = $1;
-			$bitrate *= 1000 if $bitrate < 8000;
+		elsif ($header =~ /^(?:icy-br|x-audiocast-bitrate):\s*(.+)/i) 
+			if ($song && !$song->bitrate) {
+				$bitrate = $1;
+				$bitrate *= 1000 if $bitrate < 8000;
+			}	
 		}
 
 		elsif ($header =~ /^icy-metaint:\s*(.+)/i) {
@@ -604,12 +612,6 @@ sub parseDirectHeaders {
 	# Content-Range: has predecence over Content-Length:
 	if ($rangeLength) {
 		$length = $rangeLength;
-	}
-
-	my $song = ${*self}{'song'} if blessed $self;
-
-	if (!$song && $client->controller()->songStreamController()) {
-		$song = $client->controller()->songStreamController()->song();
 	}
 
 	if ($song && $length) {


### PR DESCRIPTION
A small patch to solve issue https://forums.slimdevices.com/showthread.php?112833-Metadata-in-FLAC-streams. There is probably more to do, especially to decide if we should believe the server bitrate or the scanned bitrate from the header. Today, the server bitrate in header has precedence which I don't think is the best option, it shoujld only be used if we did not fudn anything in the header parsing. 

But still, icy-br is often in Kbps, not in bps and now we have streams above 1000Kbps, so at least we should consider that everything under 8000 is in 1000's. I don't think we have streams below 8000!