### PR TITLE
Add support for DSD WavPack

### DIFF
--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -86,6 +86,10 @@ sub init {
 		$tagClasses{'dsf'} = 'Slim::Formats::DSF';
 	}
 
+	if (Slim::Utils::Versions->compareVersions($Audio::Scan::VERSION,'0.99') >= 0) {
+		$tagClasses{'wvpx'} = 'Slim::Formats::WavPack';
+	}
+
 	if (Slim::Utils::Versions->compareVersions($Audio::Scan::VERSION, '1.02') >= 0) {
 		$tagClasses{'ops'} = 'Slim::Formats::OggOpus';
 	}
@@ -259,6 +263,10 @@ sub readTags {
 	if ($tags->{'LEADING_MDAT'}) {
 		$type = 'mp4x';
 		$tags->{'CONTENT_TYPE'} = 'alcx' if ($tags->{'CONTENT_TYPE'} eq 'alc')
+	}
+
+	if ($tags->{'WAVPACKDSD'}) {
+		$type = 'wvpx';
 	}
 
 	# Only set if we couldn't read it from the file.

--- a/Slim/Formats/WavPack.pm
+++ b/Slim/Formats/WavPack.pm
@@ -29,6 +29,10 @@ sub getTag {
 	$tags->{CHANNELS}   = $info->{channels};
 	$tags->{VBR_SCALE}  = 1;
 	
+	if ( $info->{bits_per_sample} == 1 ) {
+	    $tags->{WAVPACKDSD} = 1;
+	}
+
 	Slim::Formats::APE->doTagMapping($tags);
 
 	return $tags;

--- a/convert.conf
+++ b/convert.conf
@@ -373,3 +373,7 @@ dsf dsf * *
 dff dff * *
 	# IFD
 	-
+
+wvpx wvpx * *
+	# IFD
+	-

--- a/strings.txt
+++ b/strings.txt
@@ -11766,19 +11766,34 @@ MPC
 	SV	Musepack
 
 WVP
-	CS	Wavpack
-	DA	Wavpack
-	DE	Wavpack
-	EN	Wavpack
-	ES	Wavpack
+	CS	WavPack
+	DA	WavPack
+	DE	WavPack
+	EN	WavPack
+	ES	WavPack
 	FI	WavPack
-	FR	Wavpack
-	IT	Wavpack
-	NL	Wavpack
-	NO	Wavpack
-	PL	Wavpack
-	RU	Wavpack
+	FR	WavPack
+	IT	WavPack
+	NL	WavPack
+	NO	WavPack
+	PL	WavPack
+	RU	WavPack
 	SV	WavPack
+
+WVPX
+	CS	WavPack DSD
+	DA	WavPack DSD
+	DE	WavPack DSD
+	EN	WavPack DSD
+	ES	WavPack DSD
+	FI	WavPack DSD
+	FR	WavPack DSD
+	IT	WavPack DSD
+	NL	WavPack DSD
+	NO	WavPack DSD
+	PL	WavPack DSD
+	RU	WavPack DSD
+	SV	WavPack DSD
 
 SHN
 # SLT: Please note that "Shorten" is a file format name, thus doesn't need to be translated

--- a/types.conf
+++ b/types.conf
@@ -57,6 +57,7 @@ wmal    -               audio/x-wma-lossless            audio
 wmap    -               audio/x-wma-wmapro              audio
 wpl     wpl             application/vnd.ms-wpl          playlist
 wvp     wv              audio/x-wavpack                 audio
+wvpx    -               audio/x-wavpack                 audio
 xml     xml,xsl         text/xml                        -
 xpf     xspf            application/xspf+xml            playlist
 xul     xul             application/vnd.mozilla.xul+xml -


### PR DESCRIPTION
From version 5.0 WavPack supports DSD-encoded WavPacks. To play these files use the DSDPlayer plugin.

Patch authored by Kimmo Taskinen