### PR TITLE
Add generic conversion rule from wvpx to flc/dff/dsf

### DIFF
--- a/convert.conf
+++ b/convert.conf
@@ -329,8 +329,11 @@ alcx flc * *
 	# FT:{START=-j %s}U:{END=-e %u}D:{RESAMPLE=-r %d}
 	[faad] -q -w -f 1 $START$ $END$ $FILE$ | [sox] -q -t wav - -t flac -C 0 $RESAMPLE$ -
 
-
 wvp flc * *
+	# FT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}
+	[wvunpack] $FILE$ -wq $START$ $END$ -o - | [sox] -q -t wav - -t flac -C 0 $RESAMPLE$ -
+
+wvpx flc * *
 	# FT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}
 	[wvunpack] $FILE$ -wq $START$ $END$ -o - | [sox] -q -t wav - -t flac -C 0 $RESAMPLE$ -
 
@@ -366,6 +369,8 @@ flc flc transcode *
 spdr spdr * *
 	 -
 
+# DSF & DFF output start here
+
 dsf dsf * *
 	# IFD
 	-
@@ -374,6 +379,10 @@ dff dff * *
 	# IFD
 	-
 
-wvpx wvpx * *
-	# IFD
-	-
+wvpx dsf * *
+	# FT:{START=--skip=%t}U:{END=--until=%v}D
+	[wvunpack] $FILE$ -q --dsf $START$ $END$ -o -
+
+wvpx dff * *
+	# FT:{START=--skip=%t}U:{END=--until=%v}D
+	[wvunpack] $FILE$ -q --dff $START$ $END$ -o -


### PR DESCRIPTION
As suggested by Kimmo Taskinen:

This adds generic conversion rules from wvpx to dff an dsf. Then Squeezelite with DSD support would not even need the DSDPlayer plugin as it supports DSD natively.

Also included is a wvpx->flc convert rule, because wvunpack can also convert DSD to pcm if you use the -w flag. The wvpx->dsf rule gets precedence over wvpx->flc except when squeezelite does not support DSD.

I have tested with squeezelite v1.8:
squeezelite without options or with the '-D' option (DoP) picks the wvpx->dsf rule.
squeezelite with option '-c flac' or '-e dsd' picks the wvpx->flc rule.

(See https://github.com/Logitech/slimserver/issues/424 for the discussion.)