### PR TITLE
Video.pm: correct default value for channels

### DIFF
--- a/Slim/Schema/Video.pm
+++ b/Slim/Schema/Video.pm
@@ -49,7 +49,7 @@ sub updateOrCreateFromResult {
 		filesize     => $result->size,
 		secs         => $result->duration_ms / 1000,
 		bitrate      => $result->bitrate,
-		channels     => 'TODO',
+		channels     => 1,
 	};
 	
 	return $class->updateOrCreateFromHash($hash);


### PR DESCRIPTION
There is a type incompatibility between the type of the MySQL Schema for videos.channel (tinyint(1) in SQL/mysql/schema_13_up.sql ), and the default value with which the field is populated (a string: "TODO"). 

I propose to set the default value to the integer 1 .