### PR TITLE
reset redirect count + socks log minor correction

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -84,7 +84,7 @@ sub new {
 		if (!$@) {
 			# no need for a hash mk_accessor type as we don't access individual keys
 			$self->socks($args->{socks});
-			main::INFOLOG && $log->info("Using SOCKS $args->{ProxyAddr}::$args->{ProxyPort} to connect");
+			main::INFOLOG && $log->info("Using SOCKS $args->{socks}->{ProxyAddr}::$args->{socks}->{ProxyPort} to connect");
 		}
 	}
 
@@ -172,9 +172,10 @@ sub use_proxy {
 }
 
 sub send_request {
-	my ( $self, $args ) = @_;
+	my ( $self, $args, $redirect ) = @_;
 
 	$self->maxRedirect( $args->{maxRedirect} || MAX_REDIR );
+	$self->response( undef ) unless $redirect;
 
 	if ( $args->{Timeout} ) {
 		$self->timeout( $args->{Timeout} );
@@ -451,7 +452,7 @@ sub _http_read {
 				$self->send_request( {
 					request => $self->request,
 					%{$args},
-				} );
+				}, 1 );
 
 				return;
 			}


### PR DESCRIPTION
When a Slim::Networking::Async::HTTP object is used with a send_request, there is a maxRedirect counter to avoid infinite looping. When there is a redirection, send_request() is automatically called recursively and the count of $previous redirection is kept in the $self->response attribute.

The issue seems to be that this counter (or the global HTTP::response object) is not initialized when send_request is called by the user which means that when a persistent connection is used and the user's code calls send_request multiple times for the same S:N:A:HTTP object, then maxRedirect will be reached. 

The correction is to erase/delete/forget the "response" attribute when the send_request is user-called and to have an extra parameter when it is recursively called for redirect reason.

Other patch is simply an error in the log for socks, so totally minor