### PR TITLE
re-use RTMP flag to indicate that SSL is required

### DIFF
--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -87,8 +87,8 @@ sub canDirectStreamSong {
 
 sub slimprotoFlags {
 	my ($client, $url, $isDirect) = @_;
-	# $url is HTTPS for sure, just need to test that direct is enabled
-	return $isDirect ? 0x20 : 0x00;
+	# $url might still be HTTP (see new), so need to check that and direct
+	return ($isDirect && $url =~ /^https:/) ? 0x20 : 0x00;
 }
 
 # we need that call structure to make sure that SUPER calls the

--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -85,6 +85,12 @@ sub canDirectStreamSong {
 	return 0;
 }
 
+sub slimprotoFlags {
+	my ($client, $url, $isDirect) = @_;
+	# $url is HTTPS for sure, just need to test that direct is enabled
+	return $isDirect ? 0x20 : 0x00;
+}
+
 # we need that call structure to make sure that SUPER calls the
 # object's parent, not the package's parent
 # see http://modernperlbooks.com/mt/2009/09/when-super-isnt.html

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -509,7 +509,7 @@ sub opened {
 #	u8_t transition_type;	// [1]	'0' = none, '1' = crossfade, '2' = fade in, '3' = fade out, '4' fade in & fade out, '5' = crossfade-immediate
 #	u8_t flags;	// [1]	0x80 - loop infinitely
 #               //      0x40 - stream without restarting decoder
-#               //      0x20 - Rtmp (SqueezePlay only) or SSL socket required (non SqueezePlay)
+#               //      0x20 - SSL socket required (when canHTTPS is set in HELO) or Rtmp (other SqueezePlay)
 #               //      0x10 - SqueezePlay direct protocol handler - pass direct to SqueezePlay
 #               //      0x08 - output only right channel as mono
 #               //      0x04 - output only left channel as mono

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -509,7 +509,7 @@ sub opened {
 #	u8_t transition_type;	// [1]	'0' = none, '1' = crossfade, '2' = fade in, '3' = fade out, '4' fade in & fade out, '5' = crossfade-immediate
 #	u8_t flags;	// [1]	0x80 - loop infinitely
 #               //      0x40 - stream without restarting decoder
-#               //      0x20 - Rtmp (SqueezePlay only)
+#               //      0x20 - Rtmp (SqueezePlay only) or SSL socket required (non SqueezePlay)
 #               //      0x10 - SqueezePlay direct protocol handler - pass direct to SqueezePlay
 #               //      0x08 - output only right channel as mono
 #               //      0x04 - output only left channel as mono


### PR DESCRIPTION
This should be as simple as that. As said, I'm not a "big fan" of using slimprotoFlags as it spreads the knowledge of something that should be core to slimproto to different places, making it difficult to manage consistently, It's just that slimprotoFlags method, should either IMHO not exist at all or be used only for user-defined/optional strm_s extensions. But it's just an opinion and we can change that later while not impacting clients as the flag is at the right place no matter what, even if set by the "wrong" method :-).

See also https://github.com/ralph-irving/squeezelite/pull/113