### PR TITLE
Add sample size to transcoder

### DIFF
--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -167,6 +167,7 @@ sub loadConversionTables {
 # %C, $CHANNELS$   - channel count
 # %c, $OCHANNELS$  - output channel count
 #   , $SAMPLESIZE$ - sample size (in bits)
+#   , $SAMPLERATE$ - sample rate (in Hz)
 # %i               - clientid
 # %I, $CLIENTID$   - clientid     ( : or . replaced by - )
 # %p               - player model
@@ -427,6 +428,7 @@ sub getConvertCommand2 {
 			player           => $player || 'undefined',
 			channels         => $track->channels() || 2,
 			sampleSize       => $track->samplesize || 16,
+			sampleRate       => $track->samplerate || 44100,
 			outputChannels   => $clientprefs ? ($clientprefs->get('outputChannels') || 2) : 2,
 			# aif/wav oddity (for '-' rule)
 			# aif - aif: any SB that does not support wav requires aif header stripping
@@ -564,6 +566,7 @@ sub tokenizeConvertCommand2 {
 	$subs{'QUALITY'}    = $quality;
 	$subs{'CHANNELS'}   = $transcoder->{'channels'};
 	$subs{'SAMPLESIZE'} = $transcoder->{'sampleSize'};
+	$subs{'SAMPLERATE'} = $transcoder->{'sampleRate'};	
 	$subs{'OCHANNELS'}  = $transcoder->{'outputChannels'};
 	$subs{'CLIENTID'}   = do { (my $tmp = $transcoder->{'clientid'}) =~ tr/.:/-/;  $tmp };
 	$subs{'PLAYER'}     = do { (my $tmp = $transcoder->{'player'}  ) =~ tr/\" /_/; $tmp };

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -166,6 +166,7 @@ sub loadConversionTables {
 
 # %C, $CHANNELS$   - channel count
 # %c, $OCHANNELS$  - output channel count
+#   , $SAMPLESIZE$ - sample size (in bits)
 # %i               - clientid
 # %I, $CLIENTID$   - clientid     ( : or . replaced by - )
 # %p               - player model
@@ -425,6 +426,7 @@ sub getConvertCommand2 {
 			name             => $client ? $client->name : 'undefined',
 			player           => $player || 'undefined',
 			channels         => $track->channels() || 2,
+			sampleSize       => $track->samplesize || 16,
 			outputChannels   => $clientprefs ? ($clientprefs->get('outputChannels') || 2) : 2,
 			# aif/wav oddity (for '-' rule)
 			# aif - aif: any SB that does not support wav requires aif header stripping
@@ -557,15 +559,16 @@ sub tokenizeConvertCommand2 {
 	# Check to see if we need to flip the endianess on output
 	$subs{'-x'}        = (unpack('n', pack('s', 1)) == 1) ? "" : "-x";
 
-	$subs{'FILE'}      = ($filepath eq '-' ? $filepath : '"' . $filepath . '"');
-	$subs{'URL'}       = '"' . $fullpath . '"';
-	$subs{'QUALITY'}   = $quality;
-	$subs{'CHANNELS'}  = $transcoder->{'channels'};
-	$subs{'OCHANNELS'} = $transcoder->{'outputChannels'};
-	$subs{'CLIENTID'}  = do { (my $tmp = $transcoder->{'clientid'}) =~ tr/.:/-/;  $tmp };
-	$subs{'PLAYER'}    = do { (my $tmp = $transcoder->{'player'}  ) =~ tr/\" /_/; $tmp };
-	$subs{'NAME'}      = do { (my $tmp = $transcoder->{'name'}    ) =~ tr/\" /_/; $tmp };
-	$subs{'GROUPID'}   = $transcoder->{'groupid'} eq 0 ? $subs{'CLIENTID'} : do { (my $tmp = sprintf ( "g%011x", $transcoder->{'groupid'}) ) =~ s/..\K(?=.)/-/g; $tmp};
+	$subs{'FILE'}       = ($filepath eq '-' ? $filepath : '"' . $filepath . '"');
+	$subs{'URL'}        = '"' . $fullpath . '"';
+	$subs{'QUALITY'}    = $quality;
+	$subs{'CHANNELS'}   = $transcoder->{'channels'};
+	$subs{'SAMPLESIZE'} = $transcoder->{'sampleSize'};
+	$subs{'OCHANNELS'}  = $transcoder->{'outputChannels'};
+	$subs{'CLIENTID'}   = do { (my $tmp = $transcoder->{'clientid'}) =~ tr/.:/-/;  $tmp };
+	$subs{'PLAYER'}     = do { (my $tmp = $transcoder->{'player'}  ) =~ tr/\" /_/; $tmp };
+	$subs{'NAME'}       = do { (my $tmp = $transcoder->{'name'}    ) =~ tr/\" /_/; $tmp };
+	$subs{'GROUPID'}    = $transcoder->{'groupid'} eq 0 ? $subs{'CLIENTID'} : do { (my $tmp = sprintf ( "g%011x", $transcoder->{'groupid'}) ) =~ s/..\K(?=.)/-/g; $tmp};
 
 	foreach my $v (keys %vars) {
 		my $value;

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -525,7 +525,8 @@ sub tokenizeConvertCommand2 {
 		$start += $transcoder->{'start'};
 	}
 
-	if ($start) {
+	# there should be no start when using stdin (cue or not)
+	if ($start && $transcoder->{'streamMode'} ne 'I') {
 		push @{$transcoder->{'usedCapabilities'}}, 'T';
 	}
 

--- a/convert.conf
+++ b/convert.conf
@@ -72,6 +72,8 @@
 
 # %C, $CHANNELS$   - channel count
 # %c, $OCHANNELS$  - output channel count
+#   , $SAMPLESIZE$ - sample size (in bits)
+#   , $SAMPLESIZE$ - sample size (in bits)
 # %i               - clientid
 # %I, $CLIENTID$   - clientid     ( : or . replaced by - )
 # %p               - player model
@@ -121,7 +123,7 @@ aif mp3 * *
 	[lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ $FILE$ -
 
 flc mp3 * *
-	# FB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}
+	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}
 	[flac] -dcs $START$ $END$ -- $FILE$ | [lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 wma mp3 * *
@@ -165,11 +167,11 @@ wav pcm * *
 	-
 
 flc pcm * *
-	# FT:{START=--skip=%t}U:{END=--until=%v}
+	# IFT:{START=--skip=%t}U:{END=--until=%v}
 	[flac] -dcs --force-raw-format --endian=little --sign=signed $START$ $END$ -- $FILE$
 
 flc aif * *
-	# FT:{START=--skip=%t}U:{END=--until=%v}
+	# IFT:{START=--skip=%t}U:{END=--until=%v}
 	[flac] -dcs --force-raw-format --endian=big --sign=signed $START$ $END$ -- $FILE$
 
 ogf ogf * *
@@ -358,6 +360,7 @@ mp3 mp3 transcode *
 
 flc flc transcode *
 	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}
+	[flac] -dcs $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ -L - -t flac -C 0  -	
 	[flac] -dcs $START$ $END$ -- $FILE$ | [sox] -q -t wav - -t flac -C 0 $RESAMPLE$ -
 
 # This example transcodes MP3s to MP3s, if the target machine has the


### PR DESCRIPTION
This is a first proposal (not to be merged at that point, but for review) of adding sample size to transcoding helper so that we can build rules that use raw format. I've not added substitution strings at that point as I'm not sure to see the need, but it can be easily done of course