### PR TITLE
add 'E' field to convert.conf

### DIFF
--- a/convert.conf
+++ b/convert.conf
@@ -359,7 +359,7 @@ mp3 mp3 transcode *
 	[lame] --silent -q $QUALITY$ $BITRATE$ $RESAMPLE$ --mp3input $FILE$ -
 
 flc flc transcode *
-	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}
+	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}E:{NOSTART=I}
 	[flac] -dcs $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ -L - -t flac -C 0  -	
 
 # This example transcodes MP3s to MP3s, if the target machine has the

--- a/convert.conf
+++ b/convert.conf
@@ -40,7 +40,10 @@
 # I - can transcode from stdin
 # F - can transcode from a named file
 # R - can transcode from a remote URL (URL types unspecified)
-# H - request to strip out header (wav/aif only)
+#
+# E - extensions syntax E:{<key>=<value>,<key>=<value>}
+#		NOSTART=I/F/R : no $START$ field when transcoding from I/F/R
+#		NOHEADER=I/F/R : strip out header when transcoding from I/F/R (waf/aif only)
 #
 # O - can seek to a byte offset in the source stream (not yet implemented)
 # T - can seek to a start time offset


### PR DESCRIPTION
Per @bpa comment here https://forums.slimdevices.com/showthread.php?113308-PCP-6-1-0-Issue-with-cue-(LMS-8-0)/page8, this PR adds a new field to convert.conf, 'E' so that we can add further extensions. The first one is to allo the $START$ removal to be optional. I've also moved the header strip out under this (it's not used at all currently)