### PR TITLE
force transcode option

### DIFF
--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -307,11 +307,14 @@ sub getConvertCommand2 {
 	my $track;
 	my $song;
 	my $client;
+	my $forceTranscode;
 
 	if ( ref $songOrTrack eq 'Slim::Player::Song' ) {
 		$song   = $songOrTrack;
 		$track  = $song->currentTrack();
 		$client = $song->master();
+		my $handler = $song->currentTrackHandler();
+		$forceTranscode = $handler->forceTranscode($client, $type) if $handler && $handler->can('forceTranscode');
 	}
 	else {
 		$track = $songOrTrack;
@@ -358,7 +361,8 @@ sub getConvertCommand2 {
 	}
 
 	# Build the full list of possible profiles
-	my @profiles = ();
+	my @profiles = $forceTranscode ? ("$type-$type-transcode-*") : ();
+
 	foreach my $checkFormat (@supportedformats) {
 
 		if ( $clientid && $player ) {
@@ -371,7 +375,7 @@ sub getConvertCommand2 {
 
 		push @profiles, "$type-$checkFormat-*-*";
 
-		if ($type eq $checkFormat && enabledFormat("$type-$checkFormat-*-*")) {
+		if ($type eq $checkFormat && enabledFormat("$type-$checkFormat-*-*") && !$forceTranscode) {
 			push @profiles, "$type-$checkFormat-transcode-*";
 		}
 	}

--- a/Slim/Plugin/WiMP/ProtocolHandler.pm
+++ b/Slim/Plugin/WiMP/ProtocolHandler.pm
@@ -40,14 +40,6 @@ sub getFormatForURL {
 	return $format;
 }
 
-sub formatOverride {
-	my ($class, $song) = @_;
-	my $format = Slim::Music::Info::contentType($song->currentTrack);
-
-	return 'tdlflc' if $format eq 'flc';
-	return $format;
-}
-
 # default buffer 3 seconds of 256kbps MP3/768kbps FLAC audio
 my %bufferSecs = (
 	flac => 80,
@@ -67,6 +59,11 @@ sub bufferThreshold {
 }
 
 sub canSeek { 1 }
+
+sub forceTranscode { 
+	my ($self, $client, $format) = @_;
+	return $format eq 'flc' && $client->model =~ /squeezebox|boom|transporter/;
+}
 
 # To support remote streaming (synced players), we need to subclass Protocols::HTTP
 sub new {


### PR DESCRIPTION
You should be able to remove the tfdlc rules and still have flc flc transcoding for ip3k. It seems to me like a quick, clean & easy modification. With that, we have the flc cue sheet working, seek from stdin and for TIDAL, transcode for ip3k and flac direct for for others

I did not take into consideration $formatOverride because I assumed that the plugin's ProtocolHandler would figure out what it wants to do, i.e. don't set forceTranscode and formatOverride in a inconsistent way. Now, if you prefer, we can include the $formatOverride as a parameter of forceTranscode method