### PR TITLE
add pcm when codec is wav

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -349,7 +349,7 @@ sub canDirectStreamSong {
 	# can't go direct if we are synced or proxy is set by user
 	my $direct = $class->canDirectStream( $client, $song->streamUrl(), $class->getFormatForURL() );
 	return 0 unless $direct;
-	
+
 	# no header or stripHeader flag has precedence
 	return $direct if $song->stripHeader || !defined $song->track->initial_block_type;
 	

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -163,7 +163,7 @@ sub play {
 	}
 
 	$client->bufferReady(0);
-	
+
 	my $ret = $client->stream_s($params);
 
 	# make sure volume is set, without changing temp setting

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -361,8 +361,10 @@ sub getConvertCommand2 {
 	}
 
 	if ($prefs->get('prioritizeNative')) {
-		my ($format) = grep /$type/, @supportedformats;
-		@supportedformats = ($format, grep { $_ !~ $type } @supportedformats) if $format;
+		my @types = $type eq 'wav' ? ('pcm', $type) : ($type);
+			my ($format) = grep /$type/, @supportedformats;
+			@supportedformats = ($format, grep { $_ !~ $type } @supportedformats) if $format;
+		}	
 	}
 
 	# Build the full list of possible profiles

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -362,6 +362,7 @@ sub getConvertCommand2 {
 
 	if ($prefs->get('prioritizeNative')) {
 		my @types = $type eq 'wav' ? ('pcm', $type) : ($type);
+		foreach my $type (@types) {
 			my ($format) = grep /$type/, @supportedformats;
 			@supportedformats = ($format, grep { $_ !~ $type } @supportedformats) if $format;
 		}	

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -931,10 +931,11 @@ sub parseWavAifHeader {
 		$args->{cb}->( $track, undef, @{$args->{pt} || []} );
 		return 0;
 	}
-	
+
 	$track->samplerate($info->{samplerate});
 	$track->samplesize($info->{samplesize});
 	$track->channels($info->{channels});	
+	$track->endian($type eq 'wav' || $info->{compression_type} eq 'swot' ? 0 : 1);
 	
 	$track->block_alignment($info->{channels} * $info->{bits_per_sample} / 8);
 	$track->audio_offset($info->{audio_offset});


### PR DESCRIPTION
Formats wav/aif/pcm are special beasts as they all can be direct . This PR promotes 'pcm' (if supported) in codec's list as well as 'wav' when 'wav' is the source format, enabling native playback on ip3k