### PR TITLE
Transcode update

### DIFF
--- a/Slim/Formats/Movie.pm
+++ b/Slim/Formats/Movie.pm
@@ -276,9 +276,8 @@ sub parseStream {
 	
 	# MPEG-4 audio = 64,  MPEG-4 ADTS main = 102, MPEG-4 ADTS Low Complexity = 103
 	# MPEG-4 ADTS Scalable Sampling Rate = 104	
-	if ($info->{tracks}->[0] && $info->{tracks}->[0]->{audio_type} == 64 && (!$args->{formats} || grep(/aac/i, @{$args->{formats}}))) {
-		$info->{audio_initiate} = \&setADTSProcess;
-		$info->{audio_format} = 'aac';
+	if ($info->{tracks}->[0] && $info->{tracks}->[0]->{audio_type} == 64) {
+		$info->{processor} = { 'aac' => \&setADTSProcess };
 	}	
 
 	return $info;

--- a/Slim/Formats/Movie.pm
+++ b/Slim/Formats/Movie.pm
@@ -277,7 +277,7 @@ sub parseStream {
 	# MPEG-4 audio = 64,  MPEG-4 ADTS main = 102, MPEG-4 ADTS Low Complexity = 103
 	# MPEG-4 ADTS Scalable Sampling Rate = 104	
 	if ($info->{tracks}->[0] && $info->{tracks}->[0]->{audio_type} == 64) {
-		$info->{processor} = { 'aac' => \&setADTSProcess };
+		$info->{processors} = { 'aac' => \&setADTSProcess };
 	}	
 
 	return $info;

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -57,16 +57,17 @@ sub request {
 	my $args  = shift;
 	my $song = $args->{'song'};
 	my $track = $song->track;
+	my $processor = $track->processor($song->wantFormat);
 
 	# no other guidance, define AudioBlock to make sure that audio_offset is skipped in requestString
-	if (!defined $track->initial_block_type || $song->stripHeader) {
+	if (!$processor || $song->stripHeader) {
 		$song->initialAudioBlock('');
 		return $self->SUPER::request($args);
 	}
 
 	# obtain initial audio block if missing and adjust seekdata then
-	if (!defined $song->initialAudioBlock && Slim::Formats->loadTagFormatForType($track->original_content_type)) {
-		my $formatClass = Slim::Formats->classForFormat($track->original_content_type);
+	if (!defined $song->initialAudioBlock && Slim::Formats->loadTagFormatForType($track->content_type)) {
+		my $formatClass = Slim::Formats->classForFormat($track->content_type);
 		my $seekdata = $song->seekdata || {};
 		
 		if ($formatClass->can('findFrameBoundaries')) {
@@ -90,18 +91,18 @@ sub request {
 
 	# setup audio pre-process if required
 	my $blockRef = \($song->initialAudioBlock);
-	(${*$self}{'audio_process'}, ${*$self}{'audio_stash'}) = $track->audio_initiate->($blockRef) if $track->audio_initiate;
+	(${*$self}{'audio_process'}, ${*$self}{'audio_stash'}) = $processor->{'init'}->($blockRef) if $processor->{'init'};
 	
 	# set initial block to be sent 
 	${*$self}{'initialAudioBlockRef'} = $blockRef;
 	${*$self}{'initialAudioBlockRemaining'} = length $$blockRef;
 
 	# dynamic headers need to be re-calculated every time 
-	$song->initialAudioBlock(undef) if $track->initial_block_type;
+	$song->initialAudioBlock(undef) if $processor->{'initial_block_type'};
 		
 	main::DEBUGLOG && $log->debug("streaming $args->{url} with header of ", length $$blockRef, " from ", 
 								  $song->seekdata ? $song->seekdata->{sourceStreamOffset} || 0 : $track->audio_offset,
-								  " and processing with ", sprintf("%s", $track->audio_initiate) || 'none'); 
+								  " and processing with ", sprintf("%s", $processor->{'init'} || 'none')); 
 
 	return $self;
 }
@@ -349,12 +350,14 @@ sub canDirectStreamSong {
 	# can't go direct if we are synced or proxy is set by user
 	my $direct = $class->canDirectStream( $client, $song->streamUrl(), $class->getFormatForURL() );
 	return 0 unless $direct;
+	
+	my $processor = $song->track->processor($song->wantFormat);
 
 	# no header or stripHeader flag has precedence
-	return $direct if $song->stripHeader || !defined $song->track->initial_block_type;
+	return $direct if $song->stripHeader || !$processor;
 	
 	# with dynamic header 2, always go direct otherwise only when not seeking
-	if ($song->track->initial_block_type == Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS || $song->seekdata) {
+	if ($processor->{'initial_block_type'} == Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS || $song->seekdata) {
 		main::INFOLOG && $directlog->info("Need to add header, cannot stream direct");
 		return 0;
 	}	
@@ -418,7 +421,6 @@ sub sysread {
 	} 
 	else {	
 		$readLength = $self->_sysread($_[1], $chunkSize, length($_[1] || ''));
-		$readLength = $self->_parseStreamHeader($_[1], $readLength, $chunkSize);
 		${*$self}{'audio_buildup'} = ${*$self}{'audio_process'}->(${*$self}{'audio_stash'}, $_[1], $chunkSize) if ${*$self}{'audio_process'}; 
 	}	
 	
@@ -452,99 +454,6 @@ sub sysread {
 	}
 	
 	return $readLength;
-}
-
-sub _parseStreamHeader {
-	my ($self, undef, $readLength, $chunkSize) = @_;
-	my $args = ${*$self}{'parser_args'};	
-
-	return $readLength unless $args && $readLength;
-	
-	# stitch with trailing bytes
-	$_[1] .= $args->{'pending'};
-	my $pending = length $args->{'pending'};
-	$args->{'pending'} = '';
-	
-	# skip header bytes if any remaining (might come from pending bytes)
-	if ($args->{'bytes'} < 0) {
-		$args->{'bytes'} += length $_[1];
-		$_[1] = substr($_[1], -$args->{'bytes'});
-
-		# we have consumed all bytes in skipping	
-		return undef unless $_[1];
-		
-		# remove ourselves when header has been consumed
-		if ($_[1] <= $chunkSize) {
-			delete ${*$self}{'parser_args'};
-			return undef;
-		}	
-	}
-	
-	# due to trailing bytes, we might be over chunksize
-	if ($pending) {
-		$args->{'pending'} = substr($_[1], $chunkSize);
-		$_[1] = substr($args->{'pending'}, 0, $chunkSize);
-		
-		# remove ourselves when we have reached end of header
-		delete ${*$self}{'parser_args'} unless $args->{'pending'};
-		return undef;
-	}
-		
-	$args->{'bytes'} += $readLength;
-	my $info = ${*$self}{'parser'}->(__PACKAGE__, \$_[1], $args);
-					
-	if (ref $info eq 'HASH') {
-		# read header in memory from file handle
-		$info->{'fh'}->seek(0, 0);
-		$info->{'fh'}->read(my $block, -s $info->{'fh'});
-						
-		# set processing optional hook
-		if ( $info->{'audio_initiate'} ) {
-			(${*$self}{'audio_process'}, ${*$self}{'audio_stash'}) = $info->{'audio_initiate'}->(\$block); 
-		}	
-		
-		# send the header, modified or not by 'initiate'
-		${*$self}{'initialAudioBlockRef'} = \$block;
-		${*$self}{'initialAudioBlockRemaining'} = length $block;
-			
-		$args->{'bytes'} -= $info->{'audio_offset'};
-		$_[1] = $args->{'bytes'} ? substr($_[1], -$args->{'bytes'}) : '';	
-
-		# see you next time if we have a header to send
-		if ($block) {
-			$args->{'pending'} = $_[1];
-			$_[1] = undef;
-		}
-
-		main::DEBUGLOG && $log->debug("found header and a processor $info->{'audio_initiate'}\@${*$self}{'audio_process'} ", 
-                                      "at $info->{'audio_offset'} for $args->{'formats'} and header ${*$self}{'initialAudioBlockRemaining'}");			
-		
-		delete ${*$self}{'parser_args'} if length $_[1];
-	} 
-	elsif ($info >= 0) {
-		# a jump is requested, this cannot be parsed on-the-fly
-		$log->error("failed to get a header $info for $args->{'format'}");
-		delete ${*$self}{'parser_args'};
-	} 
-	else {
-		main::DEBUGLOG && $log->debug("need to parse more than $args->{'bytes'} for $args->{'format'}");			
-		$_[1] = undef;
-		$readLength = undef;				
-	}
-
-	return $readLength;
-}
-
-sub setLiveHeader {
-	my ($self, $type, $formats) = @_;
-	my $formatClass;
-
-	return 0 unless Slim::Formats->loadTagFormatForType($type) && 
-                    ($formatClass = Slim::Formats->classForFormat($type)) &&
-                    $formatClass->can('parseStream');
-					
-	${*$self}{'parser'} = $formatClass->can('parseStream');
-	${*$self}{'parser_args'} = { formats => $formats };
 }
 
 sub parseDirectHeaders {

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -57,7 +57,7 @@ sub request {
 	my $args  = shift;
 	my $song = $args->{'song'};
 	my $track = $song->track;
-	my $processor = $track->processor($song->wantFormat);
+	my $processor = $track->processors($song->wantFormat);
 
 	# no other guidance, define AudioBlock to make sure that audio_offset is skipped in requestString
 	if (!$processor || $song->stripHeader) {
@@ -102,7 +102,7 @@ sub request {
 		
 	main::DEBUGLOG && $log->debug("streaming $args->{url} with header of ", length $$blockRef, " from ", 
 								  $song->seekdata ? $song->seekdata->{sourceStreamOffset} || 0 : $track->audio_offset,
-								  " and processing with ", sprintf("%s", $processor->{'init'} || 'none')); 
+								  $processor->{'init'} ? 'with a processor' : ''); 
 
 	return $self;
 }
@@ -351,7 +351,7 @@ sub canDirectStreamSong {
 	my $direct = $class->canDirectStream( $client, $song->streamUrl(), $class->getFormatForURL() );
 	return 0 unless $direct;
 	
-	my $processor = $song->track->processor($song->wantFormat);
+	my $processor = $song->track->processors($song->wantFormat);
 
 	# no header or stripHeader flag has precedence
 	return $direct if $song->stripHeader || !$processor;

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -406,7 +406,7 @@ sub open {
 		push @streamFormats, ($handler->isRemote && !Slim::Music::Info::isVolatile($handler) ? 'R' : 'F');
 		
 		my $formats = [ $format ];
-		push ($formats, grep { $_ ne $format} keys %{$track->processor}) if $track->can('processor');
+		push (@$formats, grep { $_ ne $format} keys %{$track->processor}) if $track->can('processor');
 
 		($transcoder, $error) = Slim::Player::TranscodingHelper::getConvertCommand2(
 			$self,

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -400,6 +400,8 @@ sub open {
 		my @formats = ( $format );
 		push (@formats, grep { $_ ne $format} keys %{$track->processors}) if $track->can('processors');
 
+		# we include processed formats just here because it only applies to remote + 'I' and other
+		# calls to getConvertCommand2 (seek evaluation & Volatile) rule out this case before
 		foreach (@formats) {
 			$self->wantFormat($_);
 			($transcoder, $error) = Slim::Player::TranscodingHelper::getConvertCommand2(

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -400,7 +400,7 @@ sub open {
 		my @formats = ( $format );
 		push (@formats, grep { $_ ne $format} keys %{$track->processors}) if $track->can('processors');
 
-		# we include processed formats just here because it only applies to remote + 'I' and other
+		# we include processed formats just here because they only applies to remote + 'I' and other
 		# calls to getConvertCommand2 (seek evaluation & Volatile) rule out this case before
 		foreach (@formats) {
 			$self->wantFormat($_);
@@ -417,7 +417,7 @@ sub open {
 		} elsif (main::INFOLOG && $log->is_info) {
 			 $log->info("Transcoder: streamMode=", $transcoder->{'streamMode'}, ", streamformat=", $transcoder->{'streamformat'});
 		}
-		
+
 		if ($wantTranscoderSeek && (grep(/T/, @{$transcoder->{'usedCapabilities'}}))) {
 			$transcoder->{'start'} = $self->startOffset($self->seekdata()->{'timeOffset'});
 		}

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -302,19 +302,6 @@ sub checkBin {
 }
 
 sub getConvertCommand2 {
-	my $songOrTrack = shift;
-	my $type = shift || [undef];
-	my $transcoder;
-
-	foreach (@$type) {
-		$transcoder = _getConvertCommand2($songOrTrack, $_, @_);
-		last if $transcoder;
-	} 
-
-	return $transcoder;
-}	
-
-sub _getConvertCommand2 {
 	my ($songOrTrack, $type, $streamModes, $need, $want, $formatOverride, $rateOverride) = @_;
 
 	my $track;
@@ -454,7 +441,6 @@ sub _getConvertCommand2 {
 			profile          => $profile,
 			usedCapabilities => [@$need, @$want],
 			streamMode       => $streamMode,
-			wantFormat       => $type,
 			streamformat     => $streamformat,
 			rateLimit        => $rateLimit || 320,
 			samplerateLimit  => $samplerateLimit || 44100,

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -302,6 +302,19 @@ sub checkBin {
 }
 
 sub getConvertCommand2 {
+	my $songOrTrack = shift;
+	my $type = shift || [undef];
+	my $transcoder;
+
+	foreach (@$type) {
+		$transcoder = _getConvertCommand2($songOrTrack, $_, @_);
+		last if $transcoder;
+	} 
+
+	return $transcoder;
+}	
+
+sub _getConvertCommand2 {
 	my ($songOrTrack, $type, $streamModes, $need, $want, $formatOverride, $rateOverride) = @_;
 
 	my $track;
@@ -441,6 +454,7 @@ sub getConvertCommand2 {
 			profile          => $profile,
 			usedCapabilities => [@$need, @$want],
 			streamMode       => $streamMode,
+			wantFormat       => $type,
 			streamformat     => $streamformat,
 			rateLimit        => $rateLimit || 320,
 			samplerateLimit  => $samplerateLimit || 44100,

--- a/Slim/Schema/RemoteTrack.pm
+++ b/Slim/Schema/RemoteTrack.pm
@@ -69,7 +69,7 @@ my @allAttributes = (qw(
 	);
 	
 	__PACKAGE__->mk_accessor('rw', @allAttributes);
-	__PACKAGE__->mk_accessor('hash', '_processor');
+	__PACKAGE__->mk_accessor('hash', '_processors');
 }
 
 sub init {
@@ -131,19 +131,19 @@ sub comment {
 	return $self->_comment;
 }
 
-sub processor {
+sub processors {
 	my ($self, $type, $initial_block_type, $init) = @_;
 	
-	return $self->_processor unless $type;
+	return $self->_processors unless $type;
 	
 	if (defined $initial_block_type || defined $init) {
-		$self->_processor($type, {
+		$self->_processors($type, {
 					initial_block_type => $initial_block_type,
 					init => $init,
 				} );
 	}
 
-	return $self->_processor($type);
+	return $self->_processors($type);
 }
 
 sub _mergeComments {
@@ -303,7 +303,7 @@ sub new {
 	main::DEBUGLOG && $log->is_debug && $log->debug("$class, $url");
 #	main::DEBUGLOG && $log->logBacktrace();
 	
-	$self->init_accessor(_url => $url, id => -int($self), secs => 0, stash => {}, _processor => {});
+	$self->init_accessor(_url => $url, id => -int($self), secs => 0, stash => {}, _processors => {});
 	$self->init_accessor(remote => Slim::Music::Info::isRemoteURL($url));
 	$self->setAttributes($attributes);
 	

--- a/Slim/Schema/RemoteTrack.pm
+++ b/Slim/Schema/RemoteTrack.pm
@@ -34,7 +34,7 @@ tie our %idIndex, 'Tie::Cache::LRU', CACHE_SIZE;
 
 my @allAttributes = (qw(
 	_url
-	_content_type original_content_type
+	content_type
 	bitrate
 	secs
 	
@@ -42,7 +42,7 @@ my @allAttributes = (qw(
 	
 	title titlesort titlesearch album tracknum
 	timestamp filesize disc audio audio_size audio_offset year
-	initial_block_fh initial_block_type audio_initiate
+	initial_block_fh 
 	cover vbr_scale samplerate samplesize channels block_alignment endian
 	bpm tagversion drm musicmagic_mixable
 	musicbrainz_id lossless lyrics replay_gain replay_peak extid
@@ -69,6 +69,7 @@ my @allAttributes = (qw(
 	);
 	
 	__PACKAGE__->mk_accessor('rw', @allAttributes);
+	__PACKAGE__->mk_accessor('hash', '_processor');
 }
 
 sub init {
@@ -130,16 +131,19 @@ sub comment {
 	return $self->_comment;
 }
 
-sub content_type {
-	my ($self, $ct) = @_;
+sub processor {
+	my ($self, $type, $initial_block_type, $init) = @_;
 	
-	if (!$self->original_content_type || $self->original_content_type eq $self->_content_type) {
-		$self->original_content_type($self->_content_type || $ct);
-	}	
+	return $self->_processor unless $type;
 	
-	$self->_content_type($ct) if $ct;
+	if (defined $initial_block_type || defined $init) {
+		$self->_processor($type, {
+					initial_block_type => $initial_block_type,
+					init => $init,
+				} );
+	}
 
-	return $self->_content_type;
+	return $self->_processor($type);
 }
 
 sub _mergeComments {
@@ -299,7 +303,7 @@ sub new {
 	main::DEBUGLOG && $log->is_debug && $log->debug("$class, $url");
 #	main::DEBUGLOG && $log->logBacktrace();
 	
-	$self->init_accessor(_url => $url, id => -int($self), secs => 0, stash => {});
+	$self->init_accessor(_url => $url, id => -int($self), secs => 0, stash => {}, _processor => {});
 	$self->init_accessor(remote => Slim::Music::Info::isRemoteURL($url));
 	$self->setAttributes($attributes);
 	
@@ -319,8 +323,7 @@ my %localTagMapping = (
 	album                  => 'albumname',
 	rate                   => 'samplerate',
 	age                    => 'timestamp',
-	ct                     => '_content_type',
-	content_type           => '_content_type',
+	ct                     => 'content_type',
 	fs                     => 'filesize',
 	comment                => '_comment',
 	offset                 => 'audio_offset',

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -717,7 +717,6 @@ sub parseFlacHeader {
 	
 	return 1 if ref $info ne 'HASH' && $info;
 
-	$track->audio_initiate( \&Slim::Formats::FLAC::initiateFrameAlign );
 	$track->content_type('flc');
 	
 	if ($info) {
@@ -731,10 +730,10 @@ sub parseFlacHeader {
 		Slim::Music::Info::setDuration( $track, $info->{song_length_ms} / 1000 );
 
 		# we have valid header, means there will be no alignment unless we seek
-		$track->processor('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
+		$track->processor('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK, \&Slim::Formats::FLAC::initiateFrameAlign);
 	} else {
 		# if we don't have an header, need to always process
-		$track->processor('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS );
+		$track->processor('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS, \&Slim::Formats::FLAC::initiateFrameAlign );
 	}	
 
 	# All done
@@ -794,7 +793,7 @@ sub parseMp4Header {
 	my $bitrate = $info->{avg_bitrate};
 	
 	if ( my $item = $info->{tracks}->[0] ) {
-		my $format;
+		my $format = 'mp4';
 		
 		$samplesize = $item->{bits_per_sample};
 		$channels = $item->{channels};
@@ -823,7 +822,7 @@ sub parseMp4Header {
 		} 
 		
 		# change track attributes if format has been altered
-		if ( $format ) {
+		if ( $format ne $track->content_type ) {
 			Slim::Schema->clearContentTypeCache( $track->url );
 			Slim::Music::Info::setContentType( $track->url, $format );
 			$track->content_type($format);

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -730,10 +730,10 @@ sub parseFlacHeader {
 		Slim::Music::Info::setDuration( $track, $info->{song_length_ms} / 1000 );
 
 		# we have valid header, means there will be no alignment unless we seek
-		$track->processor('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK, \&Slim::Formats::FLAC::initiateFrameAlign);
+		$track->processors('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK, \&Slim::Formats::FLAC::initiateFrameAlign);
 	} else {
 		# if we don't have an header, need to always process
-		$track->processor('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS, \&Slim::Formats::FLAC::initiateFrameAlign );
+		$track->processors('flc', Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS, \&Slim::Formats::FLAC::initiateFrameAlign );
 	}	
 
 	# All done
@@ -817,8 +817,8 @@ sub parseMp4Header {
 		}
 		
 		# use process_audio hook & format if set by parser
-		foreach ( keys %{$info->{processor}} ) {
-			$track->processor($_, Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS, $info->{processor}->{$_});
+		foreach ( keys %{$info->{processors}} ) {
+			$track->processors($_, Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS, $info->{processors}->{$_});
 		} 
 		
 		# change track attributes if format has been altered
@@ -843,7 +843,7 @@ sub parseMp4Header {
 	
 	# use the audio block to stash the temp file handler
 	$track->initial_block_fh($info->{fh});
-	$track->processor($track->content_type, $args->{initial_block_type} // Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
+	$track->processors($track->content_type, $args->{initial_block_type} // Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
 	
 	if ( main::DEBUGLOG && $log->is_debug ) {
 		$log->debug( sprintf( "mp4: %dHz, %dBits, %dch => bitrate: %dkbps (ofs:%d, len:%d, hdr:%d)",
@@ -942,7 +942,7 @@ sub parseWavAifHeader {
 	
 	# we have a dynamic header but can go direct when not seeking
 	$track->initial_block_fh($info->{fh});
-	$track->processor($type, Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
+	$track->processors($type, Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
 
 	# all done
 	$args->{cb}->( $track, undef, @{$args->{pt} || []} );

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -769,7 +769,7 @@ sub parseMp4Header {
 			# re-calculate header all the time (i.e. can't go direct at all)
 			$args->{initial_block_type} = Slim::Schema::RemoteTrack::INITIAL_BLOCK_ALWAYS;
 		
-			main::INFOLOG && $log->is_info && $log->debug("'mdat' reached before 'moov' at ", length($args->{_scanbuf}), " => seeking with $args->{_range}");
+			main::INFOLOG && $log->is_info && $log->info("'mdat' reached before 'moov' at ", length($args->{_scanbuf}), " => seeking with $args->{_range}");
 	
 			$query->send_request( {
 				request    => HTTP::Request->new( GET => $url,  [ 'Range' => "bytes=$info-" ] ),


### PR DESCRIPTION
This PR is an evolution of my header management for wav/aif + built-in transcoding/processing used for mp4 file on squeezeboxes and for flac alignement when seeking (https://github.com/Logitech/slimserver/pull/367). This modification is to allow as much as possible native streaming (used in mp4 so far). All this only applies to *remote streams*

Currently, the mp4->aac (ADTS wrapper) in Perl is always activated, whether the player can support mp4 directly or not, so not only that but also it forces proxying. With that PR, LMS will look for a transcoding rule with native format first and then try all alternative formats offered by the parseStream found in various Slim::Formats so mp4 will play non-proxied in squeezelite (and aac-capable players) and when seeking, it will be only proxied. When playing *streams* on a squeezebox, as aac is not supported, then "mp4 flc" rule will fail (all rules without I or R) and transcoder will try the "aac flc" (or any convenient rule with I oR ) instead because the Slim::Formats::Movie::parseStream reports a support for 'aac'. 

It's a generalization on my previous PR that I'm pretty happy with (I know I'll regret writing that) as it's simpler, more flexible and more elegant. A parser in Slim::Formats can add any number or internal transcoding rules, where before there was only one possible. I've also been able to remove most added variables by the original PR.

I've also removed the code to manage live headers b/c I don't think it will ever be used. It was complicated and I doubt any plugin or LMS developer will ever have a look. This new PR also would have required adjustment to that delicate piece of code and I did not want to leave something that I now would not work. I can always bring it back later if somebody cries for it.

I've only been testing it on my Windows version so far, so no rush to incorporate it