### PR TITLE
let user add extra options for IO::Socket or IO::Socket::SSL

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -89,7 +89,6 @@ sub new {
 	}
 
 	$self->options($args->{options});
-	print Dumper("additional socket", $self->options);
 
 	return $self;
 }

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -7,6 +7,13 @@ package Slim::Networking::Async::HTTP;
 # version 2.
 
 # This class provides an async HTTP implementation.
+# The constructor takes an optional hash with two keys to hash
+# - 'options': set parameters for underlying socket object
+#   Slim::Networking::Async::HTTP->new( { options => {
+#               SSL_cipher_list => 'DEFAULT:!DH',
+#               SSL_verify_mode => Net::SSLeay::VERIFY_NONE } })
+# - 'socks': use a socks proxy to tunnel the request 
+# See code below for better explanation
 
 use strict;
 

--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -95,6 +95,9 @@ sub new {
 
 sub new_socket {
 	my $self = shift;
+	
+	# merge with user-defined socket parameters
+	push @_, %{$self->options} if $self->options;
 
 	if ( my $proxy = $self->use_proxy ) {
 
@@ -108,9 +111,6 @@ sub new_socket {
 			PeerPort => $pport || 80,
 		);
 	}
-
-	# merge with user-defined socket parameters
-	push @_, %{$self->options} if $self->options;
 
 	# Create SSL socket if URI is https
 	if ( $self->request->uri->scheme eq 'https' ) {
@@ -127,8 +127,8 @@ sub new_socket {
 			my %args = @_;
 
 			# Failed. Try again with an explicit SNI.
-			$args{SSL_hostname} = $args{Host} unless defined $args{SSL_hostname};
-			$args{SSL_verify_mode} = Net::SSLeay::VERIFY_NONE() if $prefs->get('insecureHTTPS') && !defined $args{SSL_verify_mode};
+			$args{SSL_hostname} //= $args{Host};
+			$args{SSL_verify_mode} //= Net::SSLeay::VERIFY_NONE() if $prefs->get('insecureHTTPS');
 
 			if ($self->socks) {
 				return Slim::Networking::Async::Socket::HTTPSSocks->new( %{$self->socks}, %args );

--- a/Slim/Networking/SimpleAsyncHTTP.pm
+++ b/Slim/Networking/SimpleAsyncHTTP.pm
@@ -356,7 +356,9 @@ my $http = Slim::Networking::SimpleAsyncHTTP->new(
 	{
 		mydata'  => 'foo',
 		cache    => 1,		# optional, cache result of HTTP request
-		expires => '1h',	# optional, specify the length of time to cache
+		expires  => '1h',	# optional, specify the length of time to cache
+		options  => { key/value },  # optional set of key/value pairs for the underlying socket
+		socks    => { key/value },  # optional use of socks tunnel
 	}
 );
 


### PR DESCRIPTION
This simple PR let user of Slim:Networking::SimpleAsyncTTP or Slim::Networking::Async::HTTP add and extra {options} key in *new* method parameter's hash to set option for underlying socket. These options take precedence over what is set in S::N::A::HTTP->new_socket. For example, I need to disable CA certificate validation and that does not make sense to ask user to do that system-wide and I need to remove DH from cipher suite on some site, so it's easy to do 
```
$http = Slim::Networking::SimpleAsyncHTTP->new( $step2, $errorCb,  { options => {
				SSL_cipher_list => 'DEFAULT:!DH', 
				SSL_verify_mode => Net::SSLeay::VERIFY_NONE,	
		} } );
$http->get('www.google.com');
```
or
```
my $http = Slim::Networking::Async::HTTP->new( { options => {
			SSL_cipher_list => 'DEFAULT:!DH',
			SSL_verify_mode => Net::SSLeay::VERIFY_NONE,
		} } );
$http->send_request( {
		request => HTTP::Request->new( GET => 'www.google.com',
			onError	=> $errorCb,
			onBody => $bodyCb,
		} 
	);	
```