### PR TITLE
misconstructed test for MP4->AAC

### DIFF
--- a/Slim/Formats/Movie.pm
+++ b/Slim/Formats/Movie.pm
@@ -347,7 +347,7 @@ sub setADTSProcess {
 			$pos += ($atoms{$type} || $len) - 8;
 		}	
 	
-		last if $codec->{frame_size} || $codec->{entries} && $codec->{channel_config};
+		last if ($codec->{frame_size} || $codec->{entries}) && $codec->{channel_config};
 	}	
 	
 	# don't want to send a header when doing AAC demuxs


### PR DESCRIPTION
Missing parenthesis to ensure proper precedence. This should go on 8.0 as well