### PR TITLE
HTTP range request is LAST byte not SIZE !!!!!

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -732,7 +732,7 @@ sub requestString {
 		$first ||= $song->track->audio_offset if $song->stripHeader || defined $song->initialAudioBlock;
 		
 		if ($first) {
-			$request .= $CRLF . 'Range: bytes=' . ($first || 0) . '-' . ($song->track->audio_size || '');
+			$request .= $CRLF . 'Range: bytes=' . ($first || 0) . '-';
 
 			if (defined $seekdata->{timeOffset}) {
 				# Fix progress bar


### PR DESCRIPTION
That explain missings last seconds on mp4. 

I'm really sorry, I could have seen that any day since June, but it had to be today, one day after the release of 8.1

I'm a (very angry) muppet