### PR TITLE
add targeted $RESAMPLE$, not only the source $SAMPLERATE$

### DIFF
--- a/convert.conf
+++ b/convert.conf
@@ -73,10 +73,10 @@
 # %d - samplerate: samples/s
 # %D - samplerate: ksamples/s
 
-# %C, $CHANNELS$   - channel count
+# %C, $CHANNELS$   - source channel count
 # %c, $OCHANNELS$  - output channel count
-#   , $SAMPLESIZE$ - sample size (in bits)
-#   , $SAMPLESIZE$ - sample size (in bits)
+#     $SAMPLESIZE$ - source sample size (in bits)
+#     $SAMPLERATE$ - source sample rate (in Hz)
 # %i               - clientid
 # %I, $CLIENTID$   - clientid     ( : or . replaced by - )
 # %p               - player model

--- a/convert.conf
+++ b/convert.conf
@@ -363,7 +363,7 @@ mp3 mp3 transcode *
 
 flc flc transcode *
 	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}E:{NOSTART=I}
-	[flac] -dcs $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ -L - -t flac -C 0  -	
+	[flac] -dcs $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ -L - -t flac $RESAMPLE$ -C 0  -	
 
 # This example transcodes MP3s to MP3s, if the target machine has the
 # given MAC address. This rule will take precedence over the


### PR DESCRIPTION
When changing the flac transcoding rule to handle TIDAL re-encoding to compression level 0, I set the source sample rate but not the target