### PR TITLE
Deezer flac seeking for IP3K

### DIFF
--- a/Slim/Plugin/Deezer/ProtocolHandler.pm
+++ b/Slim/Plugin/Deezer/ProtocolHandler.pm
@@ -555,10 +555,11 @@ sub _gotTrack {
 			Host        => URI->new( $info->{url} )->host,
 			Timeout     => 3, # Default timeout of 10 is too long,
 		                  # by the time it fails player will underrun and stop
-		onDNS       => $params->{successCb},
-		onError     => $params->{successCb}, # even if it errors, keep going
-		passthrough => [],
-	} );
+			onDNS       => $params->{successCb},
+			onError     => $params->{successCb}, # even if it errors, keep going
+			passthrough => [],
+		} );
+	}	
 
 	# Watch for playlist commands
 	Slim::Control::Request::subscribe(
@@ -606,14 +607,6 @@ sub _playlistCallback {
 
 		Slim::Music::Info::setCurrentTitle( $song->track()->url, $title );
 	}
-}
-
-sub canDirectStreamSong {
-	my ( $class, $client, $song ) = @_;
-
-	# We need to check with the base class (HTTP) to see if we
-	# are synced or if the user has set mp3StreamingMethod
-	return $class->SUPER::canDirectStream( $client, $song->streamUrl(), $class->getFormatForURL($song->streamUrl()) );
 }
 
 # URL used for CLI trackinfo queries

--- a/Slim/Plugin/Deezer/ProtocolHandler.pm
+++ b/Slim/Plugin/Deezer/ProtocolHandler.pm
@@ -503,6 +503,7 @@ sub _gotTrack {
 
 	$info->{bitrate} = _getBitratePlaceholder($info->{url});
 	$info->{type}    = _getFormatPlaceholder($info->{url});
+	my ($trackId, $format) = _getStreamParams( $info->{url} );
 
 	# as we don't know the format for a flow/radio station, let's keep the format of the last played track to make assumptions later on...
 	$prefs->set('latestFormat', __PACKAGE__->getFormatForURL($info->{url}));
@@ -532,12 +533,27 @@ sub _gotTrack {
 	my $cache = Slim::Utils::Cache->new;
 	$cache->set( 'deezer_meta_' . $info->{id}, $meta, 86400 );
 
-	# Async resolve the hostname so gethostbyname in Player::Squeezebox::stream doesn't block
-	# When done, callback will continue on to playback
-	my $dns = Slim::Networking::Async->new;
-	$dns->open( {
-		Host        => URI->new( $info->{url} )->host,
-		Timeout     => 3, # Default timeout of 10 is too long,
+	# When doing flac, parse the header to be able to seek (IP3K)
+	if ($format =~ /fla?c/i) {
+		my $http = Slim::Networking::Async::HTTP->new;
+		$http->send_request( {
+			request     => HTTP::Request->new( GET => $info->{url} ),
+			onStream    => \&Slim::Utils::Scanner::Remote::parseFlacHeader,
+			onError     => sub {
+				my ($self, $error) = @_;
+				$log->warn( "could not find $format header $error" );
+				$params->{successCb}->();
+			},
+			passthrough => [ $song->track, { cb => $params->{successCb} }, $info->{url} ],
+		} );
+	} 
+	else {
+		# Async resolve the hostname so gethostbyname in Player::Squeezebox::stream doesn't block
+		# When done, callback will continue on to playback
+		my $dns = Slim::Networking::Async->new;
+		$dns->open( {
+			Host        => URI->new( $info->{url} )->host,
+			Timeout     => 3, # Default timeout of 10 is too long,
 		                  # by the time it fails player will underrun and stop
 		onDNS       => $params->{successCb},
 		onError     => $params->{successCb}, # even if it errors, keep going


### PR DESCRIPTION
I don't know if you are interested but now that Deezer allows flac & seeking, we have the same issue as of Tidal and others, which is that flac seeking of HTTP streams does not work on IP3K players due to lack of frame alignement. 

I'm not absolutely sure about the need of the DNS resolving, but is it correct to assume that because we'll do a header parsing in case we stream flac, then name will be solved "there" so it's not needed anymore.

It looks to me a 8.1.1 b/c it's not a new feature, but a fix. Still obviously your call