### PR TITLE
Add proxies for transcoding rules matcher

### DIFF
--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -86,8 +86,8 @@ sub loadConversionTables {
 			$line =~ s/^\s*//o;
 			$line =~ s/\s*$//o;
 
-			if ($line =~ /^proxy\s+(\S+)\s+(\S+)/i) {
-				push @{$proxies{$1}}, $2;
+			if ($line =~ /^proxy\s+(\S+)\s+(\S+)/i) {	
+				$proxies{$1} = $2;
 			}
 			elsif ($line =~ /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/) {
 
@@ -365,7 +365,7 @@ sub getConvertCommand2 {
 	}
 
 	if ($prefs->get('prioritizeNative')) {
-		my @types = $proxies{$type} ? @{$proxies{$type}} : ($type);
+		my @types = split /,/, ($proxies{$type} || $type);			
 		unshift @types, 'pcm' if grep /wav/, @types;	
 		foreach my $type (@types) {
 			my ($format) = grep /$type/, @supportedformats;

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -33,6 +33,7 @@ sub init {
 our %commandTable = ();
 our %capabilities = ();
 our %binaries = ();
+my %proxies = ();
 
 sub Conversions {
 	return \%commandTable;
@@ -85,7 +86,10 @@ sub loadConversionTables {
 			$line =~ s/^\s*//o;
 			$line =~ s/\s*$//o;
 
-			if ($line =~ /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/) {
+			if ($line =~ /^proxy\s+(\S+)\s+(\S+)/i) {
+				$proxies{$1} = $2;
+			}
+			elsif ($line =~ /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/) {
 
 				my $inputtype  = $1;
 				my $outputtype = $2;
@@ -361,10 +365,11 @@ sub getConvertCommand2 {
 	}
 
 	if ($prefs->get('prioritizeNative')) {
-		my @types = $type eq 'wav' ? ('pcm', $type) : ($type);
+		my $proxy = $proxies{$type} || $type;
+		my @types = $proxy eq 'wav' ? ('pcm', $proxy) : ($proxy);
 		foreach my $type (@types) {
 			my ($format) = grep /$type/, @supportedformats;
-			@supportedformats = ($format, grep { $_ !~ $type } @supportedformats) if $format;
+			@supportedformats = ($format, grep { $_ !~ $proxy } @supportedformats) if $format;
 		}	
 	}
 

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -87,7 +87,7 @@ sub loadConversionTables {
 			$line =~ s/\s*$//o;
 
 			if ($line =~ /^proxy\s+(\S+)\s+(\S+)/i) {
-				$proxies{$1} = $2;
+				push @{$proxies{$1}}, $2;
 			}
 			elsif ($line =~ /^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$/) {
 
@@ -365,11 +365,11 @@ sub getConvertCommand2 {
 	}
 
 	if ($prefs->get('prioritizeNative')) {
-		my $proxy = $proxies{$type} || $type;
-		my @types = $proxy eq 'wav' ? ('pcm', $proxy) : ($proxy);
+		my @types = $proxies{$type} ? @{$proxies{$type}} : ($type);
+		unshift @types, 'pcm' if grep /wav/, @types;	
 		foreach my $type (@types) {
 			my ($format) = grep /$type/, @supportedformats;
-			@supportedformats = ($format, grep { $_ !~ $proxy } @supportedformats) if $format;
+			@supportedformats = ($format, grep { $_ !~ $type } @supportedformats) if $format;
 		}	
 	}
 

--- a/convert.conf
+++ b/convert.conf
@@ -86,6 +86,14 @@
 # %q, $QUALITY$    - quality
 # %Q,              - quality ( fractal notation: if = '0' return '01' )
 #     ${FILENAME}$ - contents of {FILENAME} (may contain other $*$ substitutions )
+#
+# It's also possible to define "proxies" who tell rules matcher what format a helper
+# spits out. This is useful to use player's native format whenever possible. 
+# 	proxy <helper_format> <output_format>
+# For example if a plugin has created a new format named 'spt' whose helper's output
+# is always 'ogg', you would use
+# 	proxy spt ogg
+
 
 # specific combinations match before wildcards
 

--- a/convert.conf
+++ b/convert.conf
@@ -87,13 +87,14 @@
 # %Q,              - quality ( fractal notation: if = '0' return '01' )
 #     ${FILENAME}$ - contents of {FILENAME} (may contain other $*$ substitutions )
 #
-# It's also possible to define "proxies" who tell rules matcher what format a helper
-# spits out. This is useful to stick to player's native format whenever possible. Use
-# multiple lines if an helper can output different formats (increasing priority)
-# 	proxy <helper_format> <output_format>
+# It's also possible to define "proxies" who tell rules matcher what format(s) a 
+# helper spits out. This is useful to stick to player's native format whenever 
+# possible. Use comma-separated list for multiple output formats, from least 
+# favorite to most favorite
+# 	proxy <helper_format> <output_format>[,<output_format>]
 # For example if a plugin has created a new format named 'spt' whose helper's output
-# is always 'ogg', you would use
-# 	proxy spt ogg
+# is 'ogg' or 'pcm', and you want 'ogg' to be most desired, then add
+# 	proxy spt pcm,ogg
 
 # specific combinations match before wildcards
 

--- a/convert.conf
+++ b/convert.conf
@@ -88,12 +88,12 @@
 #     ${FILENAME}$ - contents of {FILENAME} (may contain other $*$ substitutions )
 #
 # It's also possible to define "proxies" who tell rules matcher what format a helper
-# spits out. This is useful to use player's native format whenever possible. 
+# spits out. This is useful to stick to player's native format whenever possible. Use
+# multiple lines if an helper can output different formats (increasing priority)
 # 	proxy <helper_format> <output_format>
 # For example if a plugin has created a new format named 'spt' whose helper's output
 # is always 'ogg', you would use
 # 	proxy spt ogg
-
 
 # specific combinations match before wildcards
 


### PR DESCRIPTION
As per https://forums.slimdevices.com/showthread.php?113358-transcoder-order&p=1001352&viewfull=1#post1001352, I thought that would be useful to maximize the opportunities of using native format, but it can be impossible when a PH is "hidding" the true format. This simple patch offers the possibility for a plugin (e.g.) to tell what format their helper truly outputs. 

In Spotty, you would need to add the following entry to custom-convert.conf
```
proxy spt ogg
```

~~If it can output multiple formats, depending on a command line flag, I left it simple that you can specify either one really preferred or nothing, in which case there will be no re-ordering of player's codecs. If you prefer, we can make multiple "proxies", I just felt it was un-necessary~~

NB: the format is ignored by existing parser, so AFAIK, there is no compatibility issue having an updated custom-convert.conf with previous LMS version