### PR TITLE
Update API logger for Deezer and TIDAL plugins to match plugin name

### DIFF
--- a/Slim/Plugin/Deezer/API.pm
+++ b/Slim/Plugin/Deezer/API.pm
@@ -14,7 +14,7 @@ use Slim::Utils::Log;
 
 use constant GET_ARTIST_URL => '/api/deezer/v1/opml/artist_by_name_or_id?id=%s&name=%s';
 
-my $log = logger('plugin.wimp');
+my $log = logger('plugin.deezer');
 
 
 sub getArtistMenu {

--- a/Slim/Plugin/WiMP/API.pm
+++ b/Slim/Plugin/WiMP/API.pm
@@ -14,7 +14,7 @@ use Slim::Utils::Log;
 
 use constant GET_ARTIST_URL => '/api/wimp/v1/opml/getArtist?id=%s&name=%s';
 
-my $log = logger('plugin.wimp');
+my $log = logger('plugin.tidal');
 
 
 sub getArtistMenu {


### PR DESCRIPTION
I noticed while bumping the `plugin.tidal` logging to DEBUG that I wasn't seeing any API logging to correspond to the logger category configured [here](https://github.com/Logitech/slimserver/blob/public/8.1/Slim/Plugin/WiMP/Plugin.pm#L17).  I don't use the Deezer plugin, but similarly I believe its API class should use the logger configured in [Slim/Plugin/Deezer/Plugin.pm](https://github.com/Logitech/slimserver/blob/public/8.1/Slim/Plugin/Deezer/Plugin.pm#L23).

Thank you for maintaining LMS!