### PR TITLE
Player Host header fix

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -698,8 +698,11 @@ sub requestString {
 	# Although the port can be part of the Host: header, some hosts (such
 	# as online.wsj.com don't like it, and will infinitely redirect.
 	# According to the spec, http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-	# The port is optional if it's 80, so follow that rule.
-	my $host = $port == 80 ? $server : "$server:$port";
+	# The port is optional if it's default to the service requested, so follow that rule.
+	my $host = $server;
+	if ( $port != ( 80 || 443 ) ) {
+		$host .= ":" . $port;
+	}
 
 	# Special case, for the fallback-alarm, disable Icy Metadata, or our own
 	# server will try and send it


### PR DESCRIPTION
The Player should only append the port to the Host header if it is not a default port for the requested service.

This is closer to how [Networking](https://github.com/Logitech/slimserver/blob/public/8.1/Slim/Networking/Async/HTTP.pm#L250) creates Host headers.

However, this only accounts for HTTP and HTTPS as default ports, while Networking supports more defaults, such as FTP, RTSP, MMS. So this is more of a hot fix, since to mirror how Networking builds request would require more refactoring here, or a longer/uglier if statement.

See [this thread](https://forums.slimdevices.com/showthread.php?113665-Podcast-private-feed-not-playing) for further detail.