### PR TITLE
Make random play more random

### DIFF
--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -687,6 +687,9 @@ sub stopAndClear {
 }
 
 sub fischer_yates_shuffle {
+
+	srand(time()); # make it really random
+
 	my ($listRef) = @_;
 
 	if ($#$listRef == -1 || $#$listRef == 0) {

--- a/Slim/Plugin/RandomPlay/Mixer.pm
+++ b/Slim/Plugin/RandomPlay/Mixer.pm
@@ -170,6 +170,8 @@ sub getRandomYear {
 		$years = [ Slim::Schema->rs('Track')->search(\%cond, \%attr)->get_column('me.year')->all ];
 	}
 
+	Slim::Player::Playlist::fischer_yates_shuffle($years); # SQLite's RAND function is not very random. This does a better job.
+
 	my $year = shift @$years;
 
 	$cache->set('rnd_years_' . $client->id, $years, 'never');


### PR DESCRIPTION
The original Fischer-Yates shuffle routine used a call to rand() without setting a seed, giving results that were noticeably not very random at all (selecting from a relatively small subset of the library). A call to srand(time()) at the beginning of the shuffle routine gives much better results (which we're listening to right now, definitely works). I also added a call to fischer_yates_shuffle in the code for getting a random set of years, since it also uses the database server's RAND function, which in the case SQLite has no way of setting the seed, and never does so internally (confirmed by inspection of the SQLite code).