### PR TITLE
call the right open() upon redirect

### DIFF
--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -10,6 +10,11 @@ my $log = logger('player.streaming.remote');
 my $prefs = preferences('server');
 
 sub new {
+	# make sure it's our open called, not system's one
+	return Slim::Player::Protocols::HTTPS::open(@_);
+}
+
+sub open {
 	my $class = shift;
 	my $args  = shift;
 	my $url   = $args->{'url'} || '';


### PR DESCRIPTION
**TLDR: on redirect, Slim::Player::RemoteStream::request() was calling the wrong parent's class open() for HTTPS protocol handler**

If we assume that the protocol handler is a plain HTTP or HTTPS (put aside for now an overloaded protocol handler)

Player::HTTPS::new() creates *and connects* the SSL socket directly with "$sock = $class->SUPER::new()" and then calls "$class->request()". Because it's multi-inheritance, the "$class->request()" is Player::HTTP::request() which then calls Player::RemoteStream::request()

but

**Player::HTTP::new()** simply does "$sock = $class->open()" which is a call to parent **Player::RemoteStream::open()**. **Player::RemoteStream::open()** creates the socket with "my $sock = $class->SUPER::new()" and then connects it explicitly with **$class->connect()** and then calls **$class->request()** which is **Player::HTTP::request()** which then calls **Player::RemoteStream::request()**

So if you look both chain of calls, it's the same at the end, with a pretty different logic. 

The shit hit the fan when redirection happens because the redirect is handled in **Player::RemoteStream::request()**. When a redirect happens, the current socket is closed and another call to **$class->open()** is made. On HTTP, that's fine because **$class->open()** is **Player::HTTP::open()** and as it does not exist the parent **Player::RemoteStream::open()** is used, as expected. 

Remember that **Player::RemoteStream::open ()** is creating a plain socket and connecting it with **$class->connect()**

Now, you might see it coming, when a redirect happens on HTTPS... **Player::RemoteStream::request()** makes the same thing and because **Player::HTTPS::open()** does not exist, we end up calling **Player::RemoteStream::open()** and thus we create a plain socket on which **$class::SUPER->connect()** is called. Even if that $class is Player::HTTPS, then connect() will be a SSL connect, but certainly does not do what **Player::HTTPS::new()** do

I don't fully understand why it has not bitten us before or maybe there are cases where the plain socket can be upgraded to SSL in the connect() by start_TLS, I'm not sure. 

So, the solution is to create a **Player::HTTPS::open()** method so that it is called when **Player::RemoteStream::request()** redirects and calls **$class->open()**. Then the **Player::HTTPS::new()** really does nothing than calling this open().

Now, I feel the structure between Player::RemoteStream, Player::HTTP and Player::HTTPS is wrong (un-balanced) and a lot of the Player::RemoteStream code should be moved to Player::HTTP but that's a much bigger endeavour and I'm afraid of side-effects


