### PR TITLE
handle all cases of redirect, even with direct streaming

### DIFF
--- a/Slim/Formats/RemoteStream.pm
+++ b/Slim/Formats/RemoteStream.pm
@@ -193,8 +193,8 @@ sub request {
 		# socket in a CLOSE_WAIT state and leaking.
 		$self->close();
 
-		# some 302 Location: omit the protocol
-		$redir = ($url =~ m|^(\w+://)|)[0] . $redir if $redir !~ m|^\w+://|;
+		# some 302 location omit the protocol, take it from original url
+		$redir = ($url =~ m|^(\w+://)|)[0] . ($redir =~ s|^//||r) if $redir !~ m|^\w+://|;
 		main::INFOLOG && $log->info("Redirect to: $redir");
 
 		return $class->open({

--- a/Slim/Formats/RemoteStream.pm
+++ b/Slim/Formats/RemoteStream.pm
@@ -194,7 +194,7 @@ sub request {
 		$self->close();
 
 		# some 302 location omit the protocol, take it from original url
-		$redir = ($url =~ m|^(\w+://)|)[0] . ($redir =~ s|^//||r) if $redir !~ m|^\w+://|;
+		$redir = Slim::Utils::Misc::cloneProtocol($redir, $url);
 		main::INFOLOG && $log->info("Redirect to: $redir");
 
 		return $class->open({

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -616,7 +616,7 @@ sub directHeaders {
 			}
 
 			if ($redir) {
-				
+
 				# some 302 location omit the protocol, take it from original url
 				$redir = ($url =~ m|^(\w+://)|)[0] . ($redir =~ s|^//||r) if $redir !~ m|^\w+://|;
 				main::INFOLOG && $directlog->info("Redirecting to: $redir" . (defined($controller->song->seekdata()) ? ' with seekdata' : ''));

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -616,6 +616,9 @@ sub directHeaders {
 			}
 
 			if ($redir) {
+				
+				# some 302 location omit the protocol, take it from original url
+				$redir = ($url =~ m|^(\w+://)|)[0] . ($redir =~ s|^//||r) if $redir !~ m|^\w+://|;
 
 				main::INFOLOG && $directlog->info("Redirecting to: $redir" . (defined($controller->song->seekdata()) ? ' with seekdata' : ''));
 				

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -618,7 +618,7 @@ sub directHeaders {
 			if ($redir) {
 
 				# some 302 location omit the protocol, take it from original url
-				$redir = ($url =~ m|^(\w+://)|)[0] . ($redir =~ s|^//||r) if $redir !~ m|^\w+://|;
+				$redir = Slim::Utils::Misc::cloneProtocol($redir, $url);
 				main::INFOLOG && $directlog->info("Redirecting to: $redir" . (defined($controller->song->seekdata()) ? ' with seekdata' : ''));
 				
 				# Store the old URL so we can update its bitrate/content-type/etc

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -619,7 +619,6 @@ sub directHeaders {
 				
 				# some 302 location omit the protocol, take it from original url
 				$redir = ($url =~ m|^(\w+://)|)[0] . ($redir =~ s|^//||r) if $redir !~ m|^\w+://|;
-
 				main::INFOLOG && $directlog->info("Redirecting to: $redir" . (defined($controller->song->seekdata()) ? ' with seekdata' : ''));
 				
 				# Store the old URL so we can update its bitrate/content-type/etc

--- a/Slim/Utils/Misc.pm
+++ b/Slim/Utils/Misc.pm
@@ -430,6 +430,23 @@ sub crackURL {
 	return ($host, $port, $path, $user, $pass);
 }
 
+=head2 cloneProtocol( $url, $model )
+
+borrow the protocol from $model if missing in $url
+
+=cut
+
+sub cloneProtocol {
+	my ($url, $model) = @_;
+
+	return $url if $url =~ m|^\w+://|;
+
+	$url =~ s|^//||;
+	$model =~ m|^(\w+://)|;
+
+	return $1 . $url;
+}
+
 =head2 fixPath( $file, $base)
 
 	fixPath takes relative file paths and puts the base path in the beginning


### PR DESCRIPTION
I forgot to handle the direct streaming case where the 302 is sent back by the player. I also realized that I can't assume that the "Location" header might be of form "//www.google.com" or simply "www.google.com", so I need to take care of both.

If you prefer the fully exploded version
```
if ($redir !~ m|^\w+://|) {
	$redir =~ s|^//||;
	$url =~ m|^(\w+://)|;
	$redir = $1 . $redir;
}
```
