### PR TITLE
Strip world-writable file permissions during plugin installation

### DIFF
--- a/Changelog8.html
+++ b/Changelog8.html
@@ -30,7 +30,7 @@
 
 	<li>Other:</li>
 	<ul>
-		<li></li>
+		<li><a href="https://github.com/Logitech/slimserver/issues/528">#528</a> - On Unix-like platforms, we now ensure that plugins are installed in such a way that none of their files are writable by users other than the user running LMS, even if theyʼre stored that way in the plugin ZIP file.</li>
 	</ul>
 	<br />
 </ul>

--- a/Slim/Utils/PluginDownloader.pm
+++ b/Slim/Utils/PluginDownloader.pm
@@ -113,6 +113,12 @@ sub extract {
 
 		} else {
 
+			# Strip world-writable file permissions:
+			foreach my $member ( $zip->members() ) {
+				my $attrs = $member->unixFileAttributes() & 0777;
+				$member->unixFileAttributes($attrs & ~0022) if $attrs & 0022
+			}
+
 			my $source;
 
 			# ignore additional directory information in zip


### PR DESCRIPTION
On Unix-like platforms, ensure that plugins are installed in such a way that none of their files are writable by users other than the user running LMS, even if theyʼre stored that way in the plugin ZIP file.

Fixes #528.