### PR TITLE
add option to combine channels

### DIFF
--- a/Changelog8.html
+++ b/Changelog8.html
@@ -6,6 +6,7 @@
 	<li>New Features:</li>
 	<ul>
 		<li>Try to group online artists with local artists by ignoring slightly different spelling (eg. "The Beatles" vs. "Beatles", "Amy Macdonald" vs. "Amy MacDonald").</li>
+		<li>Audio option to combine channels to build a mono signal (whether player is synchronized or not).</li>
 	</ul>
 	<br />
 

--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -418,6 +418,7 @@
 				'0' => 'OUTPUT_CHANNELS_NORMAL',
 				'1' => 'OUTPUT_CHANNELS_LEFT',
 				'2' => 'OUTPUT_CHANNELS_RIGHT',
+				'3' => 'OUTPUT_CHANNELS_COMBINED',
 			} %]
 				<option [% IF prefs.pref_outputChannels == option.key %]selected [% END %]value="[% option.key %]">[% option.value | string %]</option>
 			[%- END -%]

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -879,9 +879,9 @@ sub stream_s {
 	
 	# If the output channels pref is set, and the player is synced to at least 1 other active player
 	# we tell the player to only play the desired channel. If not actively synced, the player will play
-	# in stereo.
+	# in stereo, unless channels are combined
 	if ( my $outputChannels = $prefs->client($client)->get('outputChannels') ) {
-		if ( $client->isSynced(1) ) { # use active player count
+		if ( $outputChannels == 0x03 || $client->isSynced(1) ) { # use active player count or this is L+R
 			$flags |= ($outputChannels & 0x03) << 2;
 		}
 	}

--- a/strings.txt
+++ b/strings.txt
@@ -5693,10 +5693,10 @@ SETUP_OUTPUT_CHANNELS_DESC
 	CS	Tento přehrávač můžete nakonfigurovat, aby přehrával buď levý nebo pravý kanál. Tuto funkci můžete například využít k vytvoření stereo efektu ze 2 synchronizovaných rádií Squeezebox.
 	DA	Du kan konfigurere afspilleren til kun at spille i den venstre eller højre kanal. Dette kan bruges til at oprette et stereobillede fra to synkroniserede Squeezebox-radioer, f.eks.
 	DE	Sie können diesen Player so konfigurieren, dass er nur den linken oder rechten Kanal wiedergibt. Diese Option kann zum Beispiel verwendet werden, um ein Stereobild über zwei synchronisierte Squeezebox Radios zu erstellen.
-	EN	You can configure this player to play only the left or right channel. This can be used to create a stereo image from 2 synced Squeezebox Radios, for example.
+	EN	You can configure this player to play only the left or right channel. This can be used to create a stereo image from 2 synced Squeezebox Radios, for example. Both channels can also be combined to mono
 	ES	Puede configurar este reproductor para que sólo reproduzca el canal izquierdo o el derecho. Se puede usar, por ejemplo, para crear una imagen estéreo a partir de dos dispositivos Squeezebox Radio sincronizados.
 	FI	Voit määrittää soittimen toistamaan vain vasemmalla tai oikealla kanavalla. Näin voidaan luoda stereovaikutelma esimerkiksi kahdella synkronoidulla Squeezebox-radiolla.
-	FR	Vous pouvez configurer cette platine pour lire uniquement le canal droit ou gauche. Cette configuration vous permet par exemple de créer une image stéréo à partir de deux radios Squeezebox synchronisées.
+	FR	Vous pouvez configurer cette platine pour lire uniquement le canal droit ou gauche. Cette configuration vous permet par exemple de créer une image stéréo à partir de deux radios Squeezebox synchronisées. Les deux canaux peuvent aussi être combinés en mono
 	IT	È possibile configurare il lettore affinché riproduca solo il canale destro o sinistro. Ciò risulta utile ad esempio per creare un'immagine stereo da due Squeezebox Radio sincronizzate.
 	NL	Je kunt deze muziekspeler configureren zodat alleen via het linker- of rechterkanaal wordt afgespeeld. Zo kun je bijvoorbeeld 2 gesynchroniseerde Squeezebox Radio's in stereo-opstelling plaatsen.
 	NO	Du kan konfigurere spilleren slik at den kun spiller fra venstre eller høyre kanal. Slik kan du blant annet skape et stereobilde fra to synkroniserte Squeezebox Radio-spillere.
@@ -5750,8 +5750,8 @@ OUTPUT_CHANNELS_RIGHT
 	SV	Höger kanal
 	
 OUTPUT_CHANNELS_COMBINED
-	EN	Combined 
-	FR	Combinés
+	EN	Both Channels (Mono)
+	FR	Deux Canaux (Mono)
 
 SETUP_TRANSITIONTYPE
 	CS	Prolínání

--- a/strings.txt
+++ b/strings.txt
@@ -5748,6 +5748,10 @@ OUTPUT_CHANNELS_RIGHT
 	PL	Kanał prawy
 	RU	Правый канал
 	SV	Höger kanal
+	
+OUTPUT_CHANNELS_COMBINED
+	EN	Combined 
+	FR	Combinés
 
 SETUP_TRANSITIONTYPE
 	CS	Prolínání


### PR DESCRIPTION
Allow channels to be combined for mono playback, even when player is not synchronized. See https://github.com/ralph-irving/squeezelite/pull/131.

I've verified with a Boom and a Radio that it did not create issues and I've also updated squeezelite-esp32. 

I'm not sure this is a very important modification as nobody has been crying for it so far :-)