### PR TITLE
Transcoder conversion rules: Support resampling for Ogg/Flac streams

### DIFF
--- a/convert.conf
+++ b/convert.conf
@@ -181,7 +181,8 @@ ogf ogf * *
 	-
 
 ogf flc * *
-	[flac] --ogg -dcs -- $FILE$ | [flac] -cs --ignore-chunk-sizes --totally-silent --compression-level-0 -
+	# IFRD:{RESAMPLE=-r %d}
+	[flac] --ogg -dcs -- $FILE$ | [sox] -q --ignore-length -t wav - -t flac -C 0 $RESAMPLE$ -
 
 ogg ogg * *
 	-


### PR DESCRIPTION
This PR modifies the transcoder conversion rules for an ogg encapsulated flac stream (type `ogf`)  to allow resampling.

The issue has been discussed in #411.

At time of writing at least one 96 kHz sample rate stream is known:

Mother Earth Radio: http://icecast3.streamserver24.com/motherearth.pls

This stream requires downsampling to 48 kHz before it can be rendered on a Squeezebox Radio, which supports a maximum sample rate of 48 kHz.

