### PR TITLE
ensure playerstatus notifications sent for players when syncing

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -3478,6 +3478,9 @@ sub statusQuery_filter {
 	# Bug 10064: playlist notifications get sent to everyone in the sync-group
 	if ($request->isCommand([['playlist', 'newmetadata']]) && (my $client = $request->client)) {
 		return 0 if !grep($_->id eq $myclientid, $client->syncGroupActiveMembers());
+	} elsif ($request->isCommand([['sync']])) {
+		# Don't filter out notifications for sync commands. All players are notified
+		# of the change in sync state regardless of whether they are "on" or "off".
 	} else {
 		return 0 if $clientid ne $myclientid;
 	}


### PR DESCRIPTION
- when sync commands are executed playerstatus notifications are only sent for players that are active (on). This is controlled by the filtering of playlist commands that don't relate to active players.
- this changeset adds an explicit test for sync commands rather than "piggy-backing" on the playlist command. For sync commands playerstatus notifications are now sent to all players regardless of their on/off state. This allows clients to reliably update their states when sync commands are executed.