### PR TITLE
Improve cuesheet compilation functionality

### DIFF
--- a/Slim/Formats/Playlists/CUE.pm
+++ b/Slim/Formats/Playlists/CUE.pm
@@ -421,11 +421,6 @@ sub parse {
 		_mergeCommand('DISCNUMBER', 'DISC', $track, $track);
 	}
 
-	#
-	# WARNING: Compilation could be false if Album Artist is not defined,
-	# even if artist is not the same in all the tracks. See my note below.
-	#
-
 	main::DEBUGLOG && $log->is_debug && $log->debug('Before merging ' . Data::Dump::dump({
 		cuesheet	=> $cuesheet,
 		tracks		=> $tracks,
@@ -481,14 +476,7 @@ sub parse {
 			}
 		}
 	}
-	# WARNING:
-	# if the Album artist was not defined in cue sheet, Compilation could be
-	# false, even if all the tracks are from different artists and Abum artist
-	# was defined in Audio file.
-	#
-	# Lived untouched, sounds like an error to me, but different people
-	# use compilation with different meaning, so better stay as it was before.
-	#
+
 	my $lastpos = 0;
 	for my $key (sort {$b <=> $a} keys %$tracks) {
 

--- a/Slim/Formats/Playlists/CUE.pm
+++ b/Slim/Formats/Playlists/CUE.pm
@@ -285,14 +285,21 @@ sub parse {
 
 			} elsif ($remCommand eq 'COMPILATION') {
 
-				if ($remValue && $remValue =~ /1|YES|Y/i) {
+				my $compilation = undef;
 
+				if ($remValue =~ /^(?:1|yes|y|true)$/i) {
+					$compilation = '1'
+				} elsif ($remValue =~ /^(?:0|no|n|false)$/i) {
+					$compilation = '0';
+				}
+
+				if (defined $compilation) {
 					($cuesheet, $tracks) = _addCommand($cuesheet,
 													 $tracks,
 													 $inAlbum,
 													 $currtrack,
 													 $remCommand,
-													 '1');
+													 $compilation);
 				}
 
 			} else {

--- a/Slim/Formats/Playlists/CUE.pm
+++ b/Slim/Formats/Playlists/CUE.pm
@@ -407,15 +407,6 @@ sub parse {
 			$track->{'ARTIST'}      = $performer;
 			$track->{'TRACKARTIST'} = $performer;
 
-			# Automatically flag a compilation album
-			# since we are setting the artist.
-
-			if (defined($cuesheet->{'ALBUMARTIST'}) && $cuesheet->{'ALBUMARTIST'} ne $performer) {
-				$cuesheet->{'COMPILATION'} = '1';
-				# Deleted the condition on 'defined', it could be defined
-				# but equal NO, N, 0,... or what else.
-				# we want it to be = 1 in this case.
-			}
 		}
 
 		# Songwriter is the standard command for composer


### PR DESCRIPTION
Cuesheets, whether independent files or embedded in FLACs, have restrictive functionality for determining if a release is a compilation.

* Any release where the album artist does not match a track artist is set as a compilation
* Code comments about album artists and compilations do not reflect current functionality
* Releases cannot be explicitly tagged as not a compilation

I created a bash script to generate WAVs with cuesheets, FLACs with embedded cuesheets, and Ogg Vorbis files to test compilation statuses. I used Ogg Vorbis files as a baseline for compilation handling; I originally planned on using MP3s but TPE2's varied handling made me switch.

For both WAVs and FLACs, any album with a track artist that did not match the album artist would be tagged as a compilation and the artist would not be listed in the "Album Artist" menu. For Ogg Vorbis, the same albums were not tagged as a compilation and the album artist was listed in the "Album Artist" menu. Removing the custom cuesheet compilation code allowed `Slim::Schema->_createOrUpdateAlbum` to compute compilation status in line with Ogg Vorbis.

In determining the validity of code comments about cuesheet album artist and compilations, I generated albums in each file format without an album artist but with track artists. The track artists column is a single string up to nine characters long, where each artist is a single alphanumeric character and corresponds to a single track. For example, AABCC is a five track album with the first two tracks by artist A, the third track by artist B, and the last two tracks by artist C. 

Track Artists | Album Artist Status | Compilation Status
--- | --- | ---
AAA | A | no Compilations
AB | A and B with split results | No Compilations
AAB | A and B with split results | No Compilations
ABB | No album artist listed | In Compilations
ABA | No album artist listed | In Compilations
AAAB | A and B with split results | No Compilations
AABB | No album artist listed | In Compilations
ABBB | No album artist listed | In Compilations
AABA | No album artist listed | In Compilations
ABBA | No album artist listed | In Compilations
ABC | No album artist listed | In Compilations
AABC | No album artist listed | In Compilations
ABAC | No album artist listed | In Compilations
ABCA | No album artist listed | In Compilations
ABBC | No album artist listed | In Compilations
ABCB | No album artist listed | In Compilations
ABCC | No album artist listed | In Compilations

These compilation statuses were consistent against all three file formats.

Finally, the cuesheet would only recognize if a release had been explicitly tagged as a compilation. This has been extended to allow users the explicitly tag a release as not a compilation.