### PR TITLE
close remote track headers files handles

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -70,7 +70,7 @@ sub request {
 		my $formatClass = Slim::Formats->classForFormat($track->content_type);
 		my $seekdata = $song->seekdata || {};
 		open (my $fh, '<', $track->initial_block_fn) if $track->initial_block_fn;
-		binmode $fh;
+		binmode $fh if $fh;
 
 		if ($formatClass->can('findFrameBoundaries')) {
 			my $offset = $formatClass->findFrameBoundaries($fh, $seekdata->{sourceStreamOffset} || 0, $seekdata->{timeOffset} || 0);

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -69,16 +69,19 @@ sub request {
 	if (!defined $song->initialAudioBlock && Slim::Formats->loadTagFormatForType($track->content_type)) {
 		my $formatClass = Slim::Formats->classForFormat($track->content_type);
 		my $seekdata = $song->seekdata || {};
+		open (my $fh, '<', $track->initial_block_fn) if $track->initial_block_fn;
+		binmode $fh;
 
 		if ($formatClass->can('findFrameBoundaries')) {
-			my $offset = $formatClass->findFrameBoundaries($track->initial_block_fh, $seekdata->{sourceStreamOffset} || 0, $seekdata->{timeOffset} || 0);
+			my $offset = $formatClass->findFrameBoundaries($fh, $seekdata->{sourceStreamOffset} || 0, $seekdata->{timeOffset} || 0);
 			$seekdata->{sourceStreamOffset} = $offset if $offset;
 		}
 
 		if ($formatClass->can('getInitialAudioBlock')) {
-			$song->initialAudioBlock($formatClass->getInitialAudioBlock($track->initial_block_fh, $track, $seekdata->{timeOffset} || 0));
+			$song->initialAudioBlock($formatClass->getInitialAudioBlock($fh, $track, $seekdata->{timeOffset} || 0));
 		}
 
+		$fh->close if $fh;
 		main::DEBUGLOG && $log->debug("building new header");
 	}
 	else {

--- a/Slim/Schema/RemoteTrack.pm
+++ b/Slim/Schema/RemoteTrack.pm
@@ -42,7 +42,7 @@ my @allAttributes = (qw(
 	
 	title titlesort titlesearch album tracknum
 	timestamp filesize disc audio audio_size audio_offset year
-	initial_block_fh 
+	initial_block_fn 
 	cover vbr_scale samplerate samplesize channels block_alignment endian
 	bpm tagversion drm musicmagic_mixable
 	musicbrainz_id lossless lyrics replay_gain replay_peak extid
@@ -173,10 +173,7 @@ sub delete {}
 sub DESTROY {
 	my $self = shift;
 
-	if (my $fh = $self->initial_block_fh) {
-		$fh->close;
-		unlink $fh;
-	}
+	unlink $self->initial_block_fn if $self->initial_block_fn;
 	
 	$self->SUPER::DESTROY();
 }

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -842,7 +842,9 @@ sub parseMp4Header {
 	Slim::Music::Info::setDuration( $track, $duration );
 	
 	# use the audio block to stash the temp file handler
-	$track->initial_block_fh($info->{fh});
+	$track->initial_block_fn($info->{fh}->filename);
+	$info->{fh}->unlink_on_destroy(0);
+	$info->{fh}->close;	
 	$track->processors($track->content_type, $args->{initial_block_type} // Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
 	
 	if ( main::DEBUGLOG && $log->is_debug ) {
@@ -941,7 +943,10 @@ sub parseWavAifHeader {
 	}	
 	
 	# we have a dynamic header but can go direct when not seeking
-	$track->initial_block_fh($info->{fh});
+	$track->initial_block_fn($info->{fh}->filename);
+	$info->{fh}->unlink_on_destroy(0);
+	$info->{fh}->close;	
+	
 	$track->processors($type, Slim::Schema::RemoteTrack::INITIAL_BLOCK_ONSEEK);
 
 	# all done


### PR DESCRIPTION
To be further tested, but I think this solves the issue of opened file handles for remote streams headers.