### PR TITLE
set tmp directory under cache/ and clean it

### DIFF
--- a/Slim/Formats/AIFF.pm
+++ b/Slim/Formats/AIFF.pm
@@ -109,7 +109,7 @@ sub parseStream {
 	$args->{_scanbuf} .= $$dataref;
 	return -1 if length $args->{_scanbuf} < 32*1024;
 	
-	my $fh = File::Temp->new();
+	my $fh = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir);
 	$fh->write($args->{_scanbuf});
 	$fh->seek(0, 0);
 	

--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -946,7 +946,7 @@ sub parseStream {
 	$args->{_scanbuf} .= $$dataref;
 	return -1 if length $args->{_scanbuf} < 32*1024;
 
-	my $fh = File::Temp->new();
+	my $fh = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir);
 	$fh->write($args->{_scanbuf});
 	$fh->seek(0, 0);
 

--- a/Slim/Formats/Movie.pm
+++ b/Slim/Formats/Movie.pm
@@ -266,7 +266,7 @@ sub parseStream {
 	$args->{_scanbuf} = substr($args->{_scanbuf}, 0, $args->{_offset} + ($args->{_atom} eq 'moov' ? $args->{_need} : 0));
 	
 	# put at least 16 bytes after mdat or it confuses audio::scan (and header creation)
-	my $fh = File::Temp->new();
+	my $fh = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir);
 	$fh->write($args->{_scanbuf} . pack('N', $args->{_audio_size}) . 'mdat' . ' ' x 16);
 	$fh->seek(0, 0);
 

--- a/Slim/Formats/Wav.pm
+++ b/Slim/Formats/Wav.pm
@@ -101,7 +101,7 @@ sub parseStream {
 	$args->{_scanbuf} .= $$dataref;
 	return -1 if length $args->{_scanbuf} < 128;
 	
-	my $fh = File::Temp->new();
+	my $fh = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir);
 	$fh->write($args->{_scanbuf});
 	$fh->seek(0, 0);
 	

--- a/Slim/Utils/Misc.pm
+++ b/Slim/Utils/Misc.pm
@@ -34,6 +34,8 @@ our @EXPORT = qw(assert msg msgf errorMsg specified);
 
 use File::Basename qw(basename);
 use File::Spec::Functions qw(:ALL);
+use File::Path qw(mkpath rmtree);
+use File::Temp qw(tempdir);
 use File::Slurp;
 use FindBin qw($Bin);
 use POSIX qw(strftime);
@@ -75,6 +77,7 @@ elsif ($^O =~/darwin/i) {
 
 # Cache our user agent string.
 my $userAgentString;
+my $tempdir;
 
 my %pathToFileCache = ();
 my %fileToPathCache = ();
@@ -632,6 +635,43 @@ sub getLibraryName {
 	$hostname =~ s/\x{2019}/'/g;
 
 	return $hostname;
+}
+
+=head2 getTempDir()
+
+	Get LMS-private temp dir 
+
+=cut
+
+sub getTempDir {
+	return $tempdir;	
+}
+
+=head2 makeTempDir()
+
+	make and clean LMS-private temp dir 
+
+=cut
+
+sub makeTempDir {
+	$tempdir = catdir($prefs->get('cachedir'), 'tmp');
+	
+	if (-d $tempdir) {
+		rmtree($tempdir, { keep_root => 1 });
+		return;
+	}	
+	
+	mkpath($tempdir);
+		
+	if (!-d $tempdir) {
+		$tempdir =  tempdir( DIR => $prefs->get('cachedir'), CLEANUP => 1 );
+		$ospathslog->warn("can't make private temp dir, trying $tempdir");
+	}	
+	
+	if (!-d $tempdir) {
+		$tempdir =  tempdir( CLEANUP => 1 );
+		$ospathslog->warn("still can't make private temp dir, using $tempdir");
+	}	
 }
 
 =head2 getAudioDir()

--- a/Slim/Utils/Misc.pm
+++ b/Slim/Utils/Misc.pm
@@ -654,6 +654,7 @@ sub getTempDir {
 =cut
 
 sub makeTempDir {
+	return if $tempdir;
 	$tempdir = catdir($prefs->get('cachedir'), 'tmp');
 	
 	if (-d $tempdir) {
@@ -664,12 +665,12 @@ sub makeTempDir {
 	mkpath($tempdir);
 		
 	if (!-d $tempdir) {
-		$tempdir =  tempdir( DIR => $prefs->get('cachedir'), CLEANUP => 1 );
+		$tempdir = tempdir( DIR => $prefs->get('cachedir'), CLEANUP => 1 );
 		$ospathslog->warn("can't make private temp dir, trying $tempdir");
 	}	
 	
 	if (!-d $tempdir) {
-		$tempdir =  tempdir( CLEANUP => 1 );
+		$tempdir = tempdir( CLEANUP => 1 );
 		$ospathslog->warn("still can't make private temp dir, using $tempdir");
 	}	
 }

--- a/slimserver.pl
+++ b/slimserver.pl
@@ -943,6 +943,7 @@ sub initSettings {
 	}
 
 	Slim::Utils::Prefs::makeCacheDir();
+	Slim::Utils::Misc::makeTempDir();
 }
 
 sub daemonize {


### PR DESCRIPTION
Do not store cached headers in system's /tmp, instead use a local tmp that can be used by other LMS plugins using getTempDir()