### PR TITLE
flac & socks fixes

### DIFF
--- a/Slim/Networking/Async/Socket/HTTPSSocks.pm
+++ b/Slim/Networking/Async/Socket/HTTPSSocks.pm
@@ -13,7 +13,7 @@ sub new {
 	# change PeerAddr to proxy with no handshake (no deepcopy needed)
 	my %params = %args;
 	$params{PeerAddr} = $args{ProxyAddr};
-	$params{PeerPort} = $args{ProxyPort};
+	$params{PeerPort} = $args{ProxyPort} || 1080;
 	$params{SSL_StartHandshake} => 0;
 
 	# and connect parent's class to it
@@ -24,7 +24,6 @@ sub new {
 	$params{AuthType} = $args{Username} ? 'userpass' : 'none';
 	$params{ConnectAddr} = $args{PeerAddr} || $args{Host};
 	$params{ConnectPort} = $args{PeerPort};
-	$params{ProxyPort} = $args{ProxyPort} || 1080;
 	$params{Blocking} => 1;
 	
 	# and initiate negotiation (we'll become IO::Socket::Socks)	

--- a/Slim/Networking/Async/Socket/HTTPSocks.pm
+++ b/Slim/Networking/Async/Socket/HTTPSocks.pm
@@ -13,7 +13,7 @@ sub new {
 	# change PeerAddr to proxy (no deepcopy needed)
 	my %params = %args;
 	$params{PeerAddr} = $args{ProxyAddr};
-	$params{PeerPort} = $args{ProxyPort};
+	$params{PeerPort} = $args{ProxyPort} | 1080;
 	$params{Blocking} => 1;
 	
 	# and connect parent's class to it (better block)
@@ -24,7 +24,6 @@ sub new {
 	$params{AuthType} = $args{Username} ? 'userpass' : 'none';
 	$params{ConnectAddr} = $args{PeerAddr} || $args{Host};
 	$params{ConnectPort} = $args{PeerPort};
-	$params{ProxyPort} = $args{ProxyPort} || 1080;
 	
 	# and initiate negotiation (we'll become IO::Socket::Socks)	
 	$sock = IO::Socket::Socks->start_SOCKS($sock, %params) || return;


### PR DESCRIPTION
These are 2 fixes that I think belongs to 8.1.x and 8.2.x

1- a simple correction for socks that has "almost" practical impact but one parameter was uselessly set when start_SOCKS was called meanwhile the default 1080 port was not set. In reality, I'm the only one so far to use socks and I always set the port.

2- the flac song duration for streams would be set incorrectly when the header does not have the total number of samples, leading to an non-sense progress bar.