### PR TITLE
requestString should be from songHandler

### DIFF
--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -773,7 +773,7 @@ sub stream_s {
 
 		main::INFOLOG && logger('player.streaming.direct')->info("SqueezePlay direct stream: $url");
 
-		$request_string = $handler->requestString($client, $url, undef, $params->{'seekdata'});  
+		$request_string = $songHandler->requestString($client, $url, undef, $params->{'seekdata'});  
 		$autostart += 2; # will be 2 for direct streaming with no autostart, or 3 for direct with autostart
 
 	} elsif (my $proxy = $params->{'proxyStream'}) {
@@ -816,7 +816,7 @@ sub stream_s {
 		}
 		$server_port = $port;
 
-		$request_string = $handler->requestString($client, $url, undef, $params->{'seekdata'});  
+		$request_string = $songHandler->requestString($client, $url, undef, $params->{'seekdata'});  
 		$autostart += 2; # will be 2 for direct streaming with no autostart, or 3 for direct with autostart
 
 		if (!$server_port || !$server_ip) {


### PR DESCRIPTION
This one is just for debate at this point. While updating mixcloud plugin, I had an issue with directStream because the overloaded requestString method was not called. I realized that the requestString called is the protocol's handler one, not the song's protocol handler's and I think this is incorrect. 

They are often the same and/or descend from each other, but methods like requestString should be called associated with the song, not with the protocol as they are used to set the GET request for start the actual download.

For example, in direct streaming, LMS is supposed to tell the player "here is the exact query to do to GET the song". This is a song-context query, no a general protocol handler-context query, so even when no protocol handler object is created, the requestString should be the one of the plugin, not it's ancestor. 
 