### PR TITLE
Consistency of Player::Protocols inheritance

### DIFF
--- a/Slim/Formats/RemoteStream.pm
+++ b/Slim/Formats/RemoteStream.pm
@@ -38,7 +38,7 @@ sub isRemote {
 	return 1;
 }
 
-sub open {
+sub new {
 	my $class = shift;
 	my $args  = shift;
 
@@ -119,8 +119,12 @@ sub open {
 	
 	${*$sock}{'song'} = $args->{'song'};
 
-	return $sock->request($args);
+	return $sock->open($args);
 
+}
+
+sub open {
+	shift->request(@_);
 }
 
 sub request {
@@ -197,7 +201,7 @@ sub request {
 		$redir = Slim::Utils::Misc::cloneProtocol($redir, $url);
 		main::INFOLOG && $log->info("Redirect to: $redir");
 
-		return $class->open({
+		return $class->new({
 			'url'     => $redir,
 			'song'    => $args->{'song'},
 			'infoUrl' => $self->infoUrl,

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -42,7 +42,7 @@ sub new {
 		# return undef;
 	}
 
-	my $self = $class->open($args);
+	my $self = $class->SUPER::new($args);
 
 	if (defined($self)) {
 		${*$self}{'client'}  = $args->{'client'};

--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -10,11 +10,6 @@ my $log = logger('player.streaming.remote');
 my $prefs = preferences('server');
 
 sub new {
-	# make sure it's our open called, not system's one
-	return Slim::Player::Protocols::HTTPS::open(@_);
-}
-
-sub open {
 	my $class = shift;
 	my $args  = shift;
 	my $url   = $args->{'url'} || '';

--- a/Slim/Player/Protocols/MMS.pm
+++ b/Slim/Player/Protocols/MMS.pm
@@ -47,7 +47,7 @@ sub new {
 	my $url        = $args->{'url'};
 	my $client     = $args->{'client'};
 	
-	my $self = $class->open($args);
+	my $self = $class->SUPER::new($args);
 
 	if (defined($self)) {
 		${*$self}{'client'}  = $args->{'client'};


### PR DESCRIPTION
Well, this is a tricky one. @mherger, you might remember that you had an issue with BandCamp plugin where the open() of the plugin was not called upon HTTPS redirection.

The issue was that S::F::RemoteStream does not have a new() but only an open() and it calls the IO::Socket::INET::new first and then $class->request(). But, in S::P::P::RemoteStream::request(), if there is a redirection, it closes the current object and calls the $class->open(). Well, if the $class does not have an open, then this is bad as we then call S::F::RemoteStream::open. 

It does not matter for HTTP but in case of HTTPS that does not have an open(), the we ended up calling S::P::P::RemoteStream::open() and this is not a good idea as it creates a plain socket where still want a SSL!

So I fixed that here (https://github.com/Logitech/slimserver/pull/521). Unfortunately, this is still not correct as I cannot just, in HTTPS, change the new() with an open() because of what we did there (https://github.com/Logitech/slimserver/commit/28194569ac47c26aa4b114055cd87945a5d51b41#diff-2d0765413923fce5a260ef9beef17119f419cd77e4020ed25167990d6e51da38). The intent was to have S::P::P::HTTPS package handle HTTP url (which is a neat thing so that plugins can now simply always subclass HTTPS and don't bother)

The issue with these two changes together is that in S::P::P::HTTPS::open(), when we do a $class->SUPER::new(), because we have an HTTP url, it calls S::P::P::HTTP::new() which in return calls $class->open() which works **only** if $class is a HTTPS package, as we look for an open in S::P::P::HTTPS hierachy and we end up calling S::F::open(), which is fine.
Now if $class is any subclass of S::P::P::HTTPS, then the open() found in the hierarchy is S::P::P::HTTPS and we have a magnificent recursion that I experienced when I was trying to use my S:P::P::Buffered package to handle buffered HTTP and HTTPS url natively in LMS.

I think the initial sin is that S::F::RemoteStream should not create the object in its open() but should do that in its new(). Then, S::P::P::HTTPS does not need to have this contorted use of open and should as well do new() in new(). It sounds logical that the hierarchy of new() does the new job, instead of a method called by new()

I know all this is braincracking (at least it is for me) but I hope we can debate / review it :smile: 