### PR TITLE
When volume is < 0, oldGain should not wrap

### DIFF
--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -276,7 +276,7 @@ sub volume {
 
 	if (defined($newvolume)) {
 		# Old style volume:
-		my $oldGain = $volume_map[int($volume)];
+		my $oldGain = $volume > 0 ? $volume_map[int($volume)] : 0;
 
 		my $newGain;
 		# Negative volume = muting


### PR DESCRIPTION
Per title, some controller set a volume < 0 to indicate mute. But the volume function still uses an "oldGain" which then wraps and a result, muting set the volume to the reverse of what it was instead of actually muting. There is an optional ramp down, then volume goes back up