### PR TITLE
handle redirect with processors

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -81,13 +81,10 @@ sub request {
 
 		main::DEBUGLOG && $log->debug("building new header");
 	}
-	else {
-		$song->initialAudioBlock('');
-	}
 
-	# all set for opening the HTTP object
+	# all set for opening the HTTP object, but only handle the one non-redirected call
 	$self = $self->SUPER::request($args);
-	return unless $self;
+	return $self if !$self || exists ${*$self}{'initialAudioBlockRef'};
 
 	# setup audio pre-process if required
 	my $blockRef = \($song->initialAudioBlock);
@@ -97,8 +94,8 @@ sub request {
 	${*$self}{'initialAudioBlockRef'} = $blockRef;
 	${*$self}{'initialAudioBlockRemaining'} = length $$blockRef;
 
-	# dynamic headers need to be re-calculated every time
-	$song->initialAudioBlock(undef) if $processor->{'initial_block_type'};
+	# dynamic headers need to be re-calculated every time 
+	$song->initialAudioBlock($processor->{'initial_block_type'} ? undef : '');
 
 	main::DEBUGLOG && $log->debug("streaming $args->{url} with header of ", length $$blockRef, " from ",
 								  $song->seekdata ? $song->seekdata->{sourceStreamOffset} || 0 : $track->audio_offset,

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -78,6 +78,8 @@ sub request {
 		if ($formatClass->can('getInitialAudioBlock')) {
 			$song->initialAudioBlock($formatClass->getInitialAudioBlock($track->initial_block_fh, $track, $seekdata->{timeOffset} || 0));
 		}
+		
+		$song->initialAudioBlock('') unless defined $song->initialAudioBlock;
 
 		main::DEBUGLOG && $log->debug("building new header");
 	}
@@ -95,7 +97,7 @@ sub request {
 	${*$self}{'initialAudioBlockRemaining'} = length $$blockRef;
 
 	# dynamic headers need to be re-calculated every time 
-	$song->initialAudioBlock($processor->{'initial_block_type'} ? undef : '');
+	$song->initialAudioBlock(undef) if $processor->{'initial_block_type'};
 
 	main::DEBUGLOG && $log->debug("streaming $args->{url} with header of ", length $$blockRef, " from ",
 								  $song->seekdata ? $song->seekdata->{sourceStreamOffset} || 0 : $track->audio_offset,


### PR DESCRIPTION
There is an issue when using "processors" (e.g. mp4 => aac) and the HTTP requests redirect. The on-the-fly created header (initialAudioBlock) is overwritten by the recursive calls in S::P::P::HTTP.pm::request.

This is a 8.1 patch that does not need to be ported to 8.2 as this [PR](https://github.com/Logitech/slimserver/pull/591) includes it as well