### PR TITLE
Change name of /stream.mp3 player to 'AlexaPlayer' when &player=Alexa

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -829,7 +829,11 @@ sub processURL {
 						$agent = 'Winamp';
 					}
 
-					$client->name( $agent . ' ' . string('FROM') . ' ' . $address );
+					if ($address =~ m/alexa/i) {
+						$client->name( "Amazon Echo" );
+					} else {
+						$client->name( $agent . ' ' . string('FROM') . ' ' . $address );
+					}
 				}
 
 				# Bug 4795

--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -829,8 +829,8 @@ sub processURL {
 						$agent = 'Winamp';
 					}
 
-					if ($address =~ m/alexa/i) {
-						$client->name( "Amazon Echo" );
+					if ( $address =~ m/^alexa|^amazon|^echo/i ) {
+						$client->name( 'AlexaPlayer' );
 					} else {
 						$client->name( $agent . ' ' . string('FROM') . ' ' . $address );
 					}


### PR DESCRIPTION
The name of network client-player created via /stream.mp3 defaults to a string based on "_UserAgent from Player_". The MediaServer skill uses Axios as its http agent and defaults to &player=Alexa so the player name seen in the LMS GUI is always 'Axios from Alexa' which is a little odd because nobody understands what Axios is. This proposed change uses simply '**AlexaPlayer**' as the name seen in the GUI whenever the &player parameter matches Amazon, Alexa or Echo - it's unchanged for non-MediaServer usage.