### PR TITLE
Update Commands.pm to randomize certain ["playlist", "loadtracks"] actions

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -25,6 +25,7 @@ through Request.pm and the mechanisms it defines.
 
 use strict;
 
+use List::Util qw(shuffle);
 use Scalar::Util qw(blessed);
 use File::Spec::Functions qw(catfile);
 use File::Basename qw(basename);
@@ -1729,6 +1730,8 @@ sub playlistXtracksCommand {
 		@tracks = _playlistXtracksCommand_parseSearchTerms($client, $what, $cmd);
 	}
 
+	if ( $what =~ /track\.titlesearch|contributor\.namesearch|genre\.id/i ) { @tracks = shuffle ( @tracks ) };
+	
 	my $size;
 
 	# add or remove the found songs


### PR DESCRIPTION
The proposed simple change shuffles the @tracks array produced by calls to ["playlist", "loadtracks"] when any of track.titlesearch, contributor.namesearch, or genre.id are used as search criteria. 

When these criteria are used, there is by definition no inherent expectation of preservation of order (as there would be for e.g. an album). However, LMS currently always returns exactly the same @tracks array when  ["playlist", "loadtracks"] is used. This is indeed shuffled if the player in question has shuffle enabled, but if the player has it disabled (e.g. because the user never shuffles albums) then the result is always the same which, as mentioned in the forum, is boring.

List::Util qw(shuffle) is a core module so should not cause any dependency issues.

