### PR TITLE
there might be no port on uri, contrary to crackURL

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -98,7 +98,7 @@ sub response {
 		# re-set full uri if it is not absolute (e.g. not proxied)
 		if ($uri !~ /^https?/) {
 			my ($proto, $host, $port) = $args->{'url'} =~ m|(.+)://(?:[^\@]*\@)?([^:/]+):*(\d*)|;
-			$request_object->uri("$proto://$host:$port$uri");
+			$request_object->uri("$proto://$host" . ($port ? ":$port" : '') . $uri);
 		}	
 
 		my ($first) = $self->contentRange =~ /(\d+)-/;


### PR DESCRIPTION
Now, this is starting to be painful...

Previously, crackURL was always sending a port, but there might be none when doing direct parsing. Of course, I did not catch that in my tests because all my url's had a port, so it did not fail. 