### PR TITLE
boiler plate code for remote header parsing

### DIFF
--- a/Slim/Plugin/Deezer/ProtocolHandler.pm
+++ b/Slim/Plugin/Deezer/ProtocolHandler.pm
@@ -535,17 +535,13 @@ sub _gotTrack {
 
 	# When doing flac, parse the header to be able to seek (IP3K)
 	if ($format =~ /fla?c/i) {
-		my $http = Slim::Networking::Async::HTTP->new;
-		$http->send_request( {
-			request     => HTTP::Request->new( GET => $info->{url} ),
-			onStream    => \&Slim::Utils::Scanner::Remote::parseFlacHeader,
-			onError     => sub {
+		Slim::Utils::Scanner::Remote::parseRemoteHeader( 
+			$song->track, $info->{url}, $format, $params->{successCb}, 
+			sub {
 				my ($self, $error) = @_;
 				$log->warn( "could not find $format header $error" );
 				$params->{successCb}->();
-			},
-			passthrough => [ $song->track, { cb => $params->{successCb} }, $info->{url} ],
-		} );
+			} );
 	} 
 	else {
 		# Async resolve the hostname so gethostbyname in Player::Squeezebox::stream doesn't block

--- a/Slim/Plugin/WiMP/ProtocolHandler.pm
+++ b/Slim/Plugin/WiMP/ProtocolHandler.pm
@@ -270,7 +270,7 @@ sub _gotTrack {
 	$cache->set( 'wimp_meta_' . $info->{id}, $meta, 86400 );
 
 	Slim::Utils::Scanner::Remote::parseRemoteHeader( 
-		$song->track, $info->{url}, $format =~ s/flac/flc/r, 
+		$song->track, $info->{url}, $format, 
 		sub {
 			my $meta = $cache->get('wimp_meta_' . $info->{id});
 			$meta->{bitrate} = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $song->track->bitrate/1000);

--- a/Slim/Plugin/WiMP/ProtocolHandler.pm
+++ b/Slim/Plugin/WiMP/ProtocolHandler.pm
@@ -269,29 +269,19 @@ sub _gotTrack {
 	my $cache = Slim::Utils::Cache->new;
 	$cache->set( 'wimp_meta_' . $info->{id}, $meta, 86400 );
 
-	if ($format =~ /mp4|aac|fla?c/i) {
-		my $http = Slim::Networking::Async::HTTP->new;
-		$http->send_request( {
-			request     => HTTP::Request->new( GET => $info->{url} ),
-			onStream    => $format =~ /fla?c/i ?
-						   \&Slim::Utils::Scanner::Remote::parseFlacHeader :
-						   \&Slim::Utils::Scanner::Remote::parseMp4Header,
-			onError     => sub {
-				my ($self, $error) = @_;
-				$log->warn( "could not find $format header $error" );
-				$params->{successCb}->();
-			},
-			passthrough => [ $song->track, { cb => sub {
-			                                    my $meta = $cache->get('wimp_meta_' . $info->{id});
-			                                    $meta->{bitrate} = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $song->track->bitrate/1000);
-			                                    $cache->set( 'wimp_meta_' . $info->{id}, $meta, 86400 );
-			                                    $params->{successCb}->();
-			                               } },
-			                 $info->{url} ],
+	Slim::Utils::Scanner::Remote::parseRemoteHeader( 
+		$song->track, $info->{url}, $format =~ s/flac/flc/r, 
+		sub {
+			my $meta = $cache->get('wimp_meta_' . $info->{id});
+			$meta->{bitrate} = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $song->track->bitrate/1000);
+			$cache->set( 'wimp_meta_' . $info->{id}, $meta, 86400 );
+			$params->{successCb}->();
+		}, 
+		sub {
+			my ($self, $error) = @_;
+			$log->warn( "could not find $format header $error" );
+			$params->{successCb}->();
 		} );
-	} else {
-		$params->{successCb}->();
-	}
 }
 
 sub _gotTrackError {

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -90,7 +90,10 @@ sub parseRemoteHeader {
 
 	return $successCb->() unless $parser;
 
+	# first, tidy up things a bit
 	$url ||= $track->url;
+	$format =~ s/flac/flc/;
+
 	my $http = Slim::Networking::Async::HTTP->new;
 	my $method = $parser->{'readLimit'} ? 'onBody' : 'onStream';
 	push my @extra, $url if $parser->{'extra'} =~ /url/;

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -86,13 +86,13 @@ my %parsers = (
 
 sub parseRemoteHeader {
 	my ($track, $url, $format, $successCb, $errorCb) = @_;
-	my $parser = $parsers{$format};
-
-	return $successCb->() unless $parser;
-
+	
 	# first, tidy up things a bit
 	$url ||= $track->url;
 	$format =~ s/flac/flc/;
+	
+	my $parser = $parsers{$format};
+	return $successCb->() unless $parser;
 
 	my $http = Slim::Networking::Async::HTTP->new;
 	my $method = $parser->{'readLimit'} ? 'onBody' : 'onStream';
@@ -766,7 +766,7 @@ sub parseFlacHeader {
 	Slim::Formats->loadTagFormatForType('flc');
 	my $formatClass = Slim::Formats->classForFormat('flc');
 	my $info = $formatClass->parseStream($dataref, $args, $http->response->content_length);
-	
+
 	return 1 if ref $info ne 'HASH' && $info;
 
 	$track->content_type('flc');


### PR DESCRIPTION
This one is just a bit boiler plate code for header parsing to avoid that plugins always do the same thing and have to guess if parsers use "onStream" or "onBody" method. I've updated Tidal as an example. Nothing more