### PR TITLE
handle changing url redirection by not updating track's url

### DIFF
--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -42,7 +42,7 @@ my $_liveCount = 0;
 my @_playlistCloneAttributes = qw(
 	index
 	_track _currentTrack _currentTrackHandler
-	streamUrl originUrl
+	streamUrl
 	owner
 	_playlist _scanDone
 
@@ -126,7 +126,6 @@ sub new {
 		handler         => $handler,
 		_track          => $track,
 		streamUrl       => $url,	# May get updated later, either here or in handler
-		originUrl       => $url,	# Keep track of the non-redirected url
 	);
 
 	$self->seekdata($seekdata) if $seekdata;
@@ -281,7 +280,6 @@ sub getNextSong {
 
 						$track = $newTrack;
 						# need to replace streamUrl if we have been redirected/updated
-						$self->streamUrl($track->url);
 					}
 
 					# maybe we just found or scanned a playlist

--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -100,7 +100,10 @@ sub parse {
 				},
 			}];
 
-			$item->{type} = 'link';
+			$item->{type}       = 'link';
+			$item->{on_select} 	= 'play';
+			$item->{play}      	= $enclosure->{url};
+			$item->{playall}    = 1;
 		} 
 
 		if ( $item->{duration} && (!$duration || $duration !~ /:/) ) {

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -131,6 +131,8 @@ sub recentHandler {
 				title => $item->{title},
 				image => $item->{cover},
 				type => 'link',
+				on_select => 'play',
+				play => $item->{url},
 				items => [ {
 					title => cstring($client, 'PLUGIN_PODCAST_PLAY_FROM_POSITION_X', $position),
 					enclosure => {
@@ -176,7 +178,7 @@ sub songChangeCallback {
 	}
 
 	return unless $client->streamingSong;
-	my $url = $client->streamingSong->originUrl;
+	my $url = $client->streamingSong->track->url;
 
 	if ( defined $cache->get("podcast-$url") && $request->isCommand([['playlist'], ['newsong']]) ) {
 		if ( $client->pluginData('goto') ) {
@@ -211,12 +213,12 @@ sub _trackProgress {
 	my $key = 'podcast-' . $url;
 
 	Slim::Utils::Timers::killTimers( $client, \&_trackProgress );
-	return unless (($client->streamingSong && $client->streamingSong->originUrl eq $url) || 
-				   ($client->playingSong && $client->playingSong->originUrl eq $url)) && 
+	return unless (($client->streamingSong && $client->streamingSong->track->url eq $url) || 
+				   ($client->playingSong && $client->playingSong->track->url eq $url)) && 
 				    defined $cache->get($key);
 
 	# start recording position once we are actually playing
-	if ($client->isPlaying && $client->playingSong && $client->playingSong->originUrl eq $url) {	
+	if ($client->isPlaying && $client->playingSong && $client->playingSong->track->url eq $url) {	
 		$cache->set($key, Slim::Player::Source::songTime($client), '30days');
 		
 		# track objects aren't persistent across server restarts - keep our own list of podcast durations in the cache

--- a/Slim/Schema/RemoteTrack.pm
+++ b/Slim/Schema/RemoteTrack.pm
@@ -70,6 +70,7 @@ my @allAttributes = (qw(
 
 	__PACKAGE__->mk_accessor('rw', @allAttributes);
 	__PACKAGE__->mk_accessor('hash', '_processors');
+	__PACKAGE__->mk_accessor('array', '_redirs');
 }
 
 sub init {
@@ -251,6 +252,15 @@ sub coverArt {
 	} else {
 		return $body;
 	}
+}
+
+sub redirs {
+	my ($self, $arg) = @_;
+	my $redirs = $self->_redirs || [];
+	
+	return wantarray ? $redirs : @{$redirs} unless defined $arg;
+	return $self->_redirs($arg) if $arg =~ /^\d+$/; 
+	return $self->_redirs(scalar @{$redirs}, $arg);
 }
 
 # Although the URL is the primary key into the cache,


### PR DESCRIPTION
So, I've finally decided to try to submit something. I'm really not sure at this point, but the objective is to handle redirected url when the "final" url becomes unavailable after a short amount of time or after one access. That prevents pause/resume or could even totally block playback.

The reason is that in scanUrl, the track's url is adjusted to follow the redirection and the final location is given to the player when opening the socket's protocol handler (in the args->{'url'}). So when resuming, the $song is re-opened with that final url being used, which fails with some service (see https://forums.slimdevices.com/showthread.php?114634-Resuming-podcasts-stopped-working). Now, in the future, even just for playing, if that final url is a "single use", then first playback could fail as the scan would "consume" it.

Now, I'm having a real hard time figuring out exactly what's happening in LMS wrt the $track objects, their id and their caching by url logic. It seems that there are multiple "re-write" of the url/content-type relation (for example) and I'm not 100% sure why it is done, so that PR might have break more things than it fixes.

Now, one thing for sure is that when the streaming GET happens, we were parsing (in S::P::P::HTTP.pm) the headers and re-setting url/content-type relationship even in case of redirect and that I think is wrong. In a redirect, the headers can be anything and I think only Location: should be considered, we should not parse anything and just go to the relocation. That was making my initial modifications fail by associating some junk content-type to url.

I've also traced some of the code I've removed to https://github.com/Logitech/slimserver/commit/f12f907b21e4daab87a2c7a8b42c5b19d86f6df6#diff-d2ebe2fe55f011ce9221ed1fa9e6d10ae4265c495a8e6981a0926fbcb5e693b7 and I think the reason why it was introduced are not valid anymore but again, I'm *really* not sure. @mherger probably has a better idea of what the comment about "SN duplicates" means, but it seems that the code related to SN is now gone.

Finally, if keeping the original url in $track object is the right direction, there is probably more cleaning to be made in Slim::Utils::Scanner::Remote.pm

NB: There is another addition to get rid of one extra menu level in podcast "resume from last position", but that's non-related