### PR TITLE
HTTP get metadata propagates current wmaMeta to other HTTP tracks

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -813,7 +813,8 @@ sub getMetadataFor {
 
 	# Check for parsed WMA metadata, this is here because WMA may
 	# use HTTP protocol handler
-	if ( my $song = $client->playingSong() ) {
+	my $song = $client->playingSong();
+	if ( $song && $song->track->url eq $url ) {
 		if ( my $meta = $song->pluginData('wmaMeta') ) {
 			my $data = {};
 			if ( $meta->{artist} ) {


### PR DESCRIPTION
When I was doing some verification for the redirection management on 8.2, I think I found an issue in the getMetadataFor for HTTP. It happens when a playing track has some wmaMeta set in pluginData and another track is added which uses HTTP as a handler. 

Per code, the wmaMeta information is "propagated" to the other track because the getMetadataFor uses the playing song regardless of the $url for which metadata is requested. The result is that all added tracks receive the same icon/title. I think we need to test that the track's url of the playingSong is the url for which we want metadata...