### PR TITLE
HTTP to HTTPS redir & volatile

### DIFF
--- a/DEVELOPERS.txt
+++ b/DEVELOPERS.txt
@@ -54,16 +54,19 @@ and a few other parameters). The issue is that upon resume, the redirected locat
 and a 403 will happen. 
 
 When resuming, LMS sometimes creates a new() song, sometimes it just re-opens it with a song open(). 
-In both cases, the $url inside the track is the one that scanUrl has put after redirection. To 
-solve that, if Slim::Player::Song::open() fails and the track has been redirected, open() will 
-set streamUrl to $track->redir (the original url) and then will recuse. When using new() on resume,
-LMS does a getNextSong which is the method calling scanUrl. If it fails, getNextSong will recurse 
-with $track->redir. 
+In both cases, the $url inside the track is the one that scanUrl has put after redirection. 
+To solve that, if Slim::Player::Song::open() fails and the track has been redirected, open() will 
+set streamUrl to $track->redir (the original url) and then will recurse with direct streaming 
+disabled. It's not possible to allow direct streaming as if an HTTP -> HTTPS upgrade is requested
+during direct streaming redirection, playback will fall.
+When using new() on resume, LMS does a getNextSong which is the method calling scanUrl. If it fails, 
+getNextSong will recurse with $track->redir. 
 
 This is more tricky when direct stream is used because the error happens much later, when the 
 player returns the result of the HTTP request and it is thus not possible to recurse in open(). In 
 this case, as when redirection happens in direct streaming, we'll set the streamUrl to original url
-and give it another try. It's not foolproof, but it solves most cases.
+and give it another try. It's not foolproof, but it solves most cases. Typically, as said above, the
+upgraded HTTP -> HTTPS redirection cannot be handled
 
 Note that the original url is only set when Slim::Utils::Misc::Scanner::Remote::scanURL is called, 
 so this behavior does  not impact plugins that do not call their Slim::Player::HTTP::scanUrl 

--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -22,6 +22,9 @@ sub new {
 		return $class->SUPER::new($args);
 	}
 
+	# upon redirect, we might be upgraded to HTTPS from the previously downgraded object
+	unshift @ISA, 'IO::Socket::SSL' unless grep { $_ eq 'IO::Socket::SSL' } @ISA;
+	
 	my ($server, $port, $path) = Slim::Utils::Misc::crackURL($url);
 
 	if (!$server || !$port) {

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -458,7 +458,7 @@ sub open {
 	
 	# TODO work this out for each player in the sync-group
 	my $directUrl;
-	if ($transcoder->{'command'} eq '-' && ($directUrl = $client->canDirectStream($url, $self))) {
+	if ($transcoder->{'command'} eq '-' && ($directUrl = $client->canDirectStream($url, $self)) && (!$redir || $client->canHTTPS)) {
 		main::INFOLOG && $log->info( "URL supports direct streaming [$url->$directUrl]" );
 		$self->directstream(1);
 		$self->streamUrl($directUrl);
@@ -480,7 +480,8 @@ sub open {
 
 			if (!$sock) {
 				
-				# if we failed on a redirected track, retry once
+				# if we failed on a redirected track, retry once. Direct streaming will be disabled
+				# as redirection from HTTP to HTTPS does not work in direct mode
 				if ($track->can('redir') && $track->redir && !$redir) {
 					main::INFOLOG && $log->info("failed opening, retrying non-redirected url ", $track->redir);
 					$self->streamUrl($track->redir);


### PR DESCRIPTION
This is a tricky one... In general, when a HTTPS subclass was starting a HTTP connection that was then redirected to HTTPS, it was failing (general problem). 

In addition, for volatile URL when a attempt to re-open() a redirected track fails (gone), then the re-attempt using the original url may restart HTTP and then be upgraded. That cannot work in direct mode as players that are HTTP only and have accepted direct will not be re-directable to HTTPS. So when we re-open on volatile, we'll never use direct unless player supports HTTPS. It is still not perfect but other than dropping direct as a whole I don't have a solution