### PR TITLE
cleanup CLI socket

### DIFF
--- a/Slim/Networking/Slimproto.pm
+++ b/Slim/Networking/Slimproto.pm
@@ -251,6 +251,9 @@ sub slimproto_close {
 	Slim::Networking::Select::removeWrite($clientsock);
 	Slim::Networking::Select::removeWriteNoBlockQ($clientsock);
 
+	# close any associated cli_socket
+	Slim::Plugin::CLI::Plugin::client_socket_cleanup($clientsock->peerhost);
+
 	# close socket
 	$clientsock->close();
 

--- a/Slim/Plugin/CLI/Plugin.pm
+++ b/Slim/Plugin/CLI/Plugin.pm
@@ -306,6 +306,21 @@ sub client_socket_close {
 	}
 }
 
+sub client_socket_cleanup {
+	my $client_ip = shift;
+
+	# close all connections
+	foreach my $client_socket (keys %connections) {
+
+		# retrieve the socket object
+		$client_socket = $connections{$client_socket}{'socket'};
+		next unless $client_socket->peerhost() eq $client_ip;
+
+		# close the connection
+		client_socket_close($client_socket);
+	}
+}
+
 
 # data from connection
 sub client_socket_read {


### PR DESCRIPTION
Some squeezelite clients may open a cli connection. If they loose connection or crash, they will send a HELO message upon reconnection or a LMS timer will expire to close their connection. Upon either reconnection or timer expiry, the old player socket is closed but not its associated CLI socket (if any) leading to socket exhaustion after a while.