### PR TITLE
Add mp3 to remote header parser

### DIFF
--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -82,6 +82,7 @@ my %parsers = (
 	'wav' => { parser => \&parseWavAifHeader, extra => 'format' },    
 	'aif' => { parser => \&parseWavAifHeader, extra => 'format' },    
 	'mp4' => { parser => \&parseMp4Header, extra => 'url' },			
+	'mp3' => { parser => \&parseAudioStream, extra => 'url' },			
 );
 
 sub parseRemoteHeader {


### PR DESCRIPTION
mp3 was missing as an accepted format by parseRemoteHeader. I was not sure it parses well but it does