### PR TITLE
allow explodePlaylist to return an OPML object

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -1424,6 +1424,12 @@ sub playlistXitemCommand {
 	if ( $handler && $handler->can('explodePlaylist') ) {
 		$handler->explodePlaylist($client, $path, sub {
 			my $tracks = shift;
+			# transform opml list into url array if needed
+			if (ref $tracks eq 'HASH') {
+				$tracks = [ map { 
+					$_->{play} || $_->{url} 
+				} @{$tracks->{items}} ];
+			}	
 			$client->execute(['playlist', $cmd . 'tracks' , 'listRef', $tracks, $fadeIn]);
 			$request->setStatusDone();
 		});

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -93,6 +93,10 @@ sub getFeedAsync {
 		$handler->explodePlaylist($params->{client}, $url, sub {
 			my ($tracks) = @_;
 
+			# explode playlist might return a full opml list	
+			return $cb->($tracks, $params) if ref $tracks eq 'HASH';
+
+			# if not, this is just an array of url
 			return $cb->({
 				'type'  => 'opml',
 				'title' => '',


### PR DESCRIPTION
I'm not sure on this one: I was trying to improve a bit the YT plugin by allowing LMS' favorites to contain YT playlists and channels and let user browse through these rather than simply play all or nothing (today it's a "overridePlayback" method).

It seems that "explodePlaylist is what I want, but it only accepts an array of track's url instead of potentially a complete opml hash. If I add that option, I can have the YT plugin nicely add favorites, otherwise it looks crappy as when user clicks on the favorite link, he gets a list of "youtube://..." urls.

Now, I don't understand well, to say the least, this part of LMS and maybe this does not make sense