### PR TITLE
use keepalive on CLI

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -1424,12 +1424,6 @@ sub playlistXitemCommand {
 	if ( $handler && $handler->can('explodePlaylist') ) {
 		$handler->explodePlaylist($client, $path, sub {
 			my $tracks = shift;
-			# transform opml list into url array if needed
-			if (ref $tracks eq 'HASH') {
-				$tracks = [ map { 
-					$_->{play} || $_->{url} 
-				} @{$tracks->{items}} ];
-			}	
 			$client->execute(['playlist', $cmd . 'tracks' , 'listRef', $tracks, $fadeIn]);
 			$request->setStatusDone();
 		});

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -1424,6 +1424,12 @@ sub playlistXitemCommand {
 	if ( $handler && $handler->can('explodePlaylist') ) {
 		$handler->explodePlaylist($client, $path, sub {
 			my $tracks = shift;
+			# transform opml list into url array if needed
+			if (ref $tracks eq 'HASH') {
+				$tracks = [ map { 
+					$_->{play} || $_->{url} 
+				} @{$tracks->{items}} ];
+			}	
 			$client->execute(['playlist', $cmd . 'tracks' , 'listRef', $tracks, $fadeIn]);
 			$request->setStatusDone();
 		});

--- a/Slim/Networking/Slimproto.pm
+++ b/Slim/Networking/Slimproto.pm
@@ -251,9 +251,6 @@ sub slimproto_close {
 	Slim::Networking::Select::removeWrite($clientsock);
 	Slim::Networking::Select::removeWriteNoBlockQ($clientsock);
 
-	# close any associated cli_socket
-	Slim::Plugin::CLI::Plugin::client_socket_cleanup($clientsock->peerhost);
-
 	# close socket
 	$clientsock->close();
 


### PR DESCRIPTION
Instead of the more aggressive closing of all sockets when a peer disconnects, use TCP keepalive on cli sockets + a monitoring timer. The reason is that multiple instances of an application can share the same target IP address and we don't want to aggressively force close all CLI active socket just because a single instance failed