### PR TITLE
Allow mysb based playlists from Deezer to be played

### DIFF
--- a/Slim/Plugin/Deezer/ProtocolHandler.pm
+++ b/Slim/Plugin/Deezer/ProtocolHandler.pm
@@ -102,7 +102,10 @@ sub new {
 sub scanUrl {
 	my ( $class, $url, $args ) = @_;
 
-	$args->{cb}->( $args->{song}->currentTrack() );
+	# can't just take $args->{song}->currentTrack as it might be a playlist
+	$args->{cb}->( Slim::Schema->updateOrCreate( {
+		url => $url,
+	} ) );
 }
 
 # Source for AudioScrobbler
@@ -313,7 +316,8 @@ sub getNextTrack {
 	my ( $class, $song, $successCb, $errorCb ) = @_;
 
 	my $client = $song->master();
-	my $url    = $song->track()->url;
+	# must use currentTrack and not track to get the playlist item (if any)
+	my $url    = $song->currentTrack()->url;
 
 	$song->pluginData( radioTrackURL => undef );
 	$song->pluginData( radioTitle    => undef );

--- a/Slim/Plugin/Deezer/ProtocolHandler.pm
+++ b/Slim/Plugin/Deezer/ProtocolHandler.pm
@@ -103,7 +103,7 @@ sub scanUrl {
 	my ( $class, $url, $args ) = @_;
 
 	# can't just take $args->{song}->currentTrack as it might be a playlist
-	$args->{cb}->( Slim::Schema->updateOrCreate( {
+	$args->{cb}->( Slim::Schema->objectForUrl( {
 		url => $url,
 	} ) );
 }
@@ -650,9 +650,9 @@ sub getMetadataFor {
 	return {} unless $url;
 
 	my $icon = $class->getIcon();
+	my $song = $client->currentSongForUrl($url);
 
 	if ( $url =~ /\.dzr$/ ) {
-		my $song = $client->currentSongForUrl($url);
 		if (!$song || !($url = $song->pluginData('radioTrackURL'))) {
 			return {
 				title     => ($url && $url =~ /flow\.dzr/) ? $client->string('PLUGIN_DEEZER_FLOW') : $client->string('PLUGIN_DEEZER_SMART_RADIO'),
@@ -665,6 +665,9 @@ sub getMetadataFor {
 	}
 
 	my $cache = Slim::Utils::Cache->new;
+
+	# need to take the real current track url for playlists	
+	$url = $song->currentTrack->url if $song->isPlaylist;
 
 	# If metadata is not here, fetch it so the next poll will include the data
 	my ($trackId, $format) = _getStreamParams($url);

--- a/Slim/Plugin/Deezer/ProtocolHandler.pm
+++ b/Slim/Plugin/Deezer/ProtocolHandler.pm
@@ -667,7 +667,7 @@ sub getMetadataFor {
 	my $cache = Slim::Utils::Cache->new;
 
 	# need to take the real current track url for playlists	
-	$url = $song->currentTrack->url if $song->isPlaylist;
+	$url = $song->currentTrack->url if $song && $song->isPlaylist;
 
 	# If metadata is not here, fetch it so the next poll will include the data
 	my ($trackId, $format) = _getStreamParams($url);

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -1147,18 +1147,19 @@ sub parsePlaylist {
 		@results = eval { $formatClass->read( $fh, '', $playlist->url ) };
 	}
 	 elsif ( $type =~ /json/ ) {
-        warn 'json!';
         my $feed = eval { Slim::Formats::XML::parseXMLIntoFeed( $http->response->content_ref, $type ) };
         $@ && $log->error("Failed to parse playlist from OPML: $@");
 
         if ($feed && $feed->{items}) {
 			$args->{song}->_playlist(1);
 			@results = map {
-				# $_->{play} || $_->{url};
 				Slim::Schema->updateOrCreate( {
-					# title => $_->{name},
 					url => $_->{play} || $_->{url},
-					} );
+					attributes => {
+						TITLE => $_->{name},
+						COVER => $_->{image},
+					},
+				} );
 			} grep {
 				$_ ->{play} || $_->{url}
 			} @{$feed->{items}};

--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -1146,6 +1146,24 @@ sub parsePlaylist {
 		my $fh = IO::String->new( $http->response->content_ref );
 		@results = eval { $formatClass->read( $fh, '', $playlist->url ) };
 	}
+	 elsif ( $type =~ /json/ ) {
+        warn 'json!';
+        my $feed = eval { Slim::Formats::XML::parseXMLIntoFeed( $http->response->content_ref, $type ) };
+        $@ && $log->error("Failed to parse playlist from OPML: $@");
+
+        if ($feed && $feed->{items}) {
+			$args->{song}->_playlist(1);
+			@results = map {
+				# $_->{play} || $_->{url};
+				Slim::Schema->updateOrCreate( {
+					# title => $_->{name},
+					url => $_->{play} || $_->{url},
+					} );
+			} grep {
+				$_ ->{play} || $_->{url}
+			} @{$feed->{items}};
+		}
+	}
 
 	if ( !scalar @results || !defined $results[0]) {
 		main::DEBUGLOG && $log->is_debug && $log->debug( "Unable to parse playlist for content-type $type $@" );
@@ -1182,7 +1200,9 @@ sub parsePlaylist {
 			next;
 		}
 
-		__PACKAGE__->scanURL( $entry->url, {
+		# playlist might contain tracks with a different handler
+		my $handler = Slim::Player::ProtocolHandlers->handlerForURL($entry->url);
+		$handler->scanUrl( $entry->url, {
 			client => $client,
 			song   => $args->{song},
 			depth  => $args->{depth} + 1,


### PR DESCRIPTION
This is not a ready for use PR, but just a status of where I am wrt playlists as favorites for protocol handler like Deezer. 

First, I'm not sure this is not a complex solution for a simple problem => when I add the result of a Deezer menu item (say a search for album) as a favorite, the favorites.opml registers the http:// link with the search keys/values with a type "playlist". As far as I can see, it is all fine then, I can later browse that favorite and play it. When playing it, the player's tracklist is loaded with all the tracks. There is no need of "exploding" anything as LMS use getFeedAsync to obtain the sub-items of that favorite, because it's a feed type "playlist" and then LMS populates the tracklist with individual items.

Now, if the favorite is a type "audio" and not "playlist", it's a different story as here what LMS handles it not an opml feed, but a "source" playlist like in m3u (not sure I got my terminology right). That mean that it is *not* a browsable item and when played, a single item will be added to the tracklist. When going through tracks of that playlist, visually we'll stay on the single playlist entry, but we go through real tracks one by one. That's where LMS uses the difference between _track and _currentTrack (see my long comment in DEVELOPERS.txt) where _track is the playlist's entry that never changes and _currentTrack is the individual "real" track that is currently playing. 

So that PR deals with that type of playlist when they are Deezer entries. Is this really needed? I don't know as, per above, so far when I add a Deezer menu item a favorite, it comes with a "playlist" type, so it works as a browsable opml feed.