### PR TITLE
songHandler should be currentTrackHandler

### DIFF
--- a/DEVELOPERS.txt
+++ b/DEVELOPERS.txt
@@ -205,25 +205,27 @@ have been skipped). On further open(), the next sub-track is set in _currentTrac
 - currentTrack() is a method that returns the actual current track, i.e. _currentTrack || _track
 
 >>> Handlers in Slim::Player::Song and Slim::Player::SongStreamingController
-- $song->handler (RO) is set at the creation of the song. it depends on track->url at creation but can
-  be if the PH wants to pass-on to another PH (like thin PH do)
+- $song->handler (RO) is set at the creation of the song. it is based on track->url at creation and is 
+  immutable. 
 - $song->_currentTrackHandler (RW) is set when a single track happens to be a playlist, for each item.
-  It allows each individual sub-tracks to have their own PR when it relates to some of their management.
-  It means that it is empty most of the time.
+  It allows each individual sub-tracks to have their own PH when it relates to some of their management.
+  It means that it is empty most of the time but PH can update it when $track is changed after scanning
+  (for example when upgrding from HTTP to HTTPS)
 - $song->currentTrackHandler() is a method that returns (_currentTrackHandler || handler) so it tells 
   what shall be used for all url related to the current (sub) track
 - $songStreamingController->urlHandler is RO and set at the creation of the song streaming controller, 
   based on the streamUrl (in S::P::Song::open)
 - $songStreamingController->streamHandler is RO and set at creation of the song streaming controller. 
   It is the class of the *socket* object created by $song->handler->new.
-- $songStreamingController->songHandler is a method that returns the $song->handler, so the song main 
-  handler, not the sub-track
+- $songStreamingController->currentTrackHandler is a shortcut to $song->currentTrackhandler
 
 >>> Protocol Handlers
 These files contains a base class but whose methods are called in different contexts (the $self)
-1- a $song context means they are called with a $song->currentHandler or $song->handler
-2- a $sock context means they are called with a $socket (or the object) that was created by $song->handler->new
-3- a simple $url context means they are called by $song->currentHandler, $song->Handler or a $songStreamingController->streamHandler
+1- a $song context means they are called with a $song->currentTrackHandler or $song->handler
+2- a $sock context means they are called with a $socket (or the object) that was created by 
+   $song->handler->new
+3- a simple $url context means they are called by $song->currentTrackHandler, $song->Handler or a 
+   $songStreamingController->streamHandler
 
 So it's a bit confusing that methods from the same package can be object-oriented called with totally
 different type of ancestors/context. In fact, some methods can be called in both context is the 
@@ -231,7 +233,7 @@ ancestor of the PH is capable of (e.g. HTTP).
 
 - functions like sysread are only called with a $sock context
 - functions like getMetadataFor can be called with a $song or an $url context
-- functions like requestString cal be called in a $song or $sock context
+- functions like requestString can be called in a $song or $sock context
 
 >>> Example of requestString
 That function is to create the HTTP headers to be sent with the GET to grab the actual audio. It 

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -262,9 +262,9 @@ sub getFormatForURL {
 	return Slim::Music::Info::typeFromSuffix($url);
 }
 
-sub getSongHandler {
+sub currentTrackHandler {
 	my ($class, $self, $track) = @_;
-	
+
 	# re-evaluate as we might have been upgraded to HTTPS
 	return $class ne __PACKAGE__ ? $class : Slim::Player::ProtocolHandlers->handlerForURL($track->url);
 }

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -255,7 +255,7 @@ sub getNextSong {
 						if ($self->_track() == $track) {
 							# Update of original track, by playlist or redirection
 							$self->_track($newTrack);	
-							$self->init_accessor(handler => $handler->getSongHandler($self, $newTrack)) if $handler->can('getSongHandler');
+							$self->_currentTrackHandler($handler->currentTrackHandler($self, $newTrack)) if $handler->can('currentTrackHandler');
 														
 							main::INFOLOG && $log->info("Track updated by scan: $url -> " . $newTrack->url);
 

--- a/Slim/Player/SongStreamController.pm
+++ b/Slim/Player/SongStreamController.pm
@@ -63,8 +63,8 @@ sub close {
 	}
 }
 
-sub songHandler {
-	return shift->song->handler();
+sub currentTrackHandler {
+	return shift->song->currentTrackHandler();
 }
 
 sub isDirect {

--- a/Slim/Player/SongStreamController.pm
+++ b/Slim/Player/SongStreamController.pm
@@ -67,6 +67,11 @@ sub currentTrackHandler {
 	return shift->song->currentTrackHandler();
 }
 
+sub songHandler {
+	$log->warn('this method is deprecated, please use currentTrackHandler');
+	return shift->song->handler();
+}
+
 sub isDirect {
 	return shift->song->directstream() || 0;
 }


### PR DESCRIPTION
This completes the previous work on handlers and trying to clarify the roles of the handlers, between the song/track and the streamUrl.

Previously, the songHandler was prioritized over the streamUrl handler, but it was still missing once case where the $track is a playlist and in fact it's not that $song (master track) handler that should be used but the _currentTrack (sub-track) handler. This is the case where a remote/http playlist is an opml list that contains tracks served by protocol handlers (e.g. Deezer)

I think it also handles the HTTP => HTTPS upgrade in a more sensible way, a combination of what was made here https://github.com/Logitech/slimserver/commit/1120bab6954664dad8bcb39a1c2bafec6ae36dac and there https://github.com/Logitech/slimserver/commit/f59ac6e30c80204654c8a00d5eaf6c7529c292ab, not always replacing the _currentTrackHandler, only if the current PH agrees to, but in a consistent fashion with the usage of _currentTrackHandler in playlists, not a brute-force re-init of the (normally) immutable handler accessor.

This looks like a lot of changes but it's mainly renaming the handler's name to make it consistent/meaningful. 