### PR TITLE
Add $client to a few StreamingController methods

### DIFF
--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -679,7 +679,7 @@ sub stopAndClear {
 	my $client = shift;
 
 	# Bug 11447 - Have to stop player and clear song queue
-	$client->controller->stop();
+	$client->controller->stop($client);
 	$client->controller()->resetSongqueue();
 
 	@{playList($client)} = ();

--- a/Slim/Player/Source.pm
+++ b/Slim/Player/Source.pm
@@ -73,15 +73,15 @@ sub playmode {
 	return _returnPlayMode($controller, $client) unless defined $newmode;
 	
 	if ($newmode eq 'stop') {
-		$controller->stop();
+		$controller->stop($client);
 	} elsif ($newmode eq 'play') {
 		if (!$client->power()) {$client->power(1);}
-		$controller->play(undef, $seekdata, $reconnect, $fadeIn);
+		$controller->play(undef, $seekdata, $reconnect, $fadeIn, $client);
 	} elsif ($newmode eq 'pause') {
-		$controller->pause();
+		$controller->pause($client);
 	} elsif ($newmode eq 'resume') {
 		if (!$client->power()) {$client->power(1);}
-		$controller->resume($fadeIn);
+		$controller->resume($fadeIn, $client);
 	} else {
 		logBacktrace($client->id . " unknown playmode: $newmode");
 	}


### PR DESCRIPTION
Currently, the Group plugin overwrites Playlist::stopAndClear and Source::playMode just to add the $client (player) requestor of the play/stop/pause/resume. It might not hurt to natively add the $client as a parameter to LMS so that other StreamingController don't have to do the same unelegant overwrite. It's not a big deal though, so feel free to accept it or not. If you do, I'll simply won't load these files when the Group plugin uses LMS 8.2 and above