### PR TITLE
don't hijack active DynamicPlayList mixes

### DIFF
--- a/Slim/Plugin/DontStopTheMusic/Plugin.pm
+++ b/Slim/Plugin/DontStopTheMusic/Plugin.pm
@@ -180,10 +180,10 @@ sub onPlaylistChange {
 		( Slim::Utils::PluginManager->isEnabled('Slim::Plugin::RandomPlay::Plugin') && Slim::Plugin::RandomPlay::Plugin::active($client) )
 		|| ( Slim::Utils::PluginManager->isEnabled('Plugins::SugarCube::Plugin') && preferences('plugin.SugarCube')->client($client)->get('sugarcube_status') )
 		|| ( Slim::Utils::PluginManager->isEnabled('Plugins::DynamicPlayList::Plugin')
-			&& (((Slim::Utils::PluginManager->dataForPlugin('Plugins::DynamicPlayList::Plugin'))->{'version'}) ge '3.0.0')
+			&& Slim::Utils::Versions->checkVersion(Plugins::DynamicPlayList::Plugin->_pluginDataFor('version'), '3.0.0', 10) > 0
 			&& Plugins::DynamicPlayList::Plugin::active($client) )
 	) {
-		$log->warn("Found RandomPlay,SugarCube or DynamicPlayList active - I'm not going to interfere with them.");
+		$log->warn("Found RandomPlay, SugarCube or DynamicPlayList active - I'm not going to interfere with them.");
 		return;
 	}
 

--- a/Slim/Plugin/DontStopTheMusic/Plugin.pm
+++ b/Slim/Plugin/DontStopTheMusic/Plugin.pm
@@ -179,8 +179,11 @@ sub onPlaylistChange {
 	if (
 		( Slim::Utils::PluginManager->isEnabled('Slim::Plugin::RandomPlay::Plugin') && Slim::Plugin::RandomPlay::Plugin::active($client) )
 		|| ( Slim::Utils::PluginManager->isEnabled('Plugins::SugarCube::Plugin') && preferences('plugin.SugarCube')->client($client)->get('sugarcube_status') )
+		|| ( Slim::Utils::PluginManager->isEnabled('Plugins::DynamicPlayList::Plugin')
+			&& (((Slim::Utils::PluginManager->dataForPlugin('Plugins::DynamicPlayList::Plugin'))->{'version'}) ge '3.0.0')
+			&& Plugins::DynamicPlayList::Plugin::active($client) )
 	) {
-		$log->warn("Found RandomPlay or SugarCube active - I'm not going to interfere with them.");
+		$log->warn("Found RandomPlay,SugarCube or DynamicPlayList active - I'm not going to interfere with them.");
 		return;
 	}
 


### PR DESCRIPTION
suggestion for a fix so DSTM won't take over if there's an active DynamicPlayList mix
works with this mod of DynamicPlayList (>= v3.0.0): https://github.com/AF-1/lms-dynamicplaylist
version check should prevent errors with older DPL versions that don't include the necessary function