### PR TITLE
PodcastIndex cache fix

### DIFF
--- a/Slim/Plugin/Podcast/PodcastIndex.pm
+++ b/Slim/Plugin/Podcast/PodcastIndex.pm
@@ -116,7 +116,7 @@ sub newsHandler {
 			},
 			{
 				cache => 1,
-				expires => 600,
+				expires => 300,
 				timeout => 15,
 			},
 		)->get($url, @$headers);
@@ -127,7 +127,8 @@ sub getHeaders {
 	my $config = $prefs->get('podcastindex');
 	my $k = pack('H*', scalar(reverse(MIME::Base64::decode($config->{k}))));
 	my $s = pack('H*', scalar(reverse(MIME::Base64::decode($config->{s}))));
-	my $time = time;
+	# try to fit in a 5 minutes window for cache
+	my $time = int(time / 300) * 300;
 	my $headers = [
 		'X-Auth-Key', $k,
 		'X-Auth-Date', $time,


### PR DESCRIPTION
PodcastIndex requires Unix Epoch time as part of Auth and that caused the http backend cache to almost never be used as request is different every second. Particulary, "new episodes" seems to send a different request with different epoch (not sure why) but as a result, we would play a different episode than the selected one as LMS re-issues the request (re-descend the OPML tree) when "play" is pressed. Luckily, PodcastIndex as a 5 minutes window for epoch and this PR takes advantage of it. But the cache for podcast unfortunately might still need to be re-written