### PR TITLE
Fix duplicate 'player' URL parameters in settings links

### DIFF
--- a/HTML/EN/html/SqueezeJS/Base.js
+++ b/HTML/EN/html/SqueezeJS/Base.js
@@ -837,6 +837,9 @@ SqueezeJS.Utils = {
 		if (url.search(/player=/) && ! rExp.exec(url))
 			url = url.replace(/player=/ig, '');
 
+		// reset the regex so it starts matching at the beginning of the url
+		rExp.lastIndex = 0;
+
 		return (rExp.exec(url) ? url.replace(rExp, '=' + id) : url + '&player=' + id);
 	},
 


### PR DESCRIPTION
A second execution of the regex will start where the first execution
left off, causing it to not match URLs that already have a 'player'
parameter.