### PR TITLE
Propagate favorites_url regardless of whether the menu item is playable

### DIFF
--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -1119,8 +1119,7 @@ sub _cliQuery_done {
 						}
 						$hash{'text'} = $itemText;
 
-						if ($isPlayable) {
-							my $presetParams = _favoritesParams($item);
+						if ( my $presetParams = _favoritesParams($item) ) {							
 							if ($presetParams && !$xmlBrowseInterimCM) {
 								$hash{'presetParams'} = $presetParams;
 								$presetFavSet = 1;


### PR DESCRIPTION
Since 8.2.0 a favorites_url has been able to resolve to full opml through explodeplaylist on a protocolhandler.
Therefore a 'favorites_url' can represent any menu tree that a plugin wants it to.  Prior to 8.2 explodeplaylist could only return an array of playable urls.

However, currently Slim::Control::XMLBrowser will not present the 'favorites' information if a menu item supplied by a plugin is not playable (audio or playlist).  I don't believe this restriction is required anymore.  Changing, as per this pull request,  results in the 'favorites' info being presented if the item is playable OR has a 'favorites_url'

I've tested this change with Material skin and that controller behaves as expected, presenting the 'add to favorourites' option for non-playable menu items.

For your information,  this change brings the functionality in line with Slim::Web::XMLBrowser, which present a favorites_url in the web default skin regardless if the menu item is playable or not.