### PR TITLE
fix range for bogus mp4 streams

### DIFF
--- a/Slim/Utils/Scanner/Remote.pm
+++ b/Slim/Utils/Scanner/Remote.pm
@@ -888,8 +888,14 @@ sub parseMp4Header {
 		return 0;
 	}
 	
+	# some mp4 file have wrong mdat length
+	if ($info->{audio_offset} + $info->{audio_size} > $http->response->content_length) { 
+		$log->warn("inconsistent audio offset/size $info->{audio_offset}+$info->{audio_size}and content_length ", $http->response->content_length);
+		$track->audio_size($http->response->content_length - $info->{audio_offset});
+	} else {
+		$track->audio_size($info->{audio_size});		
+	} 	
 	$track->audio_offset($info->{audio_offset});
-	$track->audio_size($info->{audio_size});
 	$track->samplerate($samplerate);
 	$track->samplesize($samplesize);
 	$track->channels($channels);	


### PR DESCRIPTION
According to this discussion https://forums.slimdevices.com/showthread.php?115070-Global-Player-Remote-M4A-(containing-AAC)-streams-no-longer-working-in-LMS, some site might have bogus mp4 header or HTTP content-length which cause stream GET using a range request to fail. This PR forces audio_size to make sure audio_offset+size do not overshoot content_range