### PR TITLE
Debian update notification - Change installation hint message to prefer apt over dpkg 

### DIFF
--- a/HTML/EN/html/docs/linux-update.html
+++ b/HTML/EN/html/docs/linux-update.html
@@ -17,6 +17,11 @@ These currently are available for .rpm and .deb based systems.<p>
 
 <ul style="direction: ltr;">
 	<li>Log in to your server machine using your username and password.</li>
-	<li>Run the following command to execute the installer</li>
-	<li><code>sudo [% distro == 'rpm' ? 'rpm -Uvh' : 'dpkg -i' %] [% installerFile %]</code></li>
+	<li>Run the following command to execute the installer:</li>
+	<li><code>sudo [% distro == 'rpm' ? 'rpm -Uvh' : 'apt install' %] [% installerFile %]</code></li>
+	[% IF distro == 'deb' %]
+	<p>
+	<li>That command may fail on an old machine. Should it fail, run this command instead:</li>
+	<li><code>sudo dpkg -i [% installerFile %]</code></li>
+	[% END %]
 </ul>

--- a/HTML/EN/html/docs/linux-update.html.de
+++ b/HTML/EN/html/docs/linux-update.html.de
@@ -18,5 +18,10 @@ Dies ist derzeit auf RPM und Debian basierenden Systemen der Fall.<p>
 <ul style="direction: ltr;">
 	<li>Melde dich auf deinem Linux-Rechner an.</li>
 	<li>F&uuml;hre folgenden Befehl in einem Terminal aus:</li>
-	<li><code>sudo [% distro == 'rpm' ? 'rpm -Uvh' : 'dpkg -i' %] [% installerFile %]</code></li>
+	<li><code>sudo [% distro == 'rpm' ? 'rpm -Uvh' : 'apt install' %] [% installerFile %]</code></li>
+	[% IF distro == 'deb' %]
+	<p>
+	<li>Dieser Befehl kann auf einem alten Rechner fehlschlagen. Sollte es fehlschlagen, f&uuml;hre stattdessen diesen Befehl aus:</li>
+	<li><code>sudo dpkg -i [% installerFile %]</code></li>
+	[% END %]
 </ul>


### PR DESCRIPTION
Modern Debian based systems can now use the `apt` package manager in place of `dpkg` to install a stand alone debian package. This is better for the ordinary user, because LMS' package dependencies are automatically taken care of.

`apt` is a required package in the current Debian distributions, and can be expected to present on most users' systems.

`sudo apt install /path/to/LMS.deb` would be the appropriate command line.

This proposed change amends the software update help text by offering an `apt` based command line that the user can execute. The traditional `dpkg -i` command line is retained because, well, if it is removed then someone will be sure to need it.

The German text would benefit from a read over by a German speaker.

The proposal has been triggered by a recent comment in the forum - there has been a recent change in LMS' dependencies which seems to have caught someone out..
