### PR TITLE
Allow redirection to be disabled

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -186,7 +186,7 @@ sub use_proxy {
 sub send_request {
 	my ( $self, $args, $redirect ) = @_;
 
-	$self->maxRedirect( $args->{maxRedirect} || MAX_REDIR );
+	$self->maxRedirect( $args->{maxRedirect} // MAX_REDIR );
 	$self->response( undef ) unless $redirect;
 
 	if ( $args->{Timeout} ) {


### PR DESCRIPTION
It's a valid request to have no redirection at all but use of || operator disallows it