### PR TITLE
Use a closure for processors context

### DIFF
--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -974,7 +974,11 @@ sub parseStream {
 
 sub initiateFrameAlign {
 	my $context = { aligned => 0 };
-	return (\&frameAlign, $context);
+	
+	# use a closure to hold context
+	return sub {
+		return frameAlign($context, @_);
+	}
 }
 
 sub frameAlign {

--- a/Slim/Formats/Movie.pm
+++ b/Slim/Formats/Movie.pm
@@ -354,7 +354,11 @@ sub setADTSProcess {
 	
 	# don't want to send a header when doing AAC demuxs
 	$$bufref = '';
-	return (\&extractADTS, $codec);
+	
+	# use a closure to hold context
+	return sub {
+		return extractADTS($codec, @_);
+	}
 }	
 
 sub extractADTS {

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -172,7 +172,7 @@ sub request {
 
 	# setup audio pre-process if required
 	my $blockRef = \($song->initialAudioBlock);
-	(${*$self}{'audio_process'}, ${*$self}{'audio_stash'}) = $processor->{'init'}->($blockRef) if $processor->{'init'};
+	${*$self}{'audio_process'} = $processor->{'init'}->($blockRef) if $processor->{'init'};
 
 	# set initial block to be sent
 	${*$self}{'initialAudioBlockRef'} = $blockRef;
@@ -638,12 +638,12 @@ sub sysread {
 	my $readLength;
 
 	# do not read if we are building-up too much processed audio
-	if (${*$self}{'audio_buildup'} > $chunkSize) {
-		${*$self}{'audio_buildup'} = ${*$self}{'audio_process'}->(${*$self}{'audio_stash'}, $_[1], $chunkSize);
+	if (${*$self}{'audio_bytes'} > $chunkSize) {
+		${*$self}{'audio_bytes'} = ${*$self}{'audio_process'}->($_[1], $chunkSize);
 	}
 	else {
 		$readLength = readChunk($self, $_[1], $chunkSize, length($_[1] || ''));
-		${*$self}{'audio_buildup'} = ${*$self}{'audio_process'}->(${*$self}{'audio_stash'}, $_[1], $chunkSize) if ${*$self}{'audio_process'};
+		${*$self}{'audio_bytes'} = ${*$self}{'audio_process'}->($_[1], $chunkSize) if ${*$self}{'audio_process'};
 	}
 
 	# use $readLength from socket for meta interval adjustement


### PR DESCRIPTION
Thinking about our discussion on podcasts, I remembered that the "processors" architecture could probably be more elegant by using a closure instead of expecting the caller to hold context in a stash (if we need it).

So it's just cosmetic, let me know if you think it's better