### PR TITLE
Podcasts: Pre-caching image and more-info data can bring the server to a crawl

### DIFF
--- a/Slim/Plugin/Podcast/Parser.pm
+++ b/Slim/Plugin/Podcast/Parser.pm
@@ -11,6 +11,8 @@ use Slim::Utils::Cache;
 use Slim::Utils::DateTime;
 use Slim::Utils::Strings qw(cstring);
 
+use Slim::Plugin::Podcast::Plugin;
+
 my $cache = Slim::Utils::Cache->new;
 
 my $fetching;
@@ -23,6 +25,10 @@ sub parse {
 
 	# don't use eval() - caller is Slim::Formats::XML is doing so already
 	my $feed = Slim::Formats::XML::parseXMLIntoFeed( $http->contentRef, $http->headers()->content_type );
+
+	# refresh precached image & more info data - keeps them up to date
+	my $feedUrl = $http->params->{params}->{url};
+	Slim::Plugin::Podcast::Plugin::precacheFeedData($feedUrl, $feed);
 
 	foreach my $item ( @{$feed->{items}} ) {
 		if ($item->{type} && $item->{type} eq 'link') {

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -193,7 +193,7 @@ sub handleFeed {
 
 			Slim::Formats::XML->getFeedAsync(
 				sub {
-					_precacheShowDetails($url, $_[0]);
+					precacheFeedData($url, $_[0]);
 				},
 				sub {
 					$log->warn("can't get $url RSS feed information: ", $_[0]);
@@ -290,7 +290,7 @@ sub searchHandler {
 				$feed->{parser} ||= 'Slim::Plugin::Podcast::Parser';
 				push @$items, $feed;
 
-				_precacheShowDetails($feed->{url}, $feed);
+				precacheFeedData($feed->{url}, $feed);
 			}
 
 			push @$items, { name => cstring($client, 'EMPTY') } if !scalar @$items;
@@ -319,7 +319,7 @@ sub searchHandler {
 	)->get($url, @$headers);
 }
 
-sub _precacheShowDetails {
+sub precacheFeedData {
 	my ($url, $feed) = @_;
 
 	# keep image for around 90 days, randomizing cache period to

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -183,7 +183,14 @@ sub handleFeed {
 			playlist => $url,
 		};
 
+		# pre-cache feed data if absent
 		unless ($image && $cache->get('podcast_moreInfo_' . $url)) {
+			# first - cache a placeholder image & moreInfo to guard against retrieving
+			# the feed multiple times while browsing within the podcast menu
+			# they will be replaced with real data after feed is successfully retrieved
+			$cache->set('podcast-rss-' . $url, __PACKAGE__->_pluginDataFor('icon'), '1days');
+			$cache->set('podcast_moreInfo_' . $url, {}, '1days');
+
 			Slim::Formats::XML->getFeedAsync(
 				sub {
 					_precacheShowDetails($url, $_[0]);

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -202,7 +202,8 @@ sub handleFeed {
 		my $url = pop @need;
 		Slim::Formats::XML->getFeedAsync(
 			sub {
-				precacheFeedData($url, $_[0]);
+				# called by feed parser, so not needed here
+				# precacheFeedData($url, $_[0]);
 				$fetch->();
 			},
 			sub {
@@ -331,6 +332,11 @@ sub searchHandler {
 
 sub precacheFeedData {
 	my ($url, $feed) = @_;
+	# sanity check
+	unless (defined($url) && (ref($feed) eq 'HASH')) {
+		$log->error("Unexpected feed data for URL '$url'");
+		return;
+	}
 
 	# keep image for around 90 days, randomizing cache period to
 	# avoid flood of simultaneous requests in future

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -322,8 +322,12 @@ sub searchHandler {
 sub _precacheShowDetails {
 	my ($url, $feed) = @_;
 
+	# keep image for around 90 days, randomizing cache period to
+	# avoid flood of simultaneous requests in future
+	my $cacheTime = sprintf("%.3f days", 80 + rand(20));
+
 	if (my $image = $feed->{image}) {
-		$cache->set('podcast-rss-' . $url, $image, '90days');
+		$cache->set('podcast-rss-' . $url, $image, $cacheTime);
 	}
 	else {
 		# always cache image to avoid sending a flood of requests
@@ -339,7 +343,9 @@ sub _precacheShowDetails {
 		}
 	}
 
-	$cache->set('podcast_moreInfo_' . $url, \%moreInfo);
+	# keep moreInfo for around 90 days, same as image
+	# it will not change often
+	$cache->set('podcast_moreInfo_' . $url, \%moreInfo, $cacheTime);
 }
 
 sub registerProvider {


### PR DESCRIPTION
These proposed changes seek to address issues that have arisen with pre-caching Podcast feed images and data.

At present, there is a problem with the pre-caching process, because it potentially generates a large number of simultaneous feed requests which can overload a modestly powered server, especially where the user subscribes to a large number of feeds. It's not an obvious problem on, say, an iMac, but it has created problems on a Raspberry Pi, as reported here: [Slow loading of a list of podcast episodes](https://forums.slimdevices.com/showthread.php?114928-Logitech-Media-Server-8-2-0-released&p=1033229&viewfull=1#post1033229).

I have submitted the PR against LMS 8.2, on the premise that the issue is a bug in 8.2. But it can be applied equally well to 8.3.

The proposed changes are:

- **Podcast: Pre-caching - Guard against fetching same feed multiple times**
This change ensures that only one pre-caching attempt per day will be made for each feed. At present, a pre-caching attempt may be made on each occasion that the user browses within the podcast menu.

- **Podcast: Pre-caching - Randomize image & moreInfo caching period**
This change implements randomization of the cache period, to reduce the likelihood that future cache refreshes will happen all at once. It also sets the cache period for a podcast's 'moreInfo' data to the same period as the podcast image.  At present that data is only cached for the default period of one hour, which can become burdensome if the user has many feeds.

- **Podcast: Pre-caching - Refresh pre-cached data while browsing a feed**
This change implements an opportunistic refresh of the cache when the user browses into a podcast feed. It will help to keep the cache up to date.

- **Podcast: Pre-caching - Schedule activity over an extended period**
This change spreads out the pre-caching activity by launching each feed at 30 second intervals. Lower powered servers will benefit from this somewhat laid back approach. It does mean that a user with a large number of feeds will wait longer to see the podcast images properly populated, but perhaps that is not so very important.
**Update:** Commit now revised - refer below.
