### PR TITLE
Allow podcast providers to have a "country" capability

### DIFF
--- a/Slim/Plugin/Podcast/HTML/EN/plugins/Podcast/settings/basic.html
+++ b/Slim/Plugin/Podcast/HTML/EN/plugins/Podcast/settings/basic.html
@@ -82,4 +82,12 @@
 		[% END %]
 	[% END %]
 
+	[% IF hasCountry %]
+		[% WRAPPER settingSection %]
+			[% WRAPPER settingGroup title="PLUGIN_PODCAST_COUNTRY" desc="PLUGIN_PODCAST_COUNTRY_DESC" %]
+				<input type="text" class="stdedit" name="pref_country" id="pref_country" value="[% prefs.pref_country %]" size="2">
+			[% END %]
+		[% END %]
+	[% END %]
+
 [% PROCESS settings/footer.html %]

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -68,6 +68,7 @@ sub initPlugin {
 		provider => Slim::Plugin::Podcast::PodcastIndex->getName(),
 		newSince => 7,
 		maxNew => 7,
+		country => '',
 	});
 
 	if (main::WEBUI) {

--- a/Slim/Plugin/Podcast/Provider.pm
+++ b/Slim/Plugin/Podcast/Provider.pm
@@ -8,8 +8,8 @@ package Slim::Plugin::Podcast::Provider;
 
 use strict;
 
-sub new { shift };
-
+sub new { shift }
+sub hasCountry { }
 sub getMenuItems { [ { } ] }
 
 

--- a/Slim/Plugin/Podcast/Settings.pm
+++ b/Slim/Plugin/Podcast/Settings.pm
@@ -15,7 +15,7 @@ use Slim::Utils::Strings qw(string);
 
 my $log   = logger('plugin.podcast');
 my $prefs = preferences('plugin.podcast');
-my @hidden = qw(maxNew newSince );
+my @hidden = qw(maxNew newSince country);
 
 sub name {
 	return Slim::Web::HTTP::CSRF->protectName('PLUGIN_PODCAST');
@@ -48,6 +48,7 @@ sub handler {
 sub beforeRender {
 	my ($class, $params, $client) = @_;
 	$params->{newsHandler} = defined Slim::Plugin::Podcast::Plugin::getProviderByName->can('newsHandler');
+	$params->{hasCountry} = Slim::Plugin::Podcast::Plugin::getProviderByName->hasCountry;
 }
 
 sub saveSettings {
@@ -85,7 +86,7 @@ sub saveSettings {
 		
 		# don't erase hidden parameters if they are not set
 		foreach (@hidden) {
-			$params->{"pref_$_"} ||= $prefs->get($_);
+			$params->{"pref_$_"} //= $prefs->get($_);
 		}	
 		
 		$prefs->set( feeds => $feeds );

--- a/Slim/Plugin/Podcast/strings.txt
+++ b/Slim/Plugin/Podcast/strings.txt
@@ -301,6 +301,16 @@ PLUGIN_PODCAST_MAXNEW
 	EN	Number of new episodes per feed
 	FR	Nombre de nouveaux épisodes par flux
 
+PLUGIN_PODCAST_COUNTRY_DESC
+	DE	Suche auf ein Land beschränken (optional)
+	EN	Limit search to a country (optional)
+	FR	Limite la recherche à un pays (optionnel)
+
+PLUGIN_PODCAST_COUNTRY
+	DE	Land
+	EN	Country
+	FR	Pays	
+
 PLUGIN_PODCAST_SUBSCRIBE
 	DE	Podcast '%s' abonnieren
 	EN	Subscribe to '%s'


### PR DESCRIPTION
Instead of having each provider has its own UI settings for country, let it declare a "country" capability so that LMS can offer the option in the podcast generic settings