### PR TITLE
Podcasts: Pre-caching image data  - do not continually try again when there is no image to be had

### DIFF
--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -341,15 +341,11 @@ sub precacheFeedData {
 
 	# keep image for around 90 days, randomizing cache period to
 	# avoid flood of simultaneous requests in future
+	# it is not mandatory that a podcast include an image, so set
+	# suitable default
+	my $image = $feed->{image} || __PACKAGE__->_pluginDataFor('icon');
 	my $cacheTime = sprintf("%.3f days", 80 + rand(20));
-
-	if (my $image = $feed->{image}) {
-		$cache->set('podcast-rss-' . $url, $image, $cacheTime);
-	}
-	else {
-		# always cache image to avoid sending a flood of requests
-		$cache->set('podcast-rss-' . $url, __PACKAGE__->_pluginDataFor('icon'), '1days');
-	}
+	$cache->set('podcast-rss-' . $url, $image, $cacheTime);
 
 	# pre-cache some additional information to be shown in feed info menu
 	my %moreInfo;


### PR DESCRIPTION
This proposal is a follow up to https://github.com/Logitech/slimserver/pull/668.

Some podcasts do not provide image data in their feeds. This is quite acceptable.

In this case we provide a default image, but only for 24 hours. Thereafter we just fetch the feed again, and re-try. That is unnecessary. If there's no image, well, there's just no image. There is no point in continually trying again.

This proposed change has us adopt the same circa 90 day policy to the default image that is applied to "real" images.
