### PR TITLE
Slim::Formats:XML - Correct/tidy up image extraction from podcast feeds

### DIFF
--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -409,7 +409,17 @@ sub parseRSS {
 	# E.g. If a broken podcast provides an empty 'url' tag, 'XMLin' would interpret it
 	# as an empty hash ref. So we explicitly guard against such occurrences.
 
-	if ( ref $xml->{'channel'}->{'image'} ) {
+	# Prefer an 'itunes:image' if it exists, because some publishers seem to mess up
+	# the standard RSS image.
+	if ( ref $xml->{'itunes:image'} eq 'HASH' ) {
+		my $href = $xml->{'itunes:image'}->{'href'};
+		$feed{'image'} = $href unless ref $href;
+	}
+	elsif ( ref $xml->{'channel'}->{'itunes:image'} eq 'HASH' ) {
+		my $href = $xml->{'channel'}->{'itunes:image'}->{'href'};
+		$feed{'image'} = $href unless ref $href;
+	}
+	elsif ( ref $xml->{'channel'}->{'image'} ) {
 
 		my $image = $xml->{'channel'}->{'image'};
 		my $url = "";
@@ -429,14 +439,6 @@ sub parseRSS {
 		}
 
 		$feed{'image'} = trim($url) unless ref $url; # scalar value only !
-	}
-	elsif ( ref $xml->{'itunes:image'} eq 'HASH' ) {
-		my $href = $xml->{'itunes:image'}->{'href'};
-		$feed{'image'} = $href unless ref $href;
-	}
-	elsif ( ref $xml->{'channel'}->{'itunes:image'} eq 'HASH' ) {
-		my $href = $xml->{'channel'}->{'itunes:image'}->{'href'};
-		$feed{'image'} = $href unless ref $href;
 	}
 
 	if (my $language = $xml->{'channel'}->{'language'}) {

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -549,8 +549,9 @@ sub parseAtom {
 	);
 
 	# look for an image
-	if ( $xml->{'logo'} ) {
-		$feed{'image'} = $xml->{'logo'};
+	# but ensure it's a *scalar* value, anything else will break Jive browsing
+	if ( $xml->{'logo'} && ! ref $xml->{'logo'} ) {
+		$feed{'image'} = trim($xml->{'logo'});
 	}
 
 	my $count = 1;

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -428,7 +428,7 @@ sub parseRSS {
 			$url = $image->{'link'};
 		}
 
-		$feed{'image'} = $url unless ref $url; # scalar value only !
+		$feed{'image'} = trim($url) unless ref $url; # scalar value only !
 	}
 	elsif ( ref $xml->{'itunes:image'} eq 'HASH' ) {
 		my $href = $xml->{'itunes:image'}->{'href'};


### PR DESCRIPTION
These proposed changes correct and tidy up some aspects of RSS feed parsing in connection with the extraction of a podcast feed's image property. They have been identified during testing of https://github.com/Logitech/slimserver/pull/668.

- **Slim::Formats:XML - RSS - Trim whitespace from Podcast image URL**

A URL provided within an RSS image url element may contain leading and trailing white space as well as the text of the URL itself. LMS should trim any such white space from an extracted URL element to make the URL useable. At present LMS fails to this and, therefore, fails to retrieve an image. The RSS parser adopts the same approach when retrieving an audio URL from the feed. 

Most publishers do not incorporate such white space into their feed, but some do. Example at time of writing:
Radio Prague International:  https://english.radio.cz/rcz-rss/en.

- **Slim::Formats:XML - Atom parsing - Some checks on Podcast image URL**

Trim white space from URL (as above). Check that the image element (`logo`) is a scalar, as it should be, otherwise Jive browsing breaks. This replicates the check already carried out on an RSS feed.

Atom podcast feeds seem to be rare, and I have not encountered the problem in practice. But I see no reason for not carrying out the same precautionary checks.
 
- **Slim::Formats:XML - RSS - Prefer iTunes podcast image if available**

Some podcast publishers seem unable to construct a podcast RSS feed's channel image element properly, or adopt novel and non-standard practices. The RSS parser already checks for an array of image URLs, and an image URL in a `link` element, both practices being thoroughly out of specification.

I have encountered a third novelty: the URL is included as an `href` attribute to the URL element.
Example:   Czech Radio  http://www2.rozhlas.cz/podcast/plus.rss

Rather than add another special case, it has occurred to me that we might improve matters by preferring to use an `itunes:image` element if it is found. The RSS parser already recognizes this Apple mandated element, but only if the standard RSS image element is not found. As many podcast publishers now publish their podcasts through Apple, we are less likely to encounter novelties if we choose to use this is as the primary image source.

- **Slim::Formats:XML - RSS - Remove non-existent iTunes image tag**

At present the RSS parser looks for the `itunes:image` element both at the top level of the feed, and nested under the `channel` level of the feed.

Apple's documentation is perfectly clear that this element is nested under the parent `channel` element. This is specified in Apple's Podcasters guide to RSS: https://help.apple.com/itc/podcasts_connect/#/itcb54353390.

So I propose removing this extraneous look, as it very unlikely to find anything.

**Update:** This proposed commit now withdrawn.