### PR TITLE
Fix up character encoding issues in Web UI Scanner progress reporting and Web UI log display

### DIFF
--- a/Slim/Schema/Progress.pm
+++ b/Slim/Schema/Progress.pm
@@ -13,7 +13,7 @@ use base 'Slim::Schema::DBI';
 	$class->set_primary_key('id');
 
 	if ($] > 5.007) {
-		$class->utf8_columns(qw/info/);
+		$class->utf8_columns(qw/name info/);
 	}
 }
 

--- a/Slim/Utils/Progress.pm
+++ b/Slim/Utils/Progress.pm
@@ -92,7 +92,9 @@ sub new {
 	my $self = $class->SUPER::new();
 	
 	$self->type( $args->{type} || 'NOTYPE' );
-	$self->name( $args->{name} || 'NONAME' );
+	# Scanner progress names may include 'raw' path elements (bytes), needs decoding.
+	my $name = $args->{name} ? Slim::Utils::Unicode::utf8decode_locale($args->{name}) : 'NONAME';
+	$self->name( $name );
 	$self->total( $args->{total} || 0 );
 	$self->start( $now );
 	$self->eta( -1 );
@@ -218,6 +220,7 @@ sub update {
 	if ( $self->dball || $now > $self->dbup + UPDATE_DB_INTERVAL ) {
 		$self->dbup($now);
 	
+		# Scanner progress updates may include 'raw' path elements (bytes) in 'info', needs decoding.
 		$self->_update_db( {
 			done => $done,
 			info => $info ? Slim::Utils::Unicode::utf8decode_locale($info) : '',

--- a/Slim/Web/Pages/Common.pm
+++ b/Slim/Web/Pages/Common.pm
@@ -20,6 +20,7 @@ use Slim::Utils::Log;
 use Slim::Utils::Strings qw(string);
 use Slim::Utils::Prefs;
 use Slim::Utils::Progress;
+use Slim::Utils::Unicode;
 use Slim::Web::HTTP;
 
 my $prefs = preferences('server');
@@ -507,6 +508,10 @@ sub logFile {
 
 		my @lines;
 		while ( $count && (my $line = $file->readline()) ) {
+
+			# Decode line. The log file is encoded in utf-8, and File::ReadBackwards retrieves it raw (binmode).
+			$line = Slim::Utils::Unicode::utf8decode($line);
+
 			next if $search && $line !~ /\Q$search\E/i; 
 			
 			$line = "<span style=\"color:green\">$line<\/span>" if $line =~ /main::init.*Starting/;


### PR DESCRIPTION
- **Fix scan progress reporting - 'raw' path names need to be decoded**

Scanner reporting in the "Media Scan Details" section of the Web UI displays garbled/corrupted path names when those path names contain non-ASCII characters. This becomes particularly noticeable/problematic when the path names in the user's music library uses non-latin characters exclusively, for example Greek.

The reporting is not entirely broken. Path names are rendered correctly when displaying periodic progress updates.

A visual example of the issue being addressed:
https://forums.slimdevices.com/attachment.php?attachmentid=35856&stc=1&d=1633282161
Which has been taken from this forum post:
https://forums.slimdevices.com/showthread.php?115221-Problem-scanning-music-files-with-non-english-file-names

The problem lies in the handling of the `name` element of a progress report. Because it may contain non-ASCII characters, utf8 encoding/decoding is required, and this is not presently undertaken.

This contrasts with the periodic updates to that report. Here, path names are provided through the `info` element of the progress report, and utf8 encoding/decoding is being properly applied to these.

This proposed change corrects matters by handling the `name` element in the same way as an `info` element.

- **Fix display of log in web UI - decode it from utf-8**

The LMS log (generated through `Log4perl`) is encoded in utf-8.

When the log is rendered in the Web UI (through the "100, 500, 1000 lines" links) non-ASCII characters presently become garbled. This is because the log file is read "raw" (`binmode`). This proposed change corrects matters by decoding each log line. They are then rendered correctly in the web UI.
