### PR TITLE
Removal of hard coded sample rate in calculation used by setDelayedCallback

### DIFF
--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -583,15 +583,16 @@ sub getStreamDelay {
 	
 	return 0 unless $client->streamingSong();
 	
-	my $bitrate    = $client->streamingSong()->streambitrate() || 128000;
-	my $samplerate = $client->streamingSong()->currentTrack->samplerate() || 44100;
-	my $delay      = 0;
+	my $bitrate = $client->streamingSong()->streambitrate() || 128000;		
+	my $delay   = 0;	
+	
+	if ( $bitrate > 0 ) {	
 
-	
-	
-	if ( $bitrate > 0 ) {
+		my $samplerate = $client->streamingSong()->currentTrack->samplerate() || 44100;
+		my $depth      = $client->can('depth') ? $client->depth / 2 : 8;
+
 		my $decodeBuffer = $client->bufferFullness() / ( int($bitrate / 8) );
-		my $outputBuffer = $client->outputBufferFullness() / ($samplerate * 8);
+		my $outputBuffer = $client->outputBufferFullness() / ($samplerate * $depth);
 	
 		if ( $outputDelayOnly ) {
 			$delay = $outputBuffer;
@@ -599,9 +600,10 @@ sub getStreamDelay {
 		else {
 			$delay = $decodeBuffer + $outputBuffer;
 		}
+
+		main::INFOLOG && $log->is_info && $log->info("Delay calculated as $delay with bitrate $bitrate, samplerate $samplerate and depth $depth");
+		
 	}
-	
-	main::INFOLOG && $log->is_info && $log->info("Delay calculated as $delay with bitrate $bitrate and samplerate $samplerate");
 	
 	return $delay;
 }

--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -583,12 +583,15 @@ sub getStreamDelay {
 	
 	return 0 unless $client->streamingSong();
 	
-	my $bitrate = $client->streamingSong()->streambitrate() || 128000;
-	my $delay   = 0;
+	my $bitrate    = $client->streamingSong()->streambitrate() || 128000;
+	my $samplerate = $client->streamingSong()->currentTrack->samplerate() || 44100;
+	my $delay      = 0;
+
+	
 	
 	if ( $bitrate > 0 ) {
 		my $decodeBuffer = $client->bufferFullness() / ( int($bitrate / 8) );
-		my $outputBuffer = $client->outputBufferFullness() / (44100 * 8);
+		my $outputBuffer = $client->outputBufferFullness() / ($samplerate * 8);
 	
 		if ( $outputDelayOnly ) {
 			$delay = $outputBuffer;
@@ -597,6 +600,8 @@ sub getStreamDelay {
 			$delay = $decodeBuffer + $outputBuffer;
 		}
 	}
+	
+	main::INFOLOG && $log->is_info && $log->info("Delay calculated as $delay with bitrate $bitrate and samplerate $samplerate");
 	
 	return $delay;
 }

--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -583,8 +583,8 @@ sub getStreamDelay {
 	
 	return 0 unless $client->streamingSong();
 	
-	my $bitrate = $client->streamingSong()->streambitrate() || 128000;		
-	my $delay   = 0;	
+	my $bitrate = $client->streamingSong()->streambitrate() || 128000;	
+	my $delay   = 0;
 	
 	if ( $bitrate > 0 ) {	
 
@@ -602,7 +602,7 @@ sub getStreamDelay {
 		}
 
 		main::INFOLOG && $log->is_info && $log->info("Delay calculated as $delay with bitrate $bitrate, samplerate $samplerate and depth $depth");
-		
+
 	}
 	
 	return $delay;


### PR DESCRIPTION
See [https://forums.slimdevices.com/showthread.php?115303-Slim-Music-Info-setDelayedCallback-incorrect-delay-calc-for-48000-sample-rate](https://forums.slimdevices.com/showthread.php?115303-Slim-Music-Info-setDelayedCallback-incorrect-delay-calc-for-48000-sample-rate)

This removes the hard coding of the sample rate and includes a fallback to the original hard coded value if the sample rate is not available.  
This calculation is by Slim::Music::Info::setDelayedCallback which is typically used by plugins to sync meta data changes with the played out audio on remote streams.

I'm not quite sure what happens if the player does resampling (if it does it before or after the output buffer) but, on balance, I believe this is an improvement and will be more accurate for all modern players.