### PR TITLE
Allow 'PUT' and 'DELETE' HTTP verbs when calling an url served by a raw function

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -489,16 +489,16 @@ sub processHTTP {
 		#PUT and DELETE are only considered valid for a raw function, so we will not go any further for these HTTP verbs
 		if ( $request->method() eq 'PUT' || $request->method() eq 'DELETE') {
 					
-				$log->is_warn && $log->warn("Bad Request: [" . join(' ', ($request->method, $request->uri)) . "]");			
+			$log->is_warn && $log->warn("Bad Request: [" . join(' ', ($request->method, $request->uri)) . "]");			
 				
-				$response->code(RC_METHOD_NOT_ALLOWED);
-				$response->content_type('text/html');
-				$response->header('Connection' => 'close');
-				$response->content_ref(filltemplatefile('html/errors/405.html', $params));
+			$response->code(RC_METHOD_NOT_ALLOWED);
+			$response->content_type('text/html');
+			$response->header('Connection' => 'close');
+			$response->content_ref(filltemplatefile('html/errors/405.html', $params));
 
-				$httpClient->send_response($response);
-				closeHTTPSocket($httpClient);
-				return;
+			$httpClient->send_response($response);
+			closeHTTPSocket($httpClient);
+			return;
 		}
 
 		# Set the request time - for If-Modified-Since


### PR DESCRIPTION
This proposed change amends Slim::Web:HTTP so that it can support a plugin providing [REST style functionality](https://en.wikipedia.org/wiki/Representational_state_transfer).

- 'PUT' and 'DELETE' are allowable HTTP method verbs.
- The intention is, that 'PUT' and 'DELETE' is only valid for raw function calls fulfilled by a plugin.  The behaviour for standard calls prior to this change is maintained.  That is, for calls that are not fulfilled by a raw function, then a 405 "Method not allowed" response is returned for 'PUT' or 'DELETE' methods.