### PR TITLE
copy object prior to executing dump (to mitigate its behavior of conv…

### DIFF
--- a/Slim/Web/JSONRPC.pm
+++ b/Slim/Web/JSONRPC.pm
@@ -14,7 +14,6 @@ use strict;
 use HTTP::Status qw(RC_OK RC_FORBIDDEN);
 use JSON::XS::VersionOneAndTwo;
 use Scalar::Util qw(blessed);
-use Storable "dclone";
 
 use Slim::Web::HTTP;
 use Slim::Utils::Compress;
@@ -280,8 +279,7 @@ sub writeResponse {
 	if ( main::DEBUGLOG && $isDebug ) {
 		# Deep-copy responseRef prior to dumping its content because dump()
 		# will convert int members into strings permanently
-		my $responseRefCopy = dclone $responseRef;
-		$log->debug( "JSON response: " . Data::Dump::dump($responseRefCopy) );
+		$log->debug( "JSON response: " . Data::Dump::dump(Storable::dclone($responseRef)) );
 	}
 
 	# Don't waste CPU cycles if we're not connected

--- a/Slim/Web/JSONRPC.pm
+++ b/Slim/Web/JSONRPC.pm
@@ -14,6 +14,7 @@ use strict;
 use HTTP::Status qw(RC_OK RC_FORBIDDEN);
 use JSON::XS::VersionOneAndTwo;
 use Scalar::Util qw(blessed);
+use Storable::dclone;
 
 use Slim::Web::HTTP;
 use Slim::Utils::Compress;
@@ -276,8 +277,11 @@ sub writeResponse {
 	my $httpClient   = $context->{'httpClient'};
 	my $httpResponse = $context->{'httpResponse'};
 
+	# Deep-copy responseRef prior to dumping its content because dump()
+	# will convert int members into strings permanently
+	my $responseRefCopy = Storable::dclone $responseRef;
 	if ( main::DEBUGLOG && $isDebug ) {
-		$log->debug( "JSON response: " . Data::Dump::dump($responseRef) );
+		$log->debug( "JSON response: " . Data::Dump::dump($responseRefCopy) );
 	}
 
 	# Don't waste CPU cycles if we're not connected

--- a/Slim/Web/JSONRPC.pm
+++ b/Slim/Web/JSONRPC.pm
@@ -14,7 +14,7 @@ use strict;
 use HTTP::Status qw(RC_OK RC_FORBIDDEN);
 use JSON::XS::VersionOneAndTwo;
 use Scalar::Util qw(blessed);
-use Storable::dclone;
+use Storable "dclone";
 
 use Slim::Web::HTTP;
 use Slim::Utils::Compress;
@@ -280,7 +280,7 @@ sub writeResponse {
 	if ( main::DEBUGLOG && $isDebug ) {
 		# Deep-copy responseRef prior to dumping its content because dump()
 		# will convert int members into strings permanently
-		my $responseRefCopy = Storable::dclone $responseRef;
+		my $responseRefCopy = dclone $responseRef;
 		$log->debug( "JSON response: " . Data::Dump::dump($responseRefCopy) );
 	}
 

--- a/Slim/Web/JSONRPC.pm
+++ b/Slim/Web/JSONRPC.pm
@@ -277,10 +277,10 @@ sub writeResponse {
 	my $httpClient   = $context->{'httpClient'};
 	my $httpResponse = $context->{'httpResponse'};
 
-	# Deep-copy responseRef prior to dumping its content because dump()
-	# will convert int members into strings permanently
-	my $responseRefCopy = Storable::dclone $responseRef;
 	if ( main::DEBUGLOG && $isDebug ) {
+		# Deep-copy responseRef prior to dumping its content because dump()
+		# will convert int members into strings permanently
+		my $responseRefCopy = Storable::dclone $responseRef;
 		$log->debug( "JSON response: " . Data::Dump::dump($responseRefCopy) );
 	}
 


### PR DESCRIPTION
Issue:
When Logging for network.jsonrpc is changed to DEBUG level, API responses hash member values that were originally of type int (on any verbosity level <DEBUG) are converted to string, thereby breaking downstream json parsing of the messages. 

For example, 

When verbosity of network.jsonrpc < DEBUG
`
[{"id":1,"method":"slim.request","params":["aa:bb:cc:dd:ee:ff",["status","-","1","tags:alNx"]],"result":{"mixer volume":0,"playlist repeat":0,"playlist mode":"off","playlist shuffle":0,"power":1,"player_name":"my_player","digital_volume_control":1,"mode":"stop","player_connected":1,"signalstrength":0,"player_ip":"192.168.1.15:40974","playlist_tracks":0,"seq_no":0}}]
`
vs. verbosity level @ DEBUG
`
[{"result":{"mode":"stop","playlist shuffle":"0","seq_no":"0","player_connected":"1","playlist mode":"off","power":"1","digital_volume_control":"1","mixer volume":"0","signalstrength":"0","player_ip":"192.168.1.15:58436","playlist repeat":"0","player_name":"my_player","playlist_tracks":"0"},"params":["aa:bb:cc:dd:ee:ff",["status","-","1","tags:alNx"]],"method":"slim.request","id":"1"}]
`

Note how keys like `digital_volume_control` and `power` switch from int > str.

I believe this has to do with the use of Data::Dump::dump(). There's a good post (by `friedo`) on  [stackexchange](https://stackoverflow.com/questions/24879782/strange-behavior-using-datadump-in-combination-with-jsonxs) that discusses the behavior of casting int->str. 

As a work around for this behavior, i've performed a deep copy of the problematic variable and passed the copy to Data::Dump:dump() instead of `responseRef`. 
