### PR TITLE
Use info instead of error log level for informative logging

### DIFF
--- a/Slim/Music/Artwork.pm
+++ b/Slim/Music/Artwork.pm
@@ -231,7 +231,7 @@ sub updateStandaloneArtwork {
 		SELECT COUNT(*) FROM ( $sql ) AS t1
 	} );
 
-	$log->error("Starting updateStandaloneArtwork for $count albums");
+	main::INFOLOG && $log->is_info && $log->info("Starting updateStandaloneArtwork for $count albums");
 
 	if ( !$count ) {
 		$cb && $cb->();
@@ -654,7 +654,7 @@ sub precacheAllArtwork {
 		SELECT COUNT(*) FROM ( $sql ) AS t1
 	} );
 
-	$log->error("Starting precacheArtwork for $count albums");
+	main::INFOLOG && $log->is_info && $log->info("Starting precacheArtwork for $count albums");
 
 	if ( !$count ) {
 		$cb && $cb->();
@@ -805,7 +805,7 @@ sub precacheAllArtwork {
 
 		$progress->final;
 
-		$log->error( "precacheArtwork finished in " . $progress->duration );
+		main::INFOLOG && $log->is_info && $log->info( "precacheArtwork finished in " . $progress->duration );
 
 		$cb && $cb->();
 

--- a/Slim/Music/Import.pm
+++ b/Slim/Music/Import.pm
@@ -437,7 +437,7 @@ sub runScanPostProcessing {
 		my ($dir) = Slim::Utils::OSDetect::dirsFor('prefs');
 		my $json = catfile( $dir, 'tracks_persistent.json' );
 		if ( -e $json ) {
-			$log->error('Migrating persistent track information from MySQL');
+			main::INFOLOG && $log->is_info && $log->info('Migrating persistent track information from MySQL');
 
 			if ( Slim::Schema::TrackPersistent->import_json($json) ) {
 				unlink $json;
@@ -477,7 +477,7 @@ sub runScanPostProcessing {
 	Slim::Music::Artwork->precacheAllArtwork;
 
 	# Always run an optimization pass at the end of our scan.
-	$log->error("Starting Database optimization.");
+	main::INFOLOG && $log->is_info && $log->info("Starting Database optimization.");
 
 	$importsRunning{'dbOptimize'} = Time::HiRes::time();
 
@@ -575,7 +575,7 @@ sub runImporter {
 		$importsRunning{$importer} = Time::HiRes::time();
 
 		# rescan each enabled Import, or scan the newly enabled Import
-		$log->error("Starting $importer scan");
+		main::INFOLOG && $log->is_info && $log->info("Starting $importer scan");
 
 		$changes = $importer->startScan;
 	}
@@ -598,7 +598,7 @@ sub runArtworkImporter {
 		$importsRunning{$importer} = Time::HiRes::time();
 
 		# rescan each enabled Import, or scan the newly enabled Import
-		$log->error("Starting $importer artwork scan");
+		main::INFOLOG && $log->is_info && $log->info("Starting $importer artwork scan");
 
 		$importer->startArtworkScan;
 
@@ -707,7 +707,7 @@ sub endImporter {
 
 	if (exists $importsRunning{$importer}) {
 
-		$log->error(sprintf("Completed %s Scan in %s seconds.",
+		main::INFOLOG && $log->is_info && $log->info(sprintf("Completed %s Scan in %s seconds.",
 			$importer, sprintf('%.3f', Time::HiRes::time() - $importsRunning{$importer})
 		));
 

--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -472,11 +472,11 @@ sub _uniqueTokens {
 sub _rebuildIndex {
 	my $progress = shift;
 
-	$scanlog->error("Starting fulltext index build");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Starting fulltext index build");
 
 	my $dbh = Slim::Schema->dbh;
 
-	$scanlog->error("Initialize fulltext table");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Initialize fulltext table");
 
 	$dbh->do("DROP TABLE IF EXISTS fulltext;") or $scanlog->error($dbh->errstr);
 	if ( CAN_FTS4 ) {
@@ -489,7 +489,7 @@ sub _rebuildIndex {
 	}
 	main::idleStreams() unless main::SCANNER;
 
-	$scanlog->error("Create fulltext index for tracks");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Create fulltext index for tracks");
 	$progress && $progress->update(string('SONGS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 
@@ -499,7 +499,7 @@ sub _rebuildIndex {
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
 	main::idleStreams() unless main::SCANNER;
 
-	$scanlog->error("Create fulltext index for albums");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Create fulltext index for albums");
 	$progress && $progress->update(string('ALBUMS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 	$sql = sprintf(SQL_CREATE_ALBUM_ITEM, '', '');
@@ -508,7 +508,7 @@ sub _rebuildIndex {
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
 	main::idleStreams() unless main::SCANNER;
 
-	$scanlog->error("Create fulltext index for contributors");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Create fulltext index for contributors");
 	$progress && $progress->update(string('ARTISTS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 
@@ -518,7 +518,7 @@ sub _rebuildIndex {
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
 	main::idleStreams() unless main::SCANNER;
 
-	$scanlog->error("Create fulltext index for playlists");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Create fulltext index for playlists");
 	$progress && $progress->update(string('PLAYLISTS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 
@@ -533,7 +533,7 @@ sub _rebuildIndex {
 
 	main::idleStreams() unless main::SCANNER;
 
-	$scanlog->error("Optimize fulltext index");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Optimize fulltext index");
 	$progress && $progress->update(string('DBOPTIMIZE_PROGRESS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 
@@ -548,7 +548,7 @@ sub _rebuildIndex {
 	$progress->final(BUILD_STEPS) if $progress;
 	Slim::Schema->forceCommit if main::SCANNER;
 
-	$scanlog->error("Fulltext index build done!");
+	main::INFOLOG && $scanlog->is_info && $scanlog->info("Fulltext index build done!");
 }
 
 sub _createPlaylistItem {
@@ -577,7 +577,7 @@ sub _initPopularTerms {
 	($ftExists) = $dbh->selectrow_array( qq{ SELECT id FROM fulltext WHERE fulltext.id MATCH 'YXLALBUM*' } ) if $ftExists;     # 8.3: IDs must be prefixed to make them "non searchable"
 
 	if (!$ftExists) {
-		$scanlog->error("Fulltext index missing or outdated - re-building");
+		main::INFOLOG && $scanlog->is_info && $scanlog->info("Fulltext index missing or outdated - re-building");
 
 		$prefs->remove('popularTerms');
 		_rebuildIndex() unless $scanDone;

--- a/Slim/Plugin/OnlineLibraryBase.pm
+++ b/Slim/Plugin/OnlineLibraryBase.pm
@@ -78,7 +78,7 @@ sub deleteRemovedTracks { if (main::SCANNER && !$main::wipe) {
 			)
 	} . (IS_SQLITE ? '' : ' ORDER BY url');
 
-	$log->error("Get removed online tracks count") unless main::SCANNER && $main::progress;
+	main::INFOLOG && $log->is_info && !(main::SCANNER && $main::progress) && $log->info("Get removed online tracks count");
 	# only remove missing tracks when looking for audio tracks
 	my $notInOnlineLibraryCount = 0;
 	($notInOnlineLibraryCount) = $dbh->selectrow_array( qq{

--- a/Slim/Utils/Scanner/LMS.pm
+++ b/Slim/Utils/Scanner/LMS.pm
@@ -255,7 +255,7 @@ sub rescan {
 			
 				if ( $total && (!$progress->total || $progress->total < $total) ) {
 					# Initial progress data, report the total number in the log too
-					$log->error( "Scanning new media files ($total)" ) unless main::SCANNER && $main::progress;
+					main::INFOLOG && $log->is_info && !(main::SCANNER && $main::progress) && $log->info( "Scanning new media files ($total)" );
 					
 					$progress->total( $total );
 				}

--- a/scanner.pl
+++ b/scanner.pl
@@ -203,7 +203,7 @@ sub main {
 
 	($REVISION, $BUILDDATE) = Slim::Utils::Misc::parseRevision();
 
-	$log->error("Starting Logitech Media Server scanner (v$main::VERSION, $REVISION, $BUILDDATE) perl $]");
+	main::INFOLOG && $log->info("Starting Logitech Media Server scanner (v$main::VERSION, $REVISION, $BUILDDATE) perl $]");
 
 	# Bring up strings, database, etc.
 	initializeFrameworks($log);

--- a/slimserver.pl
+++ b/slimserver.pl
@@ -387,7 +387,7 @@ sub init {
 
 	my $log = logger('server');
 
-	$log->error("Starting Logitech Media Server (v$main::VERSION, $REVISION, $BUILDDATE) perl $] - " . $main::Config{archname});
+	main::INFOLOG && $log->info("Starting Logitech Media Server (v$main::VERSION, $REVISION, $BUILDDATE) perl $] - " . $main::Config{archname});
 
 	if ($diag) {
 		eval "use diagnostics";


### PR DESCRIPTION
Even with the log level set to `error` LMS is very chatty. This patch moves informative messages to log level `info`.
```
Nov  5 13:56:26 nasty squeezeboxserver[3945055]: [21-11-05 13:56:26.5543] main::main (206) Starting Logitech Media Server scanner (v8.3.0, 1635857800, Tue Nov  2 15:14:58 CET 2021) perl 5.028001
Nov  5 13:56:27 nasty squeezeboxserver[3945055]: [21-11-05 13:56:27.0184] Slim::Music::Import::runImporter (578) Starting Slim::Plugin::WiMP::Importer scan
Nov  5 13:56:27 nasty squeezeboxserver[3945055]: [21-11-05 13:56:27.5984] Slim::Music::Import::endImporter (711) Completed Slim::Plugin::WiMP::Importer Scan in 0.580 seconds.
Nov  5 13:56:27 nasty squeezeboxserver[3945055]: [21-11-05 13:56:27.5993] Slim::Music::Import::runImporter (578) Starting Plugins::Spotty::Importer scan
Nov  5 13:57:23 nasty squeezeboxserver[3945055]: [21-11-05 13:57:23.2652] Slim::Plugin::OnlineLibraryBase::deleteRemovedTracks (81) Get removed online tracks count
Nov  5 13:57:23 nasty squeezeboxserver[3945055]: [21-11-05 13:57:23.3764] Slim::Music::Import::endImporter (711) Completed Plugins::Spotty::Importer Scan in 55.777 seconds.
Nov  5 13:57:23 nasty squeezeboxserver[3945055]: [21-11-05 13:57:23.3768] Slim::Music::Import::runImporter (578) Starting Slim::Plugin::FullTextSearch::Plugin scan
Nov  5 13:57:23 nasty squeezeboxserver[3945055]: [21-11-05 13:57:23.3772] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (475) Starting fulltext index build
Nov  5 13:57:23 nasty squeezeboxserver[3945055]: [21-11-05 13:57:23.3774] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (479) Initialize fulltext table
Nov  5 13:57:23 nasty squeezeboxserver[3945055]: [21-11-05 13:57:23.6504] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (492) Create fulltext index for tracks
Nov  5 13:57:33 nasty squeezeboxserver[3945055]: [21-11-05 13:57:33.3874] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (502) Create fulltext index for albums
Nov  5 13:57:36 nasty squeezeboxserver[3945055]: [21-11-05 13:57:36.1004] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (511) Create fulltext index for contributors
Nov  5 13:57:36 nasty squeezeboxserver[3945055]: [21-11-05 13:57:36.3270] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (521) Create fulltext index for playlists
Nov  5 13:57:41 nasty squeezeboxserver[3945055]: [21-11-05 13:57:41.5448] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (536) Optimize fulltext index
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1506] Slim::Plugin::FullTextSearch::Plugin::_rebuildIndex (551) Fulltext index build done!
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1507] Slim::Music::Import::endImporter (711) Completed Slim::Plugin::FullTextSearch::Plugin Scan in 18.774 seconds.
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1508] Slim::Music::Import::runImporter (578) Starting Slim::Plugin::ExtendedBrowseModes::Libraries scan
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1509] Slim::Music::Import::endImporter (711) Completed Slim::Plugin::ExtendedBrowseModes::Libraries Scan in 0.000 seconds.
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1510] Slim::Music::Import::runImporter (578) Starting Slim::Plugin::OnlineLibrary::Importer::VirtualLibrariesCleanup scan
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1687] Slim::Music::Import::endImporter (711) Completed Slim::Plugin::OnlineLibrary::Importer::VirtualLibrariesCleanup Scan in 0.018 seconds.
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1696] Slim::Music::Artwork::updateStandaloneArtwork (234) Starting updateStandaloneArtwork for 0 albums
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.1697] Slim::Music::Import::endImporter (711) Completed updateStandaloneArtwork Scan in 0.001 seconds.
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.2820] Slim::Music::Artwork::precacheAllArtwork (657) Starting precacheArtwork for 7 albums
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.9438] Slim::Music::Artwork::__ANON__ (808) precacheArtwork finished in 0.659497976303101
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.9439] Slim::Music::Import::endImporter (711) Completed precacheArtwork Scan in 0.774 seconds.
Nov  5 13:57:42 nasty squeezeboxserver[3945055]: [21-11-05 13:57:42.9445] Slim::Music::Import::runScanPostProcessing (480) Starting Database optimization.
Nov  5 13:57:51 nasty squeezeboxserver[3945055]: [21-11-05 13:57:51.4232] Slim::Music::Import::endImporter (711) Completed dbOptimize Scan in 8.478 seconds.
```