### PR TITLE
Move noisy cuesheet log messages to debug level

### DIFF
--- a/Slim/Formats/Playlists/CUE.pm
+++ b/Slim/Formats/Playlists/CUE.pm
@@ -493,7 +493,7 @@ sub parse {
 		if (!defined $track->{'END'}) {
 			if (!$embedded && !$lastpos && $file) {
 
-				main::INFOLOG && $log->info("Reading tags to get ending time of $file");
+				main::DEBUGLOG && $log->is_debug && $log->debug("Reading tags to get ending time of $file");
 
 				my $tags = Slim::Formats->readTags($file);
 
@@ -501,7 +501,7 @@ sub parse {
 			}
 
 			if (!$lastpos) {
-				logError("Couldn't get duration of filename here $file");
+				main::DEBUGLOG && $log->is_debug && $log->debug("Couldn't get duration of filename here $file");
 			}
 
 			$track->{'END'} = $lastpos;
@@ -518,9 +518,8 @@ sub parse {
 		my $file = $track->{'FILENAME'};
 
 		if (!defined $track->{'START'} || !defined $track->{'END'} || !defined $file ) {
-
-			logError("Missing file or start/end points for track $file.");
-			main::INFOLOG && $log->is_info && $log->info(Data::Dump::dump($track));
+			main::DEBUGLOG && $log->is_debug && $log->debug("Missing file or start/end points for track $file");
+			main::DEBUGLOG && $log->is_debug && $log->debug(Data::Dump::dump($track));
 			next;
 		}
 


### PR DESCRIPTION
Parsing cuesheets is noisy if a cuesheet doesn't have "REM END" commands.
I get the feeling that "REM END" is some non-standard command that not all
applications are required to use or understand. I can't find information
on "REM END" or which applications that use it.

So, logging error messages if "REM END" is missing seems wrong.

For me these error messages are extremely noisy because I have used
CD ripper Sound Juicer to rip many of my CDs and Sound Juicer embeds
cuesheets in FLAC files it writes which look like this:

FILE "01 The Song.flac" FLAC
  TRACK 01 AUDIO
    INDEX 00 19404
  TRACK 02 AUDIO
    INDEX 00 11982264
  ...

When scanning this cuesheet there will be error messages logged for every
track in the cuesheet.

If a ripped CD has N tracks which are saved to separate files (each with an
embedded cuesheet) there will be N * (N + N - 1) error messages when scanning
these files.
N=10 -> 190 error messages
N=20 -> 780 error messages