### PR TITLE
Fix playback start on power-on.

### DIFF
--- a/Slim/Networking/Slimproto.pm
+++ b/Slim/Networking/Slimproto.pm
@@ -1148,9 +1148,9 @@ sub _hello_handler {
 		$client->display( $display_class->new($client) );
 
 		$client->macaddress($mac);
-		$client->init($deviceids[$deviceid], $capabilities, $syncgroupid);
+		$client->init($deviceids[$deviceid], $capabilities);
 		$client->reconnect($paddr, $revision, $s, undef, undef, $syncgroupid);
-
+		$client->startPlayingIfNeeded($deviceids[$deviceid], $capabilities, $syncgroupid);
 	} else {
 
 		main::INFOLOG && $log->info("Hello from existing client: $id on ipport: $ipport{$s}");

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -101,12 +101,16 @@ sub new {
 
 sub init {
 	my $client = shift;
-	my (undef, undef, $syncgroupid) = @_;
 
 	$client->SUPER::init(@_);
 
 	Slim::Hardware::IR::initClient($client);
 	Slim::Buttons::Home::updateMenu($client);
+}
+
+sub startPlayingIfNeeded {
+	my $client = shift;
+	my (undef, undef, $syncgroupid) = @_;
 
 	# fire it up!
 	$client->startup($syncgroupid);


### PR DESCRIPTION
Sequence of events was
Client::init
-> Player::power
-> Client::execute(['play'])
...
-> StreamingController::play
...
-> StreamingController::_Stream
...
-> Squeezebox::play
-> Squeezebox::stream_s

... at which point the flow stopped because no connection was made to
the player yet, as that only happens in Player::reconnect(). Defer
playback start until after connection to fix this.