### PR TITLE
Player restart proposal

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -381,7 +381,7 @@ sub clientForgetCommand {
 	# player that's still playing the same way as a player that's turned off while still playing, so
 	# we can make it start playing again if it reappears and the user told us to resume playing
 	# when powering on.
-	$client->persistPlaybackStateForPowerOff();
+	$prefs->client($client)->set('playingAtPowerOff', $client->controller()->isPlaying(1)) if $client->power();
 
 	$client->controller()->playerInactive($client);
 

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -377,13 +377,6 @@ sub clientForgetCommand {
 		return;
 	}
 
-	# Persist playback state like we would do when turning off a player, that is, treat a vanishing
-	# player that's still playing the same way as a player that's turned off while still playing, so
-	# we can make it start playing again if it reappears and the user told us to resume playing
-	# when powering on. Make sure elapsed is not 0 if we are playing
-	my $playing = $client->controller->playingSongElapsed() + 0.1 if $client->controller->isPlaying(1);
-	$prefs->client($client)->set('playingAtPowerOff', $playing || 0) if $client->power();
-
 	$client->controller()->playerInactive($client);
 
 	$client->forgetClient();

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -381,7 +381,8 @@ sub clientForgetCommand {
 	# player that's still playing the same way as a player that's turned off while still playing, so
 	# we can make it start playing again if it reappears and the user told us to resume playing
 	# when powering on.
-	$prefs->client($client)->set('playingAtPowerOff', $client->controller()->isPlaying(1)) if $client->power();
+	my $playing = $client->controller()->isPlaying(1);
+	$prefs->client($client)->set('playingAtPowerOff', $playing) if $client->power();
 
 	$client->controller()->playerInactive($client);
 

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -380,9 +380,9 @@ sub clientForgetCommand {
 	# Persist playback state like we would do when turning off a player, that is, treat a vanishing
 	# player that's still playing the same way as a player that's turned off while still playing, so
 	# we can make it start playing again if it reappears and the user told us to resume playing
-	# when powering on.
-	my $playing = $client->controller()->isPlaying(1);
-	$prefs->client($client)->set('playingAtPowerOff', $playing) if $client->power();
+	# when powering on. Make sure elapsed is not 0 if we are playing
+	my $playing = $client->controller->playingSongElapsed() + 0.1 if $client->controller->isPlaying(1);
+	$prefs->client($client)->set('playingAtPowerOff', $playing || 0) if $client->power();
 
 	$client->controller()->playerInactive($client);
 

--- a/Slim/Networking/Slimproto.pm
+++ b/Slim/Networking/Slimproto.pm
@@ -255,6 +255,7 @@ sub slimproto_close {
 	$clientsock->close();
 
 	if ( my $client = $sock2client{$clientsock} ) {
+		delete $heartbeat{ $client->id };
 		
 		$client->tcpsock(undef);
 
@@ -276,21 +277,6 @@ sub slimproto_close {
 				# Bug 6714, delete the cached needsUpgrade value, as the player
 				# may change firmware versions before coming back
 				$client->_needsUpgrade(undef);
-				
-				# Persist playback state like we would do when turning off a player, that is, treat a vanishing
-				# player that's still playing the same way as a player that's turned off while still playing, so
-				# we can make it start playing again if it reappears and the user told us to resume playing
-				# when powering on. Make sure elapsed is not 0 if we are playing and take the last reported
-				# position, not the extrapolated one
-				my $playing = 0;
-				
-				if ($client->controller->isPlaying(1)) {
-					$playing = $client->controller->playingSongElapsed() - (Time::HiRes::time() - $heartbeat{ $client->id });
-					$playing = 0.1 if $playing <= 0;
-					main::INFOLOG && $log->is_info && $log->info("disconnected player position $playing secs");
-				}	
-
-				preferences('server')->client($client)->set('playingAtPowerOff', $playing);
 
 				# set timer to forget client
 				if ( $forget_disconnected_time ) {
@@ -302,8 +288,6 @@ sub slimproto_close {
 				}
 			}
 		}
-
-		delete $heartbeat{ $client->id };
 	}
 
 	# forget state
@@ -313,6 +297,19 @@ sub slimproto_close {
 
 sub forget_disconnected_client {
 	my $client = shift;
+	my $cprefs = preferences('server')->client($client);				
+
+	# Persist playback state like we would do when turning off a player, that is, treat a vanishing
+	# player that's still playing the same way as a player that's turned off while still playing, so
+	# we can make it start playing again if it reappears and the user told us to resume playing
+	# when powering on. 
+	$cprefs->set('playingAtPowerOff', $client->isPlaying(1));
+	
+	if ($client->isPlaying(1)) {
+		my $position = $client->controller->playingSongElapsed();
+		$cprefs->set('positionAtDisconnect', $position);					
+		main::INFOLOG && $log->is_info && $log->info("disconnected player position $position secs");
+	}
 
 	main::INFOLOG && $log->info("forgetting disconnected client");
 

--- a/Slim/Player/Client.pm
+++ b/Slim/Player/Client.pm
@@ -560,15 +560,6 @@ sub forgetClient {
 	}
 }
 
-sub persistPlaybackStateForPowerOff {
-	my $client = shift;
-
-	if ($client->power()) {
-		my $playing = $client->controller()->isPlaying(1);
-		$prefs->client($client)->set('playingAtPowerOff', $playing);
-	}
-}
-
 sub startup {
 	my $client = shift;
 	my $syncgroupid = shift;

--- a/Slim/Player/Client.pm
+++ b/Slim/Player/Client.pm
@@ -564,6 +564,8 @@ sub startup {
 	my $client = shift;
 	my $syncgroupid = shift;
 
+	# I don't think that should be done here b/c Squeezebox::reconnect does it as 
+	# well but by doing it here, $client is not activated as it is not connected
 	Slim::Player::Sync::restoreSync($client, $syncgroupid);
 
 	# restore the old playlist

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -317,7 +317,6 @@ sub resumeOnPower {
 			# but only if we were playing at power-off (bug 7061)
 			if ($cold) {
 				my $index = Slim::Player::Source::playingSongIndex($client);
-				print("COLD RESUME OF $index FROM $playing");
 				$client->execute(["playlist","jump", $index, 1, 0, { timeOffset => $playing}]);
 			} else {	
 				$client->execute(["play"]); # will resume if paused

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -227,7 +227,7 @@ sub power {
 			$controller->playerInactive($client);
 			$prefs->client($client)->set('playingAtPowerOff', 0);
  		} else {	
-			# make sure it's not 0 if we are playing
+			# make sure it's not 0 if we are playing as it represents elapsed time
 			my $playing = $controller->playingSongElapsed() + 0.1 if $controller->isPlaying(1);
 			$prefs->client($client)->set('playingAtPowerOff', $playing || 0);
 			

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -109,8 +109,8 @@ sub init {
 	Slim::Buttons::Home::updateMenu($client);
 
 	# fire it up!
+	$client->power($prefs->client($client)->get('power'));
 	$client->startup($syncgroupid);
-	$client->power($prefs->client($client)->get('power'), 0, 1);
 
 	return if $client->display->isa('Slim::Display::NoDisplay');
 		
@@ -201,12 +201,11 @@ sub power {
 	my $client = shift;
 	my $on     = shift;
 	my $noplay = shift;
-	my $force  = shift;
 	
 	my $currOn = $prefs->client($client)->get('power') || 0;
 
 	return $currOn unless defined $on;
-	return unless (!defined(Slim::Buttons::Common::mode($client)) || ($currOn != $on)) || $force;
+	return unless (!defined(Slim::Buttons::Common::mode($client)) || ($currOn != $on));
 
 	my $resume = $prefs->client($client)->get('powerOnResume');
 	$resume =~ /(.*)Off-(.*)On/;
@@ -251,7 +250,7 @@ sub power {
 		$client->display->renderCache()->{defaultfont} = undef;
 	 	
 	 	# Do now, not earlier so that playmode changes still work
-	 	$prefs->client($client)->set('power', $on); # Do now, not earlier so that 
+	 	$prefs->client($client)->set('power', $on); 
 	 	
 		# turn off audio outputs
 		$client->audio_outputs_enable(0);

--- a/Slim/Player/Player.pm
+++ b/Slim/Player/Player.pm
@@ -294,7 +294,7 @@ sub power {
 		$controller->playerActive($client);
 
 		# Decide if we shall resume playing on power 
-		$client->resumeOnPower();
+		$client->resumeOnPower() unless $noplay;
 	}
 }
 

--- a/Slim/Player/SqueezeSlave.pm
+++ b/Slim/Player/SqueezeSlave.pm
@@ -196,7 +196,6 @@ sub songElapsedSeconds {
 	
 	if ($client->isPlaying(1)) {
 		my $timeDiff = Time::HiRes::time() - $client->jiffiesToTimestamp($jiffies);
-		#logBacktrace($client->id, ": songElapsed=$songElapsed, jiffies=$jiffies, timeDiff=$timeDiff");
 		$songElapsed += $timeDiff if ($timeDiff > 0);
 	}
 	

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -72,12 +72,13 @@ sub reconnect {
 
 	if (!defined $reconnect) {
 		
-		# reconnection of a forgotten client -> power() in client's init would not resume
-		$client->resumeOnPower() if $client->power();
+		# reconnection of a forgotten client, need to take resume position from prefs
+		$client->resumeOnPower(1) if $client->power();
 		
 	} else {
 
 		if ($client->power()) {
+			$client->resumeOnPower();
 			$controller->playerActive($client);
 		}
 

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -72,12 +72,18 @@ sub reconnect {
 
 	if (!$reconnect) {
 
+		# when reconnecting after player has been forgotten, we need to power-cycle it
+		if (!defined $reconnect && $prefs->client($client)->get('power')) {
+			$prefs->client($client)->set('power', 0);
+			$client->power(1);
+		}
+		
 		if ($client->power()) {
 			$controller->playerActive($client);
 		}
 
 		if ($controller->onlyActivePlayer($client)) {
-			main::INFOLOG && $sourcelog->is_info && $sourcelog->info($client->id . " restaring play on pseudo-reconnect at "
+			main::INFOLOG && $sourcelog->is_info && $sourcelog->info($client->id . " restarting play on pseudo-reconnect at "
 				. ($bytes_received ? $bytes_received : 0));
 			$controller->playerReconnect($bytes_received);
 		}

--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -72,8 +72,15 @@ sub reconnect {
 
 	if (!defined $reconnect) {
 		
-		# reconnection of a forgotten client, need to take resume position from prefs
-		$client->resumeOnPower(1) if $client->power();
+		# Reconnection of a forgotten client, need to take resume position from
+		# the preferences
+		if ($client->power()) {
+			# Don't try to resume if we are synced, we might confuse others who have 
+			# moved on. I think playerActive is not need should Sync::restoreSync be
+			# removed from Client::startup. 
+			$client->resumeOnPower(1) if $controller->onlyActivePlayer($client);
+			$controller->playerActive($client);
+		}		
 		
 	} else {
 
@@ -82,7 +89,7 @@ sub reconnect {
 			$controller->playerActive($client);
 		}
 
-		# disconnected but not forgotten clients may need a restart or a proper stop
+		# Disconnected but not forgotten clients may need a restart or a proper stop
 		if (!$reconnect) {
 			if ($controller->onlyActivePlayer($client)) {
 				main::INFOLOG && $sourcelog->is_info && $sourcelog->info($client->id . " restarting play on pseudo-reconnect at "

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -449,7 +449,7 @@ sub songElapsedSeconds {
 		$songElapsed = $elapsedSeconds;
 	}
 
-	if ($client->isPlaying(1)) {
+	if ($client->isPlaying(1) && !$client->disconnected()) {
 		my $timeDiff = Time::HiRes::time() - $client->jiffiesToTimestamp($jiffies);
 		$songElapsed += $timeDiff if ($timeDiff > 0);
 	}

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -449,7 +449,9 @@ sub songElapsedSeconds {
 		$songElapsed = $elapsedSeconds;
 	}
 
-	if ($client->isPlaying(1) && !$client->disconnected()) {
+	# If we are disconnected and the only player or not master, elapsed shall not progress 
+	# anymore otherwise, extrapolate value to not confuse other players
+	if ($client->isPlaying(1) && (!$client->disconnected() || ($client->isSynced() && Slim::Player::Sync::isMaster($client)))) {
 		my $timeDiff = Time::HiRes::time() - $client->jiffiesToTimestamp($jiffies);
 		$songElapsed += $timeDiff if ($timeDiff > 0);
 	}

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -944,7 +944,8 @@ sub _Continue {
 		_Streamout($self);
 	} elsif (!$bytesReceived || $seekdata) {
 		main::INFOLOG && $log->is_info && $log->info("Restarting stream at offset $bytesReceived");
-		_Stream($self, $event, {song => $song, seekdata => $seekdata, reconnect => 1});
+		# 'reconnect' should not be set as player has *not* set reconnect flag here (see SqueezeBox::reconnect)
+		_Stream($self, $event, {song => $song, seekdata => $seekdata, reconnect => 0});
 		if ($song == playingSong($self)) {
 			$song->setStatus(Slim::Player::Song::STATUS_PLAYING);
 		}

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -948,7 +948,7 @@ sub _Continue {
 			$song->setStatus(Slim::Player::Song::STATUS_PLAYING);
 		}
 	} else {
-		# this handles resuming after reboot with the caveat that if connection has been lost (no reboot) 
+		# This handles resuming after reboot with the caveat that if connection has been lost (no reboot) 
 		# while playing and before reception of next song's 1st byte, we'll resume the current song
 		main::INFOLOG && $log->is_info && $log->info("Restarting playback at time offset: ". $self->playingSongElapsed());
 		_JumpToTime($self, $event, {newtime => $self->playingSongElapsed(), restartIfNoSeek => 1});

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -926,7 +926,6 @@ sub _RetryOrNext {		# -> Idle; IF [shouldretry && canretry] THEN continue
 	
 	_getNextTrack($self, $params, 1);
 }
-	
 
 sub _Continue {
 	my ($self, $event, $params) = @_;
@@ -942,14 +941,15 @@ sub _Continue {
 	if ($seekdata && $seekdata->{'streamComplete'}) {
 		main::INFOLOG && $log->is_info && $log->info("stream already complete at offset $bytesReceived");
 		_Streamout($self);
-	} elsif (!$bytesReceived || $seekdata) {
+	} elsif ($seekdata && $bytesReceived) {
 		main::INFOLOG && $log->is_info && $log->info("Restarting stream at offset $bytesReceived");
-		# 'reconnect' should not be set as player has *not* set reconnect flag here (see SqueezeBox::reconnect)
-		_Stream($self, $event, {song => $song, seekdata => $seekdata, reconnect => 0});
+		_Stream($self, $event, {song => $song, seekdata => $seekdata, reconnect => 1});
 		if ($song == playingSong($self)) {
 			$song->setStatus(Slim::Player::Song::STATUS_PLAYING);
 		}
 	} else {
+		# this handles resuming after reboot with the caveat that if connection has been lost (no reboot) 
+		# while playing and before reception of next song's 1st byte, we'll resume the current song
 		main::INFOLOG && $log->is_info && $log->info("Restarting playback at time offset: ". $self->playingSongElapsed());
 		_JumpToTime($self, $event, {newtime => $self->playingSongElapsed(), restartIfNoSeek => 1});
 	}


### PR DESCRIPTION
This is a proposal to handle differently https://github.com/Logitech/slimserver/pull/698 as well as allowing playback to restart for Boom, Classic and Duet (maybe Transporter as well) when they reconnect before LMS has forgotten them. 

This last piece took me a while as the issue is that StreamingController is setting the slimproto 'reconnect' flag in the '_Continue' event. That flag tells player to *not* restart their internal decoder and IMHO, this can only be done if the player set the 'reconnect' bit on wlan_channellist in the 'HELO' message (this means that only the control channel was lost, so we should continue with what we have in buffers, no need to reset decoder). But in that case, Slimproto::_hello_hander calls Squeezebox::reconnect with the reconnect flag set which mean we don't use the client->playerReconnect which is the only case where '_Continue' event is used (and _Continue means send STRMs). In other terms, there is no case where STRMs is used but the player has set the 'reconnect' slimproto bit in HELO. Anyway, long story short, and I might be wrong, but I think this 'don't reset decoder' flag was never used properly, but as it was honored by SB2 devices, it caused them to fail when restarting before being forgotten.

Otherwise, I think this takes care of restarting the track in the playlist for all cases if a player reconnects either before being forgotten (5 mins) or after. I'm moved back to earlier version of some files, that includes using original API pattern for Player::power() and Player::init, so feel free to critic :smile: