### PR TITLE
Fix foobar 1.6.6+ sending Icy-Metadata on any request

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -1511,6 +1511,9 @@ sub generateHTTPResponse {
 		# $peerclient as this will cause streaming to the real client $client to stop.
 		delete $peerclient{$httpClient};
 
+		# Disable metadata in case this client sent an Icy-Metadata header
+		$sendMetaData{$httpClient} = 0;
+
 		addStreamingResponse($httpClient, $headers);
 
 		return;


### PR DESCRIPTION
This happens when using proxied stream for a UPnPBridge player like foobar 1.6.6 and this is weird.

In proxied mode, foobar is told to GET stream from LMS <IP:9000>/stream.mp3. When receiving a *stream* with icy-metadata, then foobar spontaneously makes a request to the server to grab some information and this request contains an Icy-Metadata header. LMS sends a normal "file" response (this is not a stream) but because of that header, it also tries to send icy data and crashes (sort of). 

I know it's a foobar specific issue at this point, but adding that to LMS it's a general safeguard, like it has already been put in otherplaces of S:W:Player.pm (~line 1696) to *not* send icy-metadata when this is not a proper stream.