### PR TITLE
calculate seekdata in HTTP::open() is only timeOffset is provided

### DIFF
--- a/Slim/Formats/RemoteStream.pm
+++ b/Slim/Formats/RemoteStream.pm
@@ -124,6 +124,16 @@ sub new {
 }
 
 sub open {
+	my ($self, $args) = @_;
+	my $song = $args->{'song'};
+	
+	# last chance to get the byte offset if not already provided	
+	if ($song && $song->seekdata && $song->seekdata->{'timeOffset'} && !$song->seekdata->{'sourceStreamOffset'}) {  
+		my $seekdata = $song->getSeekData($song->seekdata->{'timeOffset'});
+		$song->seekdata($seekdata) if $seekdata;
+		main::INFOLOG && $log->info("Adding seekdata ", Data::Dump::dump($song->seekdata));
+	}	
+	
 	shift->request(@_);
 }
 


### PR DESCRIPTION
Like for File::open, there are cases where only the time offset of seek data is provided (e.g. when using a PlayList, Jump command with a seekdata, user wants a time not a bytes offset). We then must calculate, if possible, such offset right before sending the HTTP request. This did not happen when seeking as StreamingController::JumpToTime does the calculation. This worked with File::open because it does calculate the seekdata during open