### PR TITLE
seekdata must be calculated later, in song->open()

### DIFF
--- a/Slim/Formats/RemoteStream.pm
+++ b/Slim/Formats/RemoteStream.pm
@@ -124,16 +124,6 @@ sub new {
 }
 
 sub open {
-	my ($self, $args) = @_;
-	my $song = $args->{'song'};
-	
-	# last chance to get the byte offset if not already provided	
-	if ($song && $song->seekdata && $song->seekdata->{'timeOffset'} && !$song->seekdata->{'sourceStreamOffset'}) {  
-		my $seekdata = $song->getSeekData($song->seekdata->{'timeOffset'});
-		$song->seekdata($seekdata) if $seekdata;
-		main::INFOLOG && $log->info("Adding seekdata ", Data::Dump::dump($song->seekdata));
-	}	
-	
 	shift->request(@_);
 }
 

--- a/Slim/Player/Protocols/HTTPS.pm
+++ b/Slim/Player/Protocols/HTTPS.pm
@@ -58,7 +58,7 @@ sub new {
 	# used for non blocking I/O
 	${*$sock}{'_sel'}    = IO::Select->new($sock);
 
-	return $sock->request($args);
+	return $sock->open($args);
 }
 
 sub close {

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -362,6 +362,14 @@ sub open {
 	main::INFOLOG && $log->info($url);
 
 	$self->seekdata($seekdata) if $seekdata;
+
+	# last chance to get the byte offset if not already provided	
+	if ($self->seekdata && $self->seekdata->{'timeOffset'} && !$self->seekdata->{'sourceStreamOffset'}) {  
+		my $seekdata = $self->getSeekData($self->seekdata->{'timeOffset'});
+		$self->seekdata($seekdata) if $seekdata;
+		main::INFOLOG && $log->info("Adding seekdata ", Data::Dump::dump($self->seekdata));
+	}	
+
 	my $sock;
 	my $format = Slim::Music::Info::contentType($track);
 


### PR DESCRIPTION
Unfortunately, calculating sourceStreamOffset in Remotestream::ipen is not enough for two reasons

1- Protocols::HTTPS was calling request() in its new() instead of open() (that's corrected)
2- In direct mode, open() is not called, only requestString and it can be overloaded by plugin, so that does not seem a good idea to put seekdata update there

So the only place that is guaranted to be used is $song->open(). It's a bit unfortunate to put it there as it's less elegant than putting it in the protocol handler's open (and it's redundant with File::open that happens later) but that will cover all cases at least