### PR TITLE
Update to MP3, FLAC, Ogg and WMA Formats to use BPM tags.

### DIFF
--- a/Slim/Formats/APE.pm
+++ b/Slim/Formats/APE.pm
@@ -37,6 +37,7 @@ use Audio::Scan;
 my %tagMapping = (
 	'TRACK'	       => 'TRACKNUM',
 	'DATE'         => 'YEAR',
+	'BPM'          => 'BPM',
 	'DISCNUMBER'   => 'DISC',
 	'ALBUM ARTIST' => 'ALBUMARTIST', # bug 10724 - support APEv2 Album Artist
 );
@@ -75,6 +76,9 @@ sub doTagMapping {
 			$tags->{$new} = delete $tags->{$old};
 		}
 	}
+
+	# Sometimes the BPM is not an integer so we try to convert.
+	$tags->{BPM} = int($tags->{BPM}) if defined $tags->{BPM};
 	
 	# Flag if we have embedded cover art
 	if ( exists $tags->{'COVER ART (FRONT)'} ) {

--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -43,6 +43,7 @@ my %tagMapping = (
 	'DISCNUMBER'                => 'DISC',
 	'DISCTOTAL'                 => 'DISCC',
 	'URL'                       => 'URLTAG',
+	'BPM'                       => 'BPM',
 	'MUSICBRAINZ_SORTNAME'      => 'ARTISTSORT',
 	'MUSICBRAINZ_ALBUMARTIST'   => 'ALBUMARTIST',
 	'MUSICBRAINZ_ALBUMARTISTID' => 'MUSICBRAINZ_ALBUMARTIST_ID',
@@ -248,6 +249,12 @@ sub _doTagMapping {
 		}
 
 		($tags->{YEAR} = $tags->{DATE}) =~ s/.*(\d\d\d\d).*/$1/;
+	}
+	if (defined $tags->{BPM}) {
+		# Make the BPM an integer by dropping digits after decimal point.
+		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
+			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
+		}
 	}
 }
 

--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -250,12 +250,9 @@ sub _doTagMapping {
 
 		($tags->{YEAR} = $tags->{DATE}) =~ s/.*(\d\d\d\d).*/$1/;
 	}
-	if (defined $tags->{BPM}) {
-		# Make the BPM an integer by dropping digits after decimal point.
-		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
-			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
-		}
-	}
+
+	# Sometimes the BPM is not an integer so we try to convert.
+	$tags->{BPM} = int($tags->{BPM}) if defined $tags->{BPM};
 }
 
 sub _addInfoTags {

--- a/Slim/Formats/MP3.pm
+++ b/Slim/Formats/MP3.pm
@@ -407,6 +407,13 @@ sub doTagMapping {
 		
 		$tags->{YEAR} = $year;
 	}
+
+	if (defined $tags->{BPM}) {
+		# Make the BPM an integer by dropping digits after decimal point.
+		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
+			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
+		}
+	}
 	
 	# Clean up comments
 	if ( $tags->{COMMENT} && ref $tags->{COMMENT} eq 'ARRAY' ) {

--- a/Slim/Formats/MP3.pm
+++ b/Slim/Formats/MP3.pm
@@ -408,12 +408,8 @@ sub doTagMapping {
 		$tags->{YEAR} = $year;
 	}
 
-	if (defined $tags->{BPM}) {
-		# Make the BPM an integer by dropping digits after decimal point.
-		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
-			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
-		}
-	}
+	# Sometimes the BPM is not an integer so we try to convert.
+	$tags->{BPM} = int($tags->{BPM}) if defined $tags->{BPM};
 	
 	# Clean up comments
 	if ( $tags->{COMMENT} && ref $tags->{COMMENT} eq 'ARRAY' ) {

--- a/Slim/Formats/Ogg.pm
+++ b/Slim/Formats/Ogg.pm
@@ -38,6 +38,7 @@ my %tagMapping = (
 	'TRACKNUMBER'               => 'TRACKNUM',
 	'DISCNUMBER'                => 'DISC',
 	'URL'                       => 'URLTAG',
+	'BPM'                       => 'BPM',
 	'MUSICBRAINZ_SORTNAME'      => 'ARTISTSORT',
 	'MUSICBRAINZ_ALBUMARTIST'   => 'ALBUMARTIST',
 	'MUSICBRAINZ_ALBUMARTISTID' => 'MUSICBRAINZ_ALBUMARTIST_ID',
@@ -94,6 +95,13 @@ sub getTag {
 	# Parse the date down to just the year, for compatibility with other formats
 	if (defined $tags->{DATE} && !defined $tags->{YEAR}) {
 		($tags->{YEAR} = $tags->{DATE}) =~ s/.*(\d\d\d\d).*/$1/;
+	}
+
+	if (defined $tags->{BPM}) {
+		# Make the BPM an integer by dropping digits after decimal point.
+		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
+			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
+		}
 	}
 
 	# Add additional info

--- a/Slim/Formats/Ogg.pm
+++ b/Slim/Formats/Ogg.pm
@@ -97,12 +97,8 @@ sub getTag {
 		($tags->{YEAR} = $tags->{DATE}) =~ s/.*(\d\d\d\d).*/$1/;
 	}
 
-	if (defined $tags->{BPM}) {
-		# Make the BPM an integer by dropping digits after decimal point.
-		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
-			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
-		}
-	}
+	# Sometimes the BPM is not an integer so we try to convert.
+	$tags->{BPM} = int($tags->{BPM}) if defined $tags->{BPM};
 
 	# Add additional info
 	$tags->{SIZE}	  = $info->{file_size};

--- a/Slim/Formats/WMA.pm
+++ b/Slim/Formats/WMA.pm
@@ -68,12 +68,8 @@ sub getTag {
 		}
 	}
 
-	if (defined $tags->{BPM}) {
-		# Make the BPM an integer by dropping digits after decimal point.
-		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
-			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
-		}
-	}
+	# Sometimes the BPM is not an integer so we try to convert.
+	$tags->{BPM} = int($tags->{BPM}) if defined $tags->{BPM};
 
 	# Add additional info
 	my $stream = $info->{streams}->[0];

--- a/Slim/Formats/WMA.pm
+++ b/Slim/Formats/WMA.pm
@@ -18,6 +18,7 @@ my $sourcelog = logger('player.source');
 my %tagMapping = (
 	'Author'                => 'ARTIST',
 	'Title'                 => 'TITLE',
+	'WM/BeatsPerMinute'     => 'BPM',
 	'WM/AlbumArtist'        => 'ALBUMARTIST',
 	'WM/AlbumTitle'         => 'ALBUM',
 	'WM/Composer'           => 'COMPOSER',
@@ -64,6 +65,13 @@ sub getTag {
 	while ( my ($old, $new) = each %tagMapping ) {
 		if ( exists $tags->{$old} ) {
 			$tags->{$new} = delete $tags->{$old};
+		}
+	}
+
+	if (defined $tags->{BPM}) {
+		# Make the BPM an integer by dropping digits after decimal point.
+		if ($tags->{BPM} =~ m|^\d+\.\d+$|) {
+			($tags->{BPM} = $tags->{BPM}) =~ s/^(\d+)(\.\d+)$/$1/;
 		}
 	}
 


### PR DESCRIPTION
Changes to 4 files in Slim/Formats to enable slimserver to use Beat-Per-Minute (BPM) tempo tag information in MP3, FLAC, Ogg and WMA files. The Linux package BPM-TOOLS can be used to tag files with BPM information and this PR enables slimserver to take advantage of this.