### PR TITLE
Shuffle for track.year

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -1727,7 +1727,7 @@ sub playlistXtracksCommand {
 		@tracks = _playlistXtracksCommand_parseSearchTerms($client, $what, $cmd);
 	}
 
-	if ( scalar @tracks && $what =~ /track\.titlesearch|contributor\.namesearch|genre\.id/i ) {
+	if ( scalar @tracks && $what =~ /track\.titlesearch|contributor\.namesearch|genre\.id|track\.year/i ) {
 		if ($prefs->get('useBalancedShuffle')) {
 			my $categoryMethod = 'artistName';
 			my $categoryRemoteItem = 'artist';


### PR DESCRIPTION
Add 'track.year=' as a category that's always returned shuffled when ['playlist', 'loadtracks'] is called from jsonrpc.js. 
MediaServer is getting a new command to 'play songs from <year>' and if this change is not made then the results will always be in the same order.