### PR TITLE
Give some time for "what's new" podcast search

### DIFF
--- a/Slim/Plugin/Podcast/PodcastIndex.pm
+++ b/Slim/Plugin/Podcast/PodcastIndex.pm
@@ -14,6 +14,7 @@ use JSON::XS::VersionOneAndTwo;
 use Digest::SHA1 qw(sha1_hex);
 use MIME::Base64;
 use URI::Escape;
+use List::Util qw(max);
 
 use Slim::Utils::Prefs;
 use Slim::Utils::Log;
@@ -119,7 +120,7 @@ sub newsHandler {
 			{
 				cache => 1,
 				expires => 300,
-				timeout => 15,
+				timeout => max(15, $count * 2),
 			},
 		)->get($url, @$headers);
 	}


### PR DESCRIPTION
I'm not 100% sure but I've seen a few cases where the "what's new" on podcasts does not work: a first list is displayed and when clicking on one item, a different one is played. 

Because queries are cached, the only rational explanation I have is that when there are a lot of feeds, the first swarm of requests is taking too much time and some timeout. Then, because LMS always redescend the branches to access a leaf, when the queries are re-done to actually play an item, the missing ones are executed and the returned list is different than the initial one and because it uses indexes from the initial list, we end up playing something else.

This PR tries to give a min time of 15s in anycase, but expands it above if we have more feeds, like 2 seconds  per feed.