### PR TITLE
Logitech#769 - Rollback type coercion of message 'id' to number.

### DIFF
--- a/Slim/Web/Cometd.pm
+++ b/Slim/Web/Cometd.pm
@@ -158,8 +158,7 @@ sub handler {
 		# Issue #765 - For comet meta messages handshake, connect, reconnect, disconnect, subscribe, unsubscribe populate 'id' field on response to ensure compatibility with the readily available npm comet library.
 		# obtain 'id' from outer object if present, otherwise default to  - Here we use different variable name '$msgid' as '$id' is defined for use within slim/subscribe channel.
 		my $msgid = $obj->{id} || '';
-		$msgid   *= 1.0 if $msgid;
-
+		
 		if ( ref $obj ne 'HASH' ) {
 			sendResponse(
 				@{$conn},


### PR DESCRIPTION
We want to rely solely on the data type that is sent by the comet library or if not present, create an empty string.

The JavaScript code in the npm comet library that generates message ids always coerces to a string is as follows:

function _nextMessageId() {
   const result = ++_messageId;
   return '' + result;
}