### PR TITLE
Fix player sync

### DIFF
--- a/Changelog8.html
+++ b/Changelog8.html
@@ -56,6 +56,7 @@
 		<li><a href="https://github.com/Logitech/slimserver/pull/754">#754</a> - improve reliabilityof "what's new" podcast search (thanks philippe44!)</li>
 		<li><a href="https://github.com/Logitech/slimserver/pull/767">#767</a> - fix compatibility with standards compliant cometd libraries (thanks lynniemagoo!)</li>
 		<li><a href="https://github.com/Logitech/slimserver-vendor/issues/95">#95</a> - update faad helper binaries to fix a crash when the decoder call fails (thanks ralphy!)</li>
+		<li><a href="https://github.com/Logitech/slimserver/pull/777">#777</a> - When syncing with disconnected player through CLI, random player is synced</li>
 	</ul>
 	<br />
 

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -3076,9 +3076,9 @@ sub syncCommand {
 		my $buddy = Slim::Player::Client::getClient($newbuddy);
 
 		# try a player index
-		if (!defined $buddy) {
+		if (looks_like_number($newbuddy) && !defined $buddy) {
 			my @clients = Slim::Player::Client::clients();
-			if (looks_like_number($newbuddy) && defined $clients[$newbuddy]) {
+			if (defined $clients[$newbuddy]) {
 				$buddy = $clients[$newbuddy];
 			}
 		}

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -25,7 +25,7 @@ through Request.pm and the mechanisms it defines.
 
 use strict;
 
-use Scalar::Util qw(blessed);
+use Scalar::Util qw(blessed looks_like_number);
 use File::Spec::Functions qw(catfile);
 use File::Basename qw(basename);
 use Digest::MD5 qw(md5_hex);
@@ -3078,7 +3078,7 @@ sub syncCommand {
 		# try a player index
 		if (!defined $buddy) {
 			my @clients = Slim::Player::Client::clients();
-			if (defined $clients[$newbuddy]) {
+			if (looks_like_number($newbuddy) && defined $clients[$newbuddy]) {
 				$buddy = $clients[$newbuddy];
 			}
 		}


### PR DESCRIPTION
When calling the sync command through the CLI with an unknown playerid, the first player in the clients array would be added (instead of ignoring the unknown playerid). 

This PR should fix that.