### PR TITLE
Improve retries for non-live remote streams.

### DIFF
--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -922,9 +922,11 @@ sub _RetryOrNext {		# -> Idle; IF [shouldretry && canretry] THEN continue
 			_Stream($self, $event, {song => $song});
 			return;
 		} else {
-			if ($song->duration() - $elapsed < 10)		# check we have more than 10 seconds left to play.
+			$log->debug("Elapsed: " . $elapsed);
+			$log->debug("Duration: " . $song->duration());
+			if (!$elapsed || !$song->duration() || $song->duration() < $elapsed || $song->duration() - $elapsed < 10)		# check we have more than 10 seconds left to play.
 			{
-				if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Will not retry - track is within 10 seconds of end.")};
+				if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Will not retry - no player sync or track is within 10 seconds of end.")};
 			} else {
                         	# get seek data from protocol handler.
                         	if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Getting seek data from protocol handler.")};
@@ -1426,8 +1428,10 @@ sub _willRetry {
 	
 	# Have we managed to play at least 10 seconds of a track and retried fewer times than there are intervals?
 	my $elapsed = $self->playingSongElapsed();
+	$log->debug("Elapsed: " . $elapsed);
+        $log->debug("Duration: " . $song->duration());
         if ($song->retryData->{'count'} > scalar @retryIntervals || !$elapsed || $elapsed < 10 ||
-                !$song->duration() || ($song->duration() - $elapsed < 10)) {
+                !$song->duration() || $song->duration() < $elapsed || ($song->duration() - $elapsed < 10)) {
 		if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Will not retry - no player sync, too many retries or track within 10 seconds of start or end.")};
 		return 0;
 	}

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -924,7 +924,7 @@ sub _RetryOrNext {		# -> Idle; IF [shouldretry && canretry] THEN continue
 		} else {
 			$log->debug("Elapsed: " . $elapsed);
 			$log->debug("Duration: " . $song->duration());
-			if (!$elapsed || !$song->duration() || $song->duration() < $elapsed || $song->duration() - $elapsed < 10)		# check we have more than 10 seconds left to play.
+			if (!$elapsed || !$song->duration() || !($elapsed < $song->duration()) || $song->duration() - $elapsed < 10)		# check we have more than 10 seconds left to play.
 			{
 				if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Will not retry - no player sync or track is within 10 seconds of end.")};
 			} else {
@@ -1431,7 +1431,7 @@ sub _willRetry {
 	$log->debug("Elapsed: " . $elapsed);
         $log->debug("Duration: " . $song->duration());
         if ($song->retryData->{'count'} > scalar @retryIntervals || !$elapsed || $elapsed < 10 ||
-                !$song->duration() || $song->duration() < $elapsed || ($song->duration() - $elapsed < 10)) {
+                !$song->duration() || !($elapsed < $song->duration()) || ($song->duration() - $elapsed < 10)) {
 		if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Will not retry - no player sync, too many retries or track within 10 seconds of start or end.")};
 		return 0;
 	}

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -1426,8 +1426,9 @@ sub _willRetry {
 	
 	# Have we managed to play at least 10 seconds of a track and retried fewer times than there are intervals?
 	my $elapsed = $self->playingSongElapsed();
-	if ($song->retryData->{'count'} > scalar @retryIntervals || $elapsed < 10 || ($song->duration() - $elapsed < 10)) {
-		if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Will not retry - too many retries already or track is within 10 seconds of start or end.")};
+        if ($song->retryData->{'count'} > scalar @retryIntervals || !$elapsed || $elapsed < 10 ||
+                !$song->duration() || ($song->duration() - $elapsed < 10)) {
+		if ( main::DEBUGLOG && $log->is_debug ) {$log->debug("Will not retry - no player sync, too many retries or track within 10 seconds of start or end.")};
 		return 0;
 	}
 


### PR DESCRIPTION
The short story behind this commit is that with this change, attempts will be made to resume non-live remote streams which end because of a failure at the Player level, such as because of a data corruption, (as opposed to the Network level) when previously playback would have ended. This is most noticable on long running streams like those hosted on Mixcloud. It potentially relieves some of the symptoms reported in issue #130.

The longer story with some history is as follows:

The _willRetry subroutine was added to Slim::Player::StreamingController in version 7.6 of slimserver with the last commit to change the subroutine in September 2011. The functional purpose of the subroutine is to retry playing a stream when if fails at the Player level. However it would appear via code inspection and testing that that _willRetry will not run as intended when called from at least two out of the three subroutines from which it is called and it seems likely that it's never worked.

One of the first things that _willRetry does on line 1394 is check whether $retryData is defined.

However the only place we have found $retryData to be assigned is at line 921 of StreamingController in the _RetryOrNext subroutine, which is only called from the ReadyToStream state.

$retryData does appear in the constructor of Slim::Player::Song at line 74 but is not mentioned anywhere else in the codebase that we can find or in any of the plugins that we've searched.

And looking at the expected contents of $retryData in StreamingController, we don't think that it was ever intended to be defined outside of StreamingController. The expected contents are "start" and "count" where the first is the time when StreamingController started retrying and the second is the number of retries.

The three places that _willRetry is called from are: _Stream, _StopNextIfMore and _SyncStopNext.

_StopNextIfMore and _SyncStopNext are both called when in the StreamingFailed state (lines 205 and 206). But $retryData will have been set to undef in _Playing at line 370 which will have been called before the StreamingFailed state can be reached.

So, as far as we can tell, _willRetry will always return 0 at line 1396 when called from _StopNextIfMore or _SyncStopNext.

Also, the current implentation only handles remote radio streams where playback is restarted from the begining. See on line 918 the check for isLive and line 921 where seekdata is omitted in the call to _Stream.

In this commit we have attempted to understand how the _willRetry subroutine was originally intended to work and implement the same logic. So we've kept the same retry intervals and retry limits for example.

When streaming to players that need the remote stream to be transcoded, such as legacy hardware players which cannot play AAC for example, the same problem manifests itself but the code to relieve the issue needed to be added to the _RetryOrNext subroutine. An else statement has been added to the inner if statement in the _RetryOrNext subroutine so previously functioning restarts of radio streams should be unchanged but now transcoded non-live streams will also be restarted.

The test case we have been using to to develop this commit is using the Mixcloud plugin with the following stream which usually fails to play to completion:

	https://www.mixcloud.com/johndigweed/transitions-with-john-digweed-and-denney/

It is not entirely predictable if and when this stream will fail so testing this commit with it requires patience and a lot of time.

Failure at the Player level seems to occur more frequently when using "Normal streaming" on the Settings -> Advanced -> Network screen than when using "Persistent mode". We do not know why this would be the case but would suggest that logically the difference is likely to be in the way the remote server handles the streamed data.