### PR TITLE
Avoid unintentional matching of subwords in notifications

### DIFF
--- a/Slim/Control/Request.pm
+++ b/Slim/Control/Request.pm
@@ -2398,19 +2398,21 @@ sub __matchingRequest {
 # return compiled regexp representing the $possibleNames array of arrays
 sub __requestRE {
 	my $possibleNames = shift || return qr /./;
-	my @regexp = ();
+	my @reParts = ();
 
 	for my $names (@$possibleNames) {
 
 		# Bracket each name using word boundaries to avoid
 		# "play" matching "play", "playlist", and "display".
 
-		push @regexp,
-			'(?:' . join('|', map { "\\b$_\\b" } @$names) . ')'
-			if scalar @$names;
+		if (scalar @$names) {
+			push @reParts,
+				'(?:' . join('|', map { "\\b$_\\b" } @$names) . ')';
+		}
 	}
 
-	return qr /${\(join(',', @regexp))}/;
+	my $re = join(',', @reParts);
+	return qr /$re/;
 }
 
 # update the super filter used by notify

--- a/Slim/Control/Request.pm
+++ b/Slim/Control/Request.pm
@@ -2404,7 +2404,13 @@ sub __requestRE {
 
 	for my $names (@$possibleNames) {
 		$regexp .= ',' if $i++;
-		$regexp .= (scalar @$names > 1) ? '(?:' . join('|', @$names) . ')' : $names->[0];
+
+		# Bracket each name using word boundaries to avoid
+		# "play" matching "play", "playlist", and "display".
+
+		my @namelist;
+		push @namelist, '\b' . $_ . '\b' for (@$names);
+		$regexp .= '(?:' . join('|', @namelist) . ')';
 	}
 
 	return qr /$regexp/;

--- a/Slim/Control/Request.pm
+++ b/Slim/Control/Request.pm
@@ -2398,22 +2398,19 @@ sub __matchingRequest {
 # return compiled regexp representing the $possibleNames array of arrays
 sub __requestRE {
 	my $possibleNames = shift || return qr /./;
-	my $regexp = '';
-
-	my $i = 0;
+	my @regexp = ();
 
 	for my $names (@$possibleNames) {
-		$regexp .= ',' if $i++;
 
 		# Bracket each name using word boundaries to avoid
 		# "play" matching "play", "playlist", and "display".
 
-		my @namelist;
-		push @namelist, '\b' . $_ . '\b' for (@$names);
-		$regexp .= '(?:' . join('|', @namelist) . ')';
+		push @regexp,
+			'(?:' . join('|', map { "\\b$_\\b" } @$names) . ')'
+			if scalar @$names;
 	}
 
-	return qr /$regexp/;
+	return qr /${\(join(',', @regexp))}/;
 }
 
 # update the super filter used by notify


### PR DESCRIPTION
Use \b to bracket words when creating regular expressions to avoid words matching subwords (eg "play" matching "playlist" and "display").

Fixes #622.