### PR TITLE
Strawberry perl windows sysread function returns POSIX error codes

### DIFF
--- a/Slim/Utils/Errno.pm
+++ b/Slim/Utils/Errno.pm
@@ -39,11 +39,19 @@ our @EXPORT = qw(EWOULDBLOCK EINPROGRESS EINTR ECHILD EBADF);
 
 BEGIN {
         if (main::ISWINDOWS) {
-                *EINTR       = sub () { 10004 };
-                *EBADF       = sub () { 10009 };
-                *ECHILD      = sub () { 10010 };
-                *EWOULDBLOCK = sub () { 10035 };
-                *EINPROGRESS = sub () { 10036 };
+		if ($] < 5.032001) {
+			*EINTR       = sub () { 10004 };
+			*EBADF       = sub () { 10009 };
+			*ECHILD      = sub () { 10010 };
+			*EWOULDBLOCK = sub () { 10035 };
+			*EINPROGRESS = sub () { 10036 };
+		} else {
+			*EINTR       = sub () { 4 };
+			*EBADF       = sub () { 9 };
+			*ECHILD      = sub () { 10 };
+			*EWOULDBLOCK = sub () { 140 };
+			*EINPROGRESS = sub () { 112 };
+		}
         } else {
                 require Errno;
                 import Errno qw(EWOULDBLOCK EINPROGRESS EINTR ECHILD EBADF);

--- a/Slim/Utils/Errno.pm
+++ b/Slim/Utils/Errno.pm
@@ -39,7 +39,7 @@ our @EXPORT = qw(EWOULDBLOCK EINPROGRESS EINTR ECHILD EBADF);
 
 BEGIN {
         if (main::ISWINDOWS) {
-		if ($] < 5.032001) {
+		if (main::ISACTIVEPERL) {
 			*EINTR       = sub () { 10004 };
 			*EBADF       = sub () { 10009 };
 			*ECHILD      = sub () { 10010 };

--- a/slimserver.pl
+++ b/slimserver.pl
@@ -56,6 +56,9 @@ use constant SLIM_SERVICE => 0;
 use constant NOUPNP       => 0;
 
 use Config;
+
+use constant ISACTIVEPERL => ( $Config{cf_email} =~ /ActiveState/i ) ? 1 : 0;
+
 my %check_inc;
 $ENV{PERL5LIB} = join $Config{path_sep}, grep { !$check_inc{$_}++ } @INC;
 


### PR DESCRIPTION
whereas ActiveState perl returns windows sockets (WSA) error codes, support both.