### PR TITLE
Bugfix: HTTPSocks.pm - Binary OR used by mistake - Logical OR needed

### DIFF
--- a/Slim/Networking/Async/HTTP.pm
+++ b/Slim/Networking/Async/HTTP.pm
@@ -133,7 +133,6 @@ sub new_socket {
 
 			my %args = @_;
 
-			# Failed. Try again with an explicit SNI.
 			$args{SSL_hostname} //= $args{Host};
 			$args{SSL_verify_mode} //= Net::SSLeay::VERIFY_NONE() if $prefs->get('insecureHTTPS');
 

--- a/Slim/Networking/Async/Socket/HTTPSocks.pm
+++ b/Slim/Networking/Async/Socket/HTTPSocks.pm
@@ -13,7 +13,7 @@ sub new {
 	# change PeerAddr to proxy (no deepcopy needed)
 	my %params = %args;
 	$params{PeerAddr} = $args{ProxyAddr};
-	$params{PeerPort} = $args{ProxyPort} | 1080;
+	$params{PeerPort} = $args{ProxyPort} || 1080;
 	$params{Blocking} => 1;
 	
 	# and connect parent's class to it (better block)


### PR DESCRIPTION
I fell across these two items by chance recently, so offer them up while fresh in my mind.

- **Slim::Networking::Async::Socket::HTTPSocks**

The binary OR operator `|` has been inadvertently used in place of the intended logical OR operator `||`. 

This was typo in PR #562 - flac & socks fixes. Refer commit: https://github.com/Logitech/slimserver/commit/907a6a

The error/typo is quite obvious when you examine the commit, but @philippe44 (author) might like to confirm.

It could result in some 'hard to fathom out' socks connection failures if left as is.

- **Slim::Networking::Async::HTTP**

Remove redundant comment. The code to which this referred was refactored away some years ago.
