### PR TITLE
Tweaks to comment presentation, hyperlinks in lyrics

### DIFF
--- a/HTML/Classic/slimserver.css
+++ b/HTML/Classic/slimserver.css
@@ -451,6 +451,10 @@ div#homeMenu {
 	padding-right: 80px;
 }
 
+.browsedbListItem .wrappedMenuItem {
+	display: inline-table;
+}
+
 .progressBar {
 	padding: 6px 0;
 }

--- a/HTML/Default/slimserver.css
+++ b/HTML/Default/slimserver.css
@@ -479,6 +479,11 @@ div.pagetitleWithIcon {
 	padding-left: 6px;
 }
 
+.browsedbListItem .wrappedMenuItem {
+	display: inline-table;
+	padding-left: 6px; /* added indent helps if browser window is too narrow for content */
+}
+
 .browsedbControls, .playlistControls, .browsedbRightControls, .browsedbLeftControls {
 	visibility: hidden;
 	position: absolute;

--- a/HTML/Default/xmlbrowser.html
+++ b/HTML/Default/xmlbrowser.html
@@ -377,6 +377,10 @@ useSpecialExt="-browse" %]
 								IF !title.defined || title == ''; title = item.title; END;
 								title = title | html | html_line_break;
 								IF item.parseURLs; title = title FILTER parseURIs; END;
+								IF item.wrap;
+									# Put wrapped text into a single element. Improves display of multiline comments & lyrics.
+									title = "<span class=\"wrappedMenuItem\"> $title </span>";
+								END;
 								title
 							%]
 

--- a/HTML/EN/slimserver.css
+++ b/HTML/EN/slimserver.css
@@ -111,6 +111,9 @@ div#browsedbList {
 	position: relative;
 }
 
+.browsedbListItem .wrappedMenuItem {
+}
+
 .browsedbListItemFullWidth {
 }
 

--- a/HTML/EN/xmlbrowser.html
+++ b/HTML/EN/xmlbrowser.html
@@ -260,6 +260,10 @@
 							IF !title.defined || title == ''; title = item.title; END;
 							title = title | html | html_line_break;
 							IF item.parseURLs; title = title FILTER parseURIs; END;
+							IF item.wrap;
+								# Put wrapped text into a single element. Improves display of multiline comments & lyrics.
+								title = "<span class=\"wrappedMenuItem\"> $title </span>";
+							END;
 							title
 						%]
 						[% IF item.weblink || !item.type.match('^text') %]

--- a/Slim/Menu/TrackInfo.pm
+++ b/Slim/Menu/TrackInfo.pm
@@ -791,7 +791,6 @@ sub infoComment {
 	my $item;
 	my $comment;
 
-	# make urls in comments into links
 	for my $c ($track->comment) {
 
 		next unless defined $c && $c !~ /^\s*$/;
@@ -843,6 +842,7 @@ sub infoLyrics {
 					wrap => 1,
 					name => $lyrics,
 					label => 'LYRICS',
+					parseURLs => 1
 				},
 			],
 

--- a/Slim/Schema/RemoteTrack.pm
+++ b/Slim/Schema/RemoteTrack.pm
@@ -153,9 +153,9 @@ sub _mergeComments {
 		my $comment;
 
 		foreach my $c (@$new) {
-			# put a slash between multiple comments.
-			$comment .= ' / ' if $comment;
-			$c =~ s/^eng(.*)/$1/;
+			# join multiple comments into a single multi-line comment
+			# consistent with Slim::Schema::Track::comment
+			$comment .= "\n" if $comment;
 			$comment .= $c;
 		}
 
@@ -360,7 +360,8 @@ sub setAttributes {
 				my @splitList = split(/\s+/, ($prefs->get('splitList') || ''));
 				$separator = ($splitList[0] || ';') . ' ';
 			}
-			$value = join($separator, @$value);
+			# - but don't join if it's a comment - the 'comment' method handles this
+			$value = join($separator, @$value) unless $key eq '_comment';
 		}
 
 		main::DEBUGLOG && $log->is_debug && defined $self->$key() && $self->$key() ne $value &&

--- a/Slim/Schema/Track.pm
+++ b/Slim/Schema/Track.pm
@@ -240,9 +240,9 @@ sub comment {
 
 		next unless $c;
 
-		# put a slash between multiple comments.
-		$comment .= ' / ' if $comment;
-		$c =~ s/^eng(.*)/$1/;
+		# join multiple comments into a single multi-line comment
+		# consistent with Slim::Schema::RemoteTrack::comment
+		$comment .= "\n" if $comment;
 		$comment .= $c;
 	}
 

--- a/Slim/Web/Pages/Common.pm
+++ b/Slim/Web/Pages/Common.pm
@@ -165,7 +165,6 @@ sub addSongInfo {
 			$params->{isFavorite} = defined Slim::Utils::Favorites->new($client)->findUrl($url);
 		}
 
-		# make urls in comments into links
 		for my $comment ($track->comment) {
 
 			next unless defined $comment && $comment !~ /^\s*$/;


### PR DESCRIPTION
These proposed changes add a few "tweaks" to the treatment and presentation of trackinfo comments, and extend the ability to follow hyperlinks to trackinfo lyrics (where these are derived from a music file tag).

I think that most users wouldn't notice the changes. I think they make small, marginal, improvements, but that's a matter of taste/personal preference.


- Add link support for lyrics in Default & Classic skins

Adds hyperlink support to the rendering of lyrics in the web interface. Some publishers do include hyperlinks in their lyrics tags, and it would be good to be able to follow these. It uses the same scheme as recently implemented in respect of hyperlinks in comments.

- Treat multiple comments as multi-line, i.e. join with "\n" in place of "/"

Some file formats allow for inclusion of multiple comment tags. LMS joins these into one composite comment text, by concatenating with a " / " separator. While this works reasonably well with short comments, I find that longer comments become difficult to read.

This change has the comments joined with a newline, turning then into multi-line comments and, in my view, easier to follow.

- Tweak display of multi-line and lyrics info items in web interface

This is a very small change to the Default & Classic skins. Its intention is to keep text in longer comments and lyrics grouped together a little better than they are now, and make them easier to read. It would not impact shorter comments adversely.
