### PR TITLE
make lyrics on Default skin songinfo page collapsible

### DIFF
--- a/Changelog8.html
+++ b/Changelog8.html
@@ -16,6 +16,7 @@
 		<li><a href="https://github.com/Logitech/slimserver/pull/846">#846</a> - Improve display of multiline lyrics and comments in the web UI (thanks mw9!)</li>
 		<li>Move persist.db out of the cache folder - it's music data which can't be restored from the music files.</li>
 		<li>Log warning if the server's time seems to be off (only if MySqueezebox integration is enabled).</li>
+		<li><a href="https://github.com/Logitech/slimserver/pull/846">#862</a> - Make lyrics on Default skin songinfo page collapsible</li>
 	</ul>
 	<br />
 

--- a/HTML/Default/skin.css
+++ b/HTML/Default/skin.css
@@ -263,25 +263,3 @@ td.sort-asc .x-grid3-hd-inner, td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 .sort-desc .x-grid3-sort-icon {
 	background-image: url('data:image/gif;base64,R0lGODlhDQAFAJEAAAAAAIuLi+zs7AAAACH5BAkKAAMALAAAAAANAAUAAAIPVI4hw2y5WntKWhOtzLYAADs=');
 }
-
-/* song info lyrics */
-#songinfo_lyrics details > summary {
-	list-style: none;
-	cursor: pointer;
-	outline: none;
-}
-#songinfo_lyrics summary::-webkit-details-marker {
-	display: none;
-}
-
-#songinfo_lyrics summary::after {
-	content: ' ▸';
-}
-
-#songinfo_lyrics details[open] summary:after {
-	content: " ▾";
-}
-
-#songinfo_lyrics p {
-	padding: 8px 0px 8px 10px;
-}

--- a/HTML/Default/skin.css
+++ b/HTML/Default/skin.css
@@ -219,7 +219,7 @@
 /* html/images/slim-ext/btn-arrow.gif */
 .x-btn-menu-arrow-wrap .x-btn-center button,
 .x-btn-mc em.x-btn-split,
-.x-btn-over .x-btn-mc em.x-btn-split, .x-btn-click .x-btn-mc em.x-btn-split, 
+.x-btn-over .x-btn-mc em.x-btn-split, .x-btn-click .x-btn-mc em.x-btn-split,
 .x-btn-menu-active .x-btn-mc em.x-btn-split, .x-btn-pressed .x-btn-mc em.x-btn-split {
 	background-image: url('data:image/gif;base64,R0lGODlhCQANAJECAL+/v////////wAAACH5BAHoAwIALAAAAAAJAA0AAAIYhI5nicviWEwm2BsWDhBdlXDg05FTQwoFADs=');
 }
@@ -262,4 +262,26 @@ td.sort-asc .x-grid3-hd-inner, td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 /* html/images/slim-ext/sort_desc.gif */
 .sort-desc .x-grid3-sort-icon {
 	background-image: url('data:image/gif;base64,R0lGODlhDQAFAJEAAAAAAIuLi+zs7AAAACH5BAkKAAMALAAAAAANAAUAAAIPVI4hw2y5WntKWhOtzLYAADs=');
+}
+
+/* song info lyrics */
+#songinfo_lyrics details > summary {
+	list-style: none;
+	cursor: pointer;
+	outline: none;
+}
+#songinfo_lyrics summary::-webkit-details-marker {
+	display: none;
+}
+
+#songinfo_lyrics summary::after {
+	content: ' ▸';
+}
+
+#songinfo_lyrics details[open] summary:after {
+	content: " ▾";
+}
+
+#songinfo_lyrics p {
+	padding: 8px 0px 8px 10px;
 }

--- a/HTML/Default/slimserver.css
+++ b/HTML/Default/slimserver.css
@@ -1616,3 +1616,25 @@ td.sort-asc .x-grid3-hd-inner, td.x-grid3-hd-menu-open .x-grid3-hd-inner {
 .x-grid3-cell-inner  {
 	white-space:normal!important;
 }
+
+/* song info lyrics */
+#songinfo_lyrics details > summary {
+	list-style: none;
+	cursor: pointer;
+	outline: none;
+}
+#songinfo_lyrics summary::-webkit-details-marker {
+	display: none;
+}
+
+#songinfo_lyrics summary::after {
+	content: ' ▸';
+}
+
+#songinfo_lyrics details[open] summary:after {
+	content: " ▾";
+}
+
+#songinfo_lyrics p {
+	padding: 8px 0px 8px 10px;
+}

--- a/HTML/Default/xmlbrowser.html
+++ b/HTML/Default/xmlbrowser.html
@@ -368,8 +368,10 @@ useSpecialExt="-browse" %]
 						[% PROCESS $item.web.value %]
 					[% ELSE %]
 						[% IF item.label %]
+							[% IF item.label == "LYRICS" %]<span id="songinfo_lyrics"><details><summary>[% END %]
 							[% item.label | string %]
 							[%- stringCOLON %]
+							[% IF item.label == "LYRICS" %]</summary>[% END %]
 						[% END %]
 						[% WRAPPER weblink %]
 							[% title = item.web.value;
@@ -466,7 +468,9 @@ useSpecialExt="-browse" %]
 		<a href="[% UNLESS item.image.match("^(\/|http)") %][% webroot %][% END %][% item.image %]" target="_blank" [% slideshowHelpers %]>
 	[% END %]
 
+	[% IF item.label == "LYRICS" %]<p>[% END %]
 	[% content %]
+	[% IF item.label == "LYRICS" %]</p></details></span>[% END %]
 
 	[% IF item.type == 'playlist' || item.weblink || item.link || !item.type.match('^text') %]
 		</a>


### PR DESCRIPTION
Lyrics on the LMS _Default skin_'s **song info** page would be displayed as collapsed by default. Items below lyrics wouldn't be pushed so far out of sight - and lyrics are just one click away.

To keep it simple it uses _html details/summary_ which has excellent browser support (exception: deprecated IE and Opera mini).