### PR TITLE
Populate the release year ('year') attribute for remote tracks in the player queue

### DIFF
--- a/Slim/Buttons/XMLBrowser.pm
+++ b/Slim/Buttons/XMLBrowser.pm
@@ -292,6 +292,7 @@ sub gotPlaylist {
 			secs    => $item->{'duration'},
 			bitrate => $item->{'bitrate'},
 			cover   => $item->{'cover'} || $item->{'image'} || $item->{'icon'},
+			year	=> $item->{'year'},
 		} );
 		
 		# This loop may have a lot of items and a lot of database updates
@@ -1316,6 +1317,7 @@ sub playItem {
 					secs    => $other->{'duration'},
 					bitrate => $other->{'bitrate'},
 					cover   => $other->{'cover'} || $other->{'image'} || $other->{'icon'},
+					year	=> $other->{'year'},
 				} );
 
 				# This loop may have a lot of items and a lot of database updates
@@ -1335,6 +1337,7 @@ sub playItem {
 				secs    => $item->{'duration'},
 				bitrate => $item->{'bitrate'},
 				cover   => $item->{'cover'} || $item->{'image'} || $item->{'icon'},
+				year	=> $item->{'year'},
 			} );
 			
 			$client->execute([ 'playlist', $action, $url, $title ]);

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4956,6 +4956,7 @@ sub _songData {
 			$remoteMeta->{B} = $remoteMeta->{buttons};
 			$remoteMeta->{L} = $remoteMeta->{info_link};
 			$remoteMeta->{t} = $remoteMeta->{tracknum};
+			$remoteMeta->{y} = $remoteMeta->{year};
 		}
 	}
 

--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -682,6 +682,7 @@ sub _cliQuery_done {
 				if ( $url ) {
 
 					main::INFOLOG && $log->info("$method $url");
+					main::DEBUGLOG && $log->is_debug && $log->debug("subFeed is " . Data::Dump::dump($subFeed));
 
 					# Set metadata about this URL
 					Slim::Music::Info::setRemoteMetadata( $url, {
@@ -690,6 +691,7 @@ sub _cliQuery_done {
 						secs    => $subFeed->{'duration'},
 						bitrate => $subFeed->{'bitrate'},
 						cover   => $subFeed->{'cover'} || $subFeed->{'image'} || $subFeed->{'icon'} || $request->getParam('icon'),
+						year	=> $subFeed->{'year'},
 					} );
 
 					$client->execute([ 'playlist', $method, $url ]);
@@ -721,6 +723,8 @@ sub _cliQuery_done {
 						$playIndex-- if defined($playIndex) && $playIndex >= scalar @urls;
 						next;
 					}
+					main::INFOLOG && $log->info("$method $url");
+					main::DEBUGLOG && $log->is_debug && $log->debug("item is " . Data::Dump::dump($item));
 
 					# Set metadata about this URL
 					Slim::Music::Info::setRemoteMetadata( $url, {
@@ -729,6 +733,7 @@ sub _cliQuery_done {
 						secs    => $item->{'duration'},
 						bitrate => $item->{'bitrate'},
 						cover   => $subFeed->{'cover'} || $subFeed->{'image'} || $subFeed->{'icon'} || $request->getParam('icon'),
+						year	=> $item->{'year'},
 					} );
 
 					main::idleStreams();

--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -453,8 +453,13 @@ sub setRemoteMetadata {
 		$attr->{BITRATE}   = $meta->{bitrate} * 1000;
 		$attr->{VBR_SCALE} = ( exists $cbr{ $meta->{bitrate} } ) ? undef : 1;
 	}
-
+	
+	if ( $meta->{year} ) {
+		$attr->{YEAR} = $meta->{year};
+	}
+	
 	if ( main::DEBUGLOG && $log->is_debug ) {
+		$log->debug( "meta data is " . Data::Dump::dump($meta) );
 		$log->debug( "Updating metadata for $url: " . Data::Dump::dump($attr) );
 	}
 

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -58,7 +58,9 @@ sub handleWebIndex {
 	my $asyncArgs = $args->{'args'};
 	my $item      = $args->{'item'} || {};
 	my $pageicon  = $Slim::Web::Pages::additionalLinks{icons}{$title};
-
+	
+	main::DEBUGLOG && $log->is_debug && $log->debug( "feed is :" . Data::Dump::dump($feed) );
+	
 	if ($title eq uc($title)) {
 		$title = string($title);
 	}
@@ -627,6 +629,7 @@ sub handleFeed {
 		if ( $url ) {
 
 			main::INFOLOG && $log->info("Playing/adding $url");
+			main::DEBUGLOG && $log->is_debug && $log->debug("streamItem is " . Data::Dump::dump($streamItem));
 
 			# Set metadata about this URL
 			Slim::Music::Info::setRemoteMetadata( $url, {
@@ -635,6 +638,7 @@ sub handleFeed {
 				secs    => $streamItem->{'duration'},
 				bitrate => $streamItem->{'bitrate'},
 				cover   => $streamItem->{'cover'} || $streamItem->{'image'} || $streamItem->{'icon'},
+				year	=> $streamItem->{'year'},
 			} );
 
 			$client->execute([ 'playlist', $action, $url ]);
@@ -669,6 +673,9 @@ sub handleFeed {
 			}
 
 			next if !$url;
+			
+			main::INFOLOG && $log->info("Playing/adding $url");
+			main::DEBUGLOG && $log->is_debug && $log->debug("item is " . Data::Dump::dump($item));
 
 			# Set metadata about this URL
 			Slim::Music::Info::setRemoteMetadata( $url, {
@@ -677,6 +684,7 @@ sub handleFeed {
 				secs    => $item->{'duration'},
 				bitrate => $item->{'bitrate'},
 				cover   => $item->{'cover'} || $item->{'image'} || $item->{'icon'},
+				year	=> $item->{'year'},
 			} );
 
 			main::idleStreams();


### PR DESCRIPTION
Many client player apps, including the Default skin, Material skin and Squeeze Ctrl, display the release year for tracks in the player queue as well as for the current track. For remote tracks, this attribute can be obtained from the track's metadata. However, the LMS code fails to pick it up correctly and all remote tracks in the player queue end up with a value of '0' in the 'year' attribute.  With this change, remote tracks for which the 'year' attribute is supplied in the metadata will have the value populated in the player queue. This currently includes all Radio Paradise tracks and, with an upcoming change to the Qobuz plugin, will also apply to tracks added to the queue from the plugin. It will also apply to tracks from any other subscription-based streaming services for which the 'year' attribute is populated. The changes have been thoroughly tested with remote radio streams including Radio Paradise, as well as with Qobuz, using multiple clients, including the LMS skins, Material Skin, Squeezer, Squeeze Ctrl and Orange (Open) Squeeze.

NOTE: To help others trying to navigate through this area of the code, a few new Debug logging entries were also added.