### PR TITLE
Add IR map to play presets with keys 0-9

### DIFF
--- a/IR/Default_with_0-9_as_presets.map
+++ b/IR/Default_with_0-9_as_presets.map
@@ -1,0 +1,13 @@
+# Buttons 0-9 play presets, the rest of the keys are handled by Default.map
+
+[common]
+0 = playPreset_0
+1 = playPreset_1
+2 = playPreset_2
+3 = playPreset_3
+4 = playPreset_4
+5 = playPreset_5
+6 = playPreset_6
+7 = playPreset_7
+8 = playPreset_8
+9 = playPreset_9


### PR DESCRIPTION
I'm not sure about this change so comments are welcome..

I use the numeric keys on a remote control to play presets on a squeezebox radio and wanted to do the same for some squeezelite-esp32 players that I have. I then noticed that I needed to change the key map to get the presets to work with the numeric keys.

If we add a key map like this to LMS, then maybe it's easier for other users who want presets 0-9 on numeric keys. I had some trouble finding good information on the IR key mapping and how to configure it. I ended up reading the perl code. It's also unfortunate that the key map setting is invisible in the player settings when there's only the default key map available - users may not understand that there is such a setting available (I didn't).

But.. maybe this isn't such a great idea..
* The new key map is quite specific and may not be interesting to others
* I don't understand which devices that use these key maps. Seems like the radio doesn't..
* Maybe I've misunderstood and/or broken something