### PR TITLE
Let reshuffle run also on single track playlist

### DIFF
--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -769,8 +769,6 @@ sub reshuffle {
 		return;
 	}
 
-	return if $songcount <= 1;
-
 	my $realsong = ${$listRef}[Slim::Player::Source::playingSongIndex($client)];
 
 	if (!defined($realsong) || $dontpreservecurrsong) {


### PR DESCRIPTION
If we don't let reshuffle run the client's shufflelist will be out of sync with the playlist.

The problem can be seen if you do:
1. Enable shuffle
2. Play a single track (playlist contains a single track)
3. Select another track to "play next"

Expected: The playlist should contain two tracks and the first track should still be playing while the second track is queued as next track.

Actual: The first track is playing, but the playlist indicates that it's the second track that's currently playing and the first track is no longer in the playlist.

The problem seems to be that the client's shufflelist remains empty after the first track is played. Then when the second track is added it is the only track added to shufflelist and the first track is lost.

It looks like this problem was introduced in 647d65e4ec.

I'm now partially reverting 647d65e4ec. The change that I'm reverting, was that an intentional change in 647d65e4ec? It doesn't look like the change matches with the commit message.