### PR TITLE
Show dynamic updates to remoteMetaData sample rate.

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4957,6 +4957,8 @@ sub _songData {
 			$remoteMeta->{L} = $remoteMeta->{info_link};
 			$remoteMeta->{t} = $remoteMeta->{tracknum};
 			$remoteMeta->{y} = $remoteMeta->{year};
+			$remoteMeta->{T} = $remoteMeta->{samplerate};
+			$remoteMeta->{I} = $remoteMeta->{samplesize};
 		}
 	}
 


### PR DESCRIPTION
Material Skin (and any other client depending on updates to remoteMetaData) was not being notified of dynamic changes to Qobuz sample rate due to downsampling.