### PR TITLE
Update Queries.pm (songinfo remote tag returns 1 or 0)

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5096,7 +5096,7 @@ sub _songData {
 			}
 
 			# correct values
-			if (($tag eq 'R' || $tag eq 'x') && $value == 0) {
+			if ($tag eq 'R' && $value == 0) {
 				$value = undef;
 			}
 			# we might need to proxy the image request to resize it


### PR DESCRIPTION
Should fix: the `songinfo` tags:x query returns nothing/undef when it should return 0. 

Only merge if this does not mess up things elsewhere.
