### PR TITLE
SqueezePlay.pm: correct regexp for fade_volume

### DIFF
--- a/Slim/Player/SqueezePlay.pm
+++ b/Slim/Player/SqueezePlay.pm
@@ -247,7 +247,7 @@ sub pcm_sample_rates {
 sub fade_volume {
 	my ($client, $fade, $callback, $callbackargs) = @_;
 
-	if (abs($fade) > 1 || $client->model !~ /baby|fab4/) {
+	if (abs($fade) > 1 || $client->model =~ /baby|fab4/) {
 		# for long fades do standard behavior so that sleep/alarm work
 		$client->SUPER::fade_volume($fade, $callback, $callbackargs);
 	} else {


### PR DESCRIPTION
Hej there,

I am trying to get some proper Mute Info into Squeezelite and found something possibly wrong in Slim/Player/SqueezePlay.pm.

Shouldn't the regexp in that line: https://github.com/Logitech/slimserver/blob/a063401fe91bc81889f3ca2524f1ce6ab349879c/Slim/Player/SqueezePlay.pm#L250

rather be
`...
if (abs($fade) > 1 || $client->model =~ /baby|fab4/) {
...`

Otherwise the comment 
`# for long fades do standard behavior so that sleep/alarm work`
 does not make any sense (at least) to me: squeezelite usually has no internal alarm function.

The issue would also explain why I am getting fade on mute and unmute with squeezelite...