### PR TITLE
add byte skipping to workaround HTTP servers that can't do range

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -11,6 +11,7 @@ use base qw(Slim::Formats::RemoteStream);
 
 use IO::Socket qw(:crlf);
 use Scalar::Util qw(blessed);
+use List::Util qw(min);
 
 use Slim::Formats::RemoteMetadata;
 use Slim::Music::Info;
@@ -86,13 +87,21 @@ sub response {
 	my $self = shift;
 	my ($args, $request, @headers) = @_;
 
+    # re-parse the request string as it might have been overloaded by subclasses
+    my $request_object = HTTP::Request->parse($request);
+
+    # do we have the range we requested
+    if ($request_object->header('Range') =~ /^bytes=(\d+)-/ &&
+        $1 != ($self->contentRange =~ /(\d+)-/)) {
+        ${*$self}{'_skip'} = $1;            
+        $log->info("range request not served, skipping $1 bytes");
+    }
+
 	# HTTP headers have now been acquired in a blocking way
 	my $enhance = $self->canEnhanceHTTP($args->{'client'}, $args->{'url'});
 	return unless $enhance;
 
 	if ($enhance == PERSISTENT || !$self->contentLength) {
-		# re-parse the request string as it might have been overloaded by subclasses
-		my $request_object = HTTP::Request->parse($request);
 		my $uri = $request_object->uri;
 
 		# re-set full uri if it is not absolute (e.g. not proxied)
@@ -579,7 +588,18 @@ sub saveStream {
 # object's parent, not the package's parent
 # see http://modernperlbooks.com/mt/2009/09/when-super-isnt.html
 sub _sysread {
-	return CORE::sysread($_[0], $_[1], $_[2], $_[3]);
+    my $self = $_[0];   
+    return CORE::sysread($_[0], $_[1], $_[2], $_[3]) unless ${*$self}{'_skip'};
+
+    # skip what we need until done or EOF
+    my $bytes = CORE::sysread($_[0], $_[1], min(${*$self}{'_skip'}, $_[2]), $_[3]);
+    return $bytes if defined $bytes && !$bytes;
+
+    # pretend we don't have received anything until we've skipped all
+    ${*$self}{'_skip'} -= $bytes if $bytes;
+    $_[1]= '';    
+    $! = EINTR;
+    return undef;
 }
 
 sub sysread {

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -87,15 +87,15 @@ sub response {
 	my $self = shift;
 	my ($args, $request, @headers) = @_;
 
-    # re-parse the request string as it might have been overloaded by subclasses
-    my $request_object = HTTP::Request->parse($request);
+	# re-parse the request string as it might have been overloaded by subclasses
+	my $request_object = HTTP::Request->parse($request);
 
-    # do we have the range we requested
-    if ($request_object->header('Range') =~ /^bytes=(\d+)-/ &&
-        $1 != ($self->contentRange =~ /(\d+)-/)) {
-        ${*$self}{'_skip'} = $1;            
-        $log->info("range request not served, skipping $1 bytes");
-    }
+	# do we have the range we requested
+	if ($request_object->header('Range') =~ /^bytes=(\d+)-/ &&
+		$1 != ($self->contentRange =~ /(\d+)-/)) {
+		${*$self}{'_skip'} = $1;            
+		$log->info("range request not served, skipping $1 bytes");
+	}
 
 	# HTTP headers have now been acquired in a blocking way
 	my $enhance = $self->canEnhanceHTTP($args->{'client'}, $args->{'url'});
@@ -147,7 +147,7 @@ sub request {
 	my $track = $song->currentTrack;
 	my $processor = $track->processors($song->wantFormat);
 
-	# no other guidance, define AudioBlock to make sure that audio_offset is skipped in requestString
+	# no other guidance, define AudioBlock if needed so that audio_offset is skipped in requestString
 	if (!$processor || $song->stripHeader) {
 		$song->initialAudioBlock('');
 		return $self->SUPER::request($args);
@@ -588,18 +588,18 @@ sub saveStream {
 # object's parent, not the package's parent
 # see http://modernperlbooks.com/mt/2009/09/when-super-isnt.html
 sub _sysread {
-    my $self = $_[0];   
-    return CORE::sysread($_[0], $_[1], $_[2], $_[3]) unless ${*$self}{'_skip'};
+	my $self = $_[0];   
+	return CORE::sysread($_[0], $_[1], $_[2], $_[3]) unless ${*$self}{'_skip'};
 
-    # skip what we need until done or EOF
-    my $bytes = CORE::sysread($_[0], $_[1], min(${*$self}{'_skip'}, $_[2]), $_[3]);
-    return $bytes if defined $bytes && !$bytes;
+	# skip what we need until done or EOF
+	my $bytes = CORE::sysread($_[0], $_[1], min(${*$self}{'_skip'}, $_[2]), $_[3]);
+	return $bytes if defined $bytes && !$bytes;
 
-    # pretend we don't have received anything until we've skipped all
-    ${*$self}{'_skip'} -= $bytes if $bytes;
-    $_[1]= '';    
-    $! = EINTR;
-    return undef;
+	# pretend we don't have received anything until we've skipped all
+	${*$self}{'_skip'} -= $bytes if $bytes;
+	$_[1]= '';    
+	$! = EINTR;
+	return undef;
 }
 
 sub sysread {


### PR DESCRIPTION
This is more a "utility" PR. The idea is that some servers (including my own Shairtunes) can't do range-request, for a good reason because they are live streaming. In that case, header bytes (e.g.) can't be skipped and wav are not stripped from header, creating a click on most SB that don't support WAV, but just PCM.

I've added a workaround in Shairtunes but I thought that could be useful to have that built-in capability in LMS: when asked to do a range-request, if it is not honored, then the HTTP sysread will simply skip the number of bytes.