### PR TITLE
Only return 'replay_gain' in status query if replay gain is currently in use.

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -3650,7 +3650,10 @@ sub statusQuery {
 			$request->addResult('can_seek', 1);
 		}
 
-		$request->addResult('replay_gain', Slim::Player::ReplayGain->fetchGainMode($client, $song) || 0)
+		my $trackGain = Slim::Player::ReplayGain->fetchGainMode($client, $song);
+		if (defined $trackGain) {
+			$request->addResult('replay_gain', $trackGain);
+		}
 	}
 
 	if ($client->currentSleepTime()) {


### PR DESCRIPTION
The client needs to be able to distinguish between a '0' value of track gain and replay gain not being used. Since the `fetchGainMode()` function returns 'undef' in the latter case, we can simply bypass adding `replay_gain` to the status query result so that the client knows that a `replay_gain` value of '0' always means 0.00dB.