### PR TITLE
Fix album_contributor updates in new & changed scan

### DIFF
--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -255,8 +255,9 @@ sub rescan {
 		SELECT COUNT(*) FROM contributor_track WHERE contributor = ?
 	} );
 
+	# There may have be more than one Artist tag in the music file, so track.primary_artist does not tell the whole story. So also check for ARTIST/ALBUMARTIST in contributor_track.
 	my $albumSth = $dbh->prepare_cached( qq{
-		SELECT COUNT(1) FROM tracks WHERE album = ? AND primary_artist = ?
+		SELECT COUNT(1) FROM tracks JOIN contributor_track ON tracks.id=contributor_track.track WHERE album=? AND ( tracks.primary_artist=? OR contributor_track.contributor=? AND contributor_track.role IN (1,5) )
 	} );
 
 	for my $id ( @$ids ) {
@@ -272,7 +273,7 @@ sub rescan {
 		}
 		# contributor->album relations aren't removed automatically when the last track with this primary_artist disappears
 		elsif ( $albumId ) {
-			$albumSth->execute($albumId, $id);
+			$albumSth->execute($albumId, $id, $id);
 			($count) = $albumSth->fetchrow_array;
 			$albumSth->finish;
 

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -255,9 +255,12 @@ sub rescan {
 		SELECT COUNT(*) FROM contributor_track WHERE contributor = ?
 	} );
 
-	# There may have be more than one Artist tag in the music file, so track.primary_artist does not tell the whole story. So also check for ARTIST/ALBUMARTIST in contributor_track.
+	# There may have been more than one Artist tag in the music file, so track.primary_artist does not tell the whole story. So also check for ARTIST/ALBUMARTIST in contributor_track.
 	my $albumSth = $dbh->prepare_cached( qq{
-		SELECT COUNT(1) FROM tracks JOIN contributor_track ON tracks.id=contributor_track.track WHERE album=? AND ( tracks.primary_artist=? OR contributor_track.contributor=? AND contributor_track.role IN (1,5) )
+		SELECT COUNT(1) FROM tracks 
+  		LEFT JOIN contributor_track ON tracks.id=contributor_track.track 
+    		WHERE album=? 
+      		AND ( tracks.primary_artist=? OR ( contributor_track.contributor=? AND contributor_track.role IN (1,5) ) )
 	} );
 
 	for my $id ( @$ids ) {


### PR DESCRIPTION
This seems to work, but I wonder if we should put some more thought into how we handle multiple Artist tags - at the moment, tracks.primary_artist is arbitrarily set to the first element in the Artists array.

Maybe if there is an ARTIST that is also an ALBUMARTIST (in the music file tags) it should take precedence? (Would also need to bear in mind that there could be multiple ALBUMARTIST tags as well).