### PR TITLE
Try to fix "insert a track after last track has been fully streamed to the player" issue

### DIFF
--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -245,8 +245,6 @@ sub addTracks {
 		});
 	}
 
-	# inform controller (mainly in case last track was already fully streamed)
-	$client->controller->playlistUpdated();
 	
 	if ($insert) {
 		_insert_done($client, $canAdd);
@@ -1078,6 +1076,9 @@ sub modifyPlaylistCallback {
 	my $request = shift;
 
 	my $client  = $request->client();
+
+	# inform controller (mainly in case last track was already fully streamed)
+	$client->controller->playlistUpdated();
 
 	main::INFOLOG && $log->info("Checking if persistPlaylists is set..");
 

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -245,6 +245,9 @@ sub addTracks {
 		});
 	}
 
+	# inform controller (mainly in case last track was already fully streamed)
+	$client->controller->playlistUpdated();
+	
 	if ($insert) {
 		_insert_done($client, $canAdd);
 	}

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -2112,6 +2112,15 @@ sub closeStream {
 	$_[0]->{'songStreamController'}->close() if $_[0]->{'songStreamController'};
 }
 
+sub playlistUpdated {
+	my ($self) = @_;
+
+	if ($self->{'streamingState'} == IDLE && $self->{'playingState'} != STOPPED) {
+		main::INFOLOG && $log->info("$self->{'masterId'} playlist update while stream already finished");
+		_getNextTrack($self);
+	}
+}	
+
 ####################################################################
 # Incoming events - <<interface>> PlayControl
 


### PR DESCRIPTION
This is a proposal for solving https://forums.slimdevices.com/forum/user-forums/logitech-media-server/1658961-tracks-added-to-current-playlist-not-playing-if-player-buffer-has-already-been-filled, the "insert a track after last track has been fully streamed to the player". 

It is not trying to solve the other issue mentioned in that post, which is what happens when inserting in a middle of a playlist track after the current has been streamed. It can be the foundation for it because it adds a callback to the streamcontroller when playlist is tweaked.

Don't merge that for now, it needs more opinions