### PR TITLE
Handle case where user moves/adds/removes tracks in a playlist while the next track is already fully streamed

### DIFF
--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -1077,9 +1077,6 @@ sub modifyPlaylistCallback {
 
 	my $client  = $request->client();
 
-	# inform controller (mainly in case last track was already fully streamed)
-	$client->controller->playlistUpdated();
-
 	main::INFOLOG && $log->info("Checking if persistPlaylists is set..");
 
 	if ( !$client || !$prefs->get('persistPlaylists') ) {

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -457,6 +457,7 @@ sub removeMultipleTracks {
 
 	my $stopped = 0;
 	my $oldMode = Slim::Player::Source::playmode($client);
+	my $flush = 0;
 
 	my $playingTrackPos   = ${shuffleList($client)}[Slim::Player::Source::playingSongIndex($client)];
 	my $streamingTrackPos = ${shuffleList($client)}[Slim::Player::Source::streamingSongIndex($client)];
@@ -484,7 +485,7 @@ sub removeMultipleTracks {
 
 			} elsif ($streamingTrackPos == $oldCount) {
 
-				Slim::Player::Source::flushStreamingSong($client);
+				$flush = 1;
 			}
 
 		} else {
@@ -550,6 +551,8 @@ sub removeMultipleTracks {
 		for my $song (@{$queue}) {
 			$song->index($oldToNewShuffled{$song->index()} || 0);
 		}
+		
+		Slim::Player::Source::flushStreamingSong($client) if $flush;
 	}
 
 	refreshPlaylist($client);

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -277,6 +277,11 @@ sub _insert_done {
 		} else {
 			push @{$client->shufflelist}, @reshuffled;
 		}
+		# need to flush if we are changing streaming song
+		if (Slim::Player::Source::streamingSongIndex($client) == $playlistIndex % count($client)) {
+			main::INFOLOG && $log->info("add+replace streaming (not playing) track");
+			Slim::Player::Source::flushStreamingSong($client);			
+		}
 	} else {
 		if (count($client) != $size) {
 			moveSong($client, $moveFrom, $playlistIndex, $size);
@@ -624,7 +629,7 @@ sub moveSong {
 			if (($playingIndex != $streamingIndex) &&
 				(($streamingIndex == $src) || ($streamingIndex == $dest) ||
 				 ($playingIndex == $src) || ($playingIndex == $dest))) {
-				$log->info("moving a track right after playing one but it has been fully streamed");
+				$log->info("move+replace streaming (not playing) track");
 				Slim::Player::Source::flushStreamingSong($client);
 			}
 

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -266,7 +266,7 @@ sub addTracks {
 sub _insert_done {
 	my ($client, $size, $callbackf, $callbackargs) = @_;
 
-	my $playlistIndex = Slim::Player::Source::streamingSongIndex($client)+1;
+	my $playlistIndex = Slim::Player::Source::playingSongIndex($client) + 1;
 	my $moveFrom = count($client) - $size;
 
 	if (shuffle($client)) {

--- a/Slim/Player/SqueezeSlave.pm
+++ b/Slim/Player/SqueezeSlave.pm
@@ -241,10 +241,7 @@ sub pcm_sample_rates {
 sub statHandler {
 	my ($client, $code) = @_;
 	
-	if ($code eq 'STMf') {
-		$client->readyToStream(1);
-		$client->controller()->playerFlushed($client);
-	} elsif ($code eq 'STMd') {
+	if ($code eq 'STMd') {
 		$client->readyToStream(1);
 		$client->controller()->playerReadyToStream($client);
 	} elsif ($code eq 'STMn') {

--- a/Slim/Player/SqueezeSlave.pm
+++ b/Slim/Player/SqueezeSlave.pm
@@ -241,7 +241,10 @@ sub pcm_sample_rates {
 sub statHandler {
 	my ($client, $code) = @_;
 	
-	if ($code eq 'STMd') {
+	if ($code eq 'STMf') {
+		$client->readyToStream(1);
+		$client->controller()->playerFlushed($client);
+	} elsif ($code eq 'STMd') {
 		$client->readyToStream(1);
 		$client->controller()->playerReadyToStream($client);
 	} elsif ($code eq 'STMn') {

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -147,7 +147,10 @@ sub statHandler {
 	}
 
 
-	if ($code eq 'STMd') {
+	if ($code eq 'STMf') {
+		$client->readyToStream(1);
+		$client->controller()->playerFlushed($client);
+	} elsif ($code eq 'STMd') {
 		$client->readyToStream(1);
 		$client->controller()->playerReadyToStream($client);
 	} elsif ($code eq 'STMn') {

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -147,10 +147,7 @@ sub statHandler {
 	}
 
 
-	if ($code eq 'STMf') {
-		$client->readyToStream(1);
-		$client->controller()->playerFlushed($client);
-	} elsif ($code eq 'STMd') {
+	if ($code eq 'STMd') {
 		$client->readyToStream(1);
 		$client->controller()->playerReadyToStream($client);
 	} elsif ($code eq 'STMn') {
@@ -392,6 +389,9 @@ sub flush {
 
 	$client->stream('f');
 	$client->SUPER::flush();
+	
+	# once flush, don't wait for answer, just get ready
+	$client->readyToStream(1);
 	return 1;
 }
 

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -147,8 +147,8 @@ Flush =>
 [	[	\&_Invalid,		\&_BadState,	\&_BadState,	\&_Invalid],		# STOPPED	
 	[	\&_BadState,	\&_Invalid,		\&_Invalid,		\&_BadState],		# BUFFERING
 	[	\&_BadState,	\&_Invalid,		\&_Invalid,		\&_BadState],		# WAITING_TO_SYNC
-	[	\&_Invalid,		\&_FlushGetNext,\&_FlushGetNext,\&_FlushGetNext],	# PLAYING
-	[	\&_Invalid,		\&_FlushGetNext,\&_FlushGetNext,\&_FlushGetNext],	# PAUSED
+	[	\&_FlushGetNext,\&_FlushGetNext,\&_FlushGetNext,\&_FlushGetNext],	# PLAYING
+	[	\&_FlushGetNext,\&_FlushGetNext,\&_FlushGetNext,\&_FlushGetNext],	# PAUSED
 ],
 Skip  => 
 [	[	\&_StopGetNext,	\&_BadState,	\&_BadState,	\&_NoOp],			# STOPPED	

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -2223,6 +2223,16 @@ sub playerTrackStarted {
 	Slim::Buttons::Common::syncPeriodicUpdates($client, Time::HiRes::time() + 0.1);
 }
 
+sub playerFlushed {
+	my ($self, $client) = @_;
+
+	main::INFOLOG && $log->info($client->id);
+
+	# STMf received as a result of strm 'q' shall be ignored. Otherwise it means 
+	# we have flushed the streaming track and are ready to stream again
+	_eventAction($self, 'ReadyToStream') if $self->{'playingState'} != STOPPED;
+}	
+
 sub playerReadyToStream {
 	my ($self, $client) = @_;
 

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -2223,16 +2223,6 @@ sub playerTrackStarted {
 	Slim::Buttons::Common::syncPeriodicUpdates($client, Time::HiRes::time() + 0.1);
 }
 
-sub playerFlushed {
-	my ($self, $client) = @_;
-
-	main::INFOLOG && $log->info($client->id);
-
-	# STMf received as a result of strm 'q' shall be ignored. Otherwise it means 
-	# we have flushed the streaming track and are ready to stream again
-	_eventAction($self, 'ReadyToStream') if $self->{'playingState'} != STOPPED;
-}	
-
 sub playerReadyToStream {
 	my ($self, $client) = @_;
 

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -440,7 +440,7 @@ sub _CheckPaused {	# only called when PAUSED
 		} elsif (!$song->duration()) {
 			
 			# Bug 7620: stop remote radio streams if they have been paused long enough for the buffer to fill.
-			# Assume unknown duration means radio and so we shuould stop now
+			# Assume unknown duration means radio and so we should stop now
 			main::INFOLOG && $log->info("Stopping remote stream upon full buffer when paused (no resume)");
 			
 			_Stop(@_);
@@ -2113,11 +2113,17 @@ sub closeStream {
 	$_[0]->{'songStreamController'}->close() if $_[0]->{'songStreamController'};
 }
 
-sub playlistUpdated {
+sub nextIfStreamed {
 	my ($self) = @_;
 
-	if ($self->{'streamingState'} == IDLE && $self->{'playingState'} != STOPPED) {
-		main::INFOLOG && $log->info("$self->{'masterId'} playlist updated after end of last track's streaming");
+	# this is called when we are adding/moving another track after last one
+	# or moving it upper in the list. If it has been fully streamed and we 
+	# are playing/buffering/waiting, then we need to grab next track. If we 
+	# are paused then we'll restart the process later upon resume
+	if ($self->{'streamingState'} == IDLE && 
+		$self->{'playingState'} != STOPPED && 
+		$self->{'playingState'} != PAUSED) {
+		main::INFOLOG && $log->info("getting next track to re-launch streaming process");
 		_getNextTrack($self);
 	}
 }	

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -978,7 +978,7 @@ sub _FlushGetNext {			# flush -> Idle; IF [moreTracks] THEN getNextTrack -> Trac
 	my ($self, $event, $params) = @_;
 	
 	# flush means that we get rid of the streaming song
-	shift $self->{'songqueue'};
+	shift @{$self->{'songqueue'}};
 
 	foreach my $player (@{$self->{'players'}})	{
 		$player->flush();


### PR DESCRIPTION
This replace my previous PR and extend to the case where users add/move/remove track N+1 when track N is currently playing *and* has been fully streamed (in other words, N+1 is already streaming). It's very visible for players with squeeezelite with large output buffers  or with bridges (to work well with squeezelite, it requires a patched version)

So far, LMS (the StreamingController) knows that case and requires the player to do a "flush" of N+1, but then it does not handle the next steps properly. 

1- It enters IDLE, and immediately requests the new track (call it A), which moves to TRACKWAIT and expects the callback when the track arrives to send a nextTrackReady event that should start the streaming of track A. The problem is that the players are not in "readyToStream" state and so the controller stays in TRACKWAIT until track N ends. Then the controller would re-check that there is something to stream and that would create a gap. Player objects are in ReadyToStream state when they have been reset of after the physical device have sent a "decoding finished" event to LMS or after they have stopped. 

I had two option, the first one I did was to get player's response to the flush request strm 'f' (STMf) to make the player ReadyToStream again and re-use the StreamingController's event "ReadyToStream" so that it resumes. That works but it means that each player must send a STMf event for sure and so far, there are 2 bugs in SqueezeLite there: on "flush", it only sends STMf if it has an actual streaming connection. But that's not sufficient because the streaming of N+1 could also be fully done (and we  have no connection to terminate), so we had to also verify there was no track N+1 in the outpufbuffer. In addition, the other bug with SqueezeLite is that is treats strm 'f' as a full stop request which is not at all the expectation (see PR). In addition, because an STMf is also sent every time on strm 'q' command, we had to differentiate that and not call ReadyToStream then (would make a state error)

The other option, which came to my mind while writing that doc, hence there is nothing better than explaining things 😄, is that when LMS request the player's object to "flush", it should simply declare it ready to stream. I can't think of a case where it's not accurate. 

That second option is less changes in the StreamingController, in Player's object and in players themselves (it seems that Boom and SqueezePlay do the right thing on strm 'f' but I'm not even sure). So less is always better...

2- Unfortunately, there is more to that problem because if the user moves/adds/removes tracks multiple times after N while N is still playing (say, it adds A, B and C...) then the StreamingController was trying to "flush" while in "TRACKWAIT" (due to at least the first change) and that was not a valid transition, so that had to be changed. 

3- In addition and in that special case, when moving/adding/removing track, LMS was not correctly re-calculating the index of songs. Precisely, playlist handling/shuffling should be done before the flush request, but the indexes to decide if we are in that special case added to be captured before. Then the flush can be done (it will get the "next" song based on actualized playlist. Currently, LMS verifies it's not in the case, then flushes, then changes the index. The problem is that flush calls a getNextTrack which works on non-updated index.

A last related but different issue was that if user adds a track after the *last* track has been fully streamed (StreamingController is IDLE but PLAYING), LMS would not realize that and would stop.