### PR TITLE
add utf-8 guess decoding on Ogg metadata

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -354,6 +354,10 @@ sub parseMetadata {
 	# 2-byte length/string pairs.
 	elsif ( $metadata =~ /^Ogg(.+)/s ) {
 		my $comments = $1;
+
+		# Bug 15896, a stream had CRLF in the metadata (no conflict with utf-8)
+		$comments =~ s/\s*[\r\n]+\s*/; /g;
+
 		my $meta = {};
 		while ( $comments ) {
 			my $length = unpack 'n', substr( $comments, 0, 2, '' );
@@ -361,18 +365,15 @@ sub parseMetadata {
 
 			main::DEBUGLOG && $directlog->is_debug && $directlog->debug("Ogg comment: $value");
 
-			# Bug 15896, a stream had CRLF in the metadata
-			$metadata =~ s/\s*[\r\n]+\s*/; /g;
-
 			# Look for artist/title/album
 			if ( $value =~ /ARTIST=(.+)/i ) {
-				$meta->{artist} = $1;
+				$meta->{artist} = Slim::Utils::Unicode::utf8decode_guess($1);
 			}
 			elsif ( $value =~ /ALBUM=(.+)/i ) {
-				$meta->{album} = $1;
+				$meta->{album} = Slim::Utils::Unicode::utf8decode_guess($1);
 			}
 			elsif ( $value =~ /TITLE=(.+)/i ) {
-				$meta->{title} = $1;
+				$meta->{title} = Slim::Utils::Unicode::utf8decode_guess($1);
 			}
 		}
 


### PR DESCRIPTION
Following, https://forums.slimdevices.com/forum/user-forums/general-discussion/1663356-ogg-vorbis-stream-maybe-more-a-radio-paradise-question, this is a PR simply to handle utf-8 encoding in such ogg metadata (proven to be needed). I don't know if Squeezebox2 or Squeezeplay filter locally but the PR (https://github.com/ralph-irving/squeezelite/pull/197) I've made in squeezelite does not and I think the right place is in LMS anyway.

Also, I moved \r\n bug 15896 where I think it should be (let me know if you agree)
