### PR TITLE
Make sure there is an icon for Ogg metadata

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -358,7 +358,9 @@ sub parseMetadata {
 		# Bug 15896, a stream had CRLF in the metadata (no conflict with utf-8)
 		$comments =~ s/\s*[\r\n]+\s*/; /g;
 
-		my $meta = {};
+		my $song = $client->controller()->songStreamController()->song();
+		my $meta = { cover => $song->icon() };
+
 		while ( $comments ) {
 			my $length = unpack 'n', substr( $comments, 0, 2, '' );
 			my $value  = substr $comments, 0, $length, '';
@@ -378,8 +380,6 @@ sub parseMetadata {
 		}
 
 		# Re-use wmaMeta field
-		my $song = $client->controller()->songStreamController()->song();
-
 		my $cb = sub {
 			$song->pluginData( wmaMeta => $meta );
 			Slim::Music::Info::setCurrentTitle($url, $meta->{title}, $client) if $meta->{title};

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -358,9 +358,7 @@ sub parseMetadata {
 		# Bug 15896, a stream had CRLF in the metadata (no conflict with utf-8)
 		$comments =~ s/\s*[\r\n]+\s*/; /g;
 
-		my $song = $client->controller()->songStreamController()->song();
-		my $meta = { cover => $song->icon() };
-
+		my $meta = { cover => Slim::Utils::Cache->new()->get("remote_image_$url") };
 		while ( $comments ) {
 			my $length = unpack 'n', substr( $comments, 0, 2, '' );
 			my $value  = substr $comments, 0, $length, '';
@@ -380,6 +378,8 @@ sub parseMetadata {
 		}
 
 		# Re-use wmaMeta field
+		my $song = $client->controller()->songStreamController()->song();
+
 		my $cb = sub {
 			$song->pluginData( wmaMeta => $meta );
 			Slim::Music::Info::setCurrentTitle($url, $meta->{title}, $client) if $meta->{title};


### PR DESCRIPTION
It's a small thing but when getting metadata from Ogg streams (it's the same for mp3), the re-use of wmaMeta does not set an icon and when getMetaDataFor() is called, then the default webradio icon is erased and because the ogg stream does not include anymetadata, then webradio's icon is replaced by an "empty" (radio) icon. 

Maybe we should do such change somewhere else, for example in HTTP::getMetadataFor but that's a broader modification. I've tried but it seems that calling $song->icon() here in getMetaDataFor() creates a recurse. You know that part better than me, I'd say that ideally we would do it there. I just don't know why it recurse (I guess $song->icon calls HTTP::getMetadataFor at some point) or if using $song->icon is the right call to get whatever is the current cover. I'd guess $song->icon() is wrong...