### PR TITLE
split artist/title in OggMeta when combined

### DIFF
--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -377,6 +377,11 @@ sub parseMetadata {
 			}
 		}
 
+		if (!$meta->{artist}) {
+			my @dashes = $meta->{title} =~ /( - )/g;
+			($meta->{artist}, $meta->{title}) = split /\s+-\s+/, $meta->{title} if scalar @dashes == 1;
+		}
+
 		# Re-use wmaMeta field
 		my $song = $client->controller()->songStreamController()->song();
 


### PR DESCRIPTION
Another small improvement: as done in getMetadataFor, it happens often that ogg webradio, like for ICY, combine artist and title alltogether, so we just untangle them when receiving metadata (also confirmed with Boom)