### PR TITLE
New and changed contributor scanning improvements

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2921,7 +2921,7 @@ sub _postCheckAttributes {
 	# Walk through the valid contributor roles, adding them to the database.
 	my $contributors = $self->_mergeAndCreateContributors($attributes, $isCompilation, $create);
 
-	my $artist = $contributors->{ARTIST} || $contributors->{TRACKARTIST};
+	my $artist = $contributors->{'ALBUMARTIST'} || $contributors->{ARTIST} || $contributors->{TRACKARTIST};
 	if ($artist) {
 		$cols{primary_artist} = $artist->[0];
 	}

--- a/Slim/Utils/Scanner/Local.pm
+++ b/Slim/Utils/Scanner/Local.pm
@@ -283,6 +283,16 @@ sub rescan {
 				WHERE  scanned_files.url LIKE '$basedir%'
 		} );
 
+		# and a table of albums being changed
+		$log->error("Build temporary table for changed albums") unless main::SCANNER && $main::progress;
+		$dbh->do('DROP TABLE IF EXISTS changed_albums');
+		$dbh->do( qq{
+			CREATE $createTemporary TABLE changed_albums AS
+				SELECT DISTINCT(tracks.album) AS album
+				FROM   changed
+				JOIN   tracks ON changed.url = tracks.url
+		} );
+
 		my $changedOnlySQL = qq{
 			SELECT url
 			FROM   changed
@@ -314,6 +324,30 @@ sub rescan {
 		}, $args);
 
 		$class->updateTracks($dbh, \$changes, $paths, $next, $changedOnlyCount, $changedOnlySQL, $args);
+
+		# Completely rebuild contributor_album for all changed albums...
+		# ... first, now that tracks has been updated, add albums referenced now which weren't referenced before (in case the user has moved a track to a different album)
+		$log->error("Adding to temporary table for changed albums") unless main::SCANNER && $main::progress;
+		$dbh->do( qq{
+			INSERT INTO changed_albums
+			SELECT DISTINCT(tracks.album) AS album
+			FROM   changed
+			JOIN   tracks ON changed.url = tracks.url
+			WHERE NOT EXISTS (SELECT * FROM changed_albums WHERE changed_albums.album = tracks.album)
+		} );
+		# ... now, rebuild contributor_album
+		$dbh->do( qq{
+			DELETE FROM contributor_album
+			WHERE contributor_album.album IN (SELECT album FROM changed_albums)
+		} );
+		$dbh->do( qq{
+			INSERT INTO contributor_album (role,contributor,album) 
+			SELECT DISTINCT role,contributor, tracks.album 
+			FROM contributor_track
+			JOIN tracks ON tracks.id=contributor_track.track
+			JOIN changed_albums ON tracks.album = changed_albums.album
+		} );
+		main::SCANNER && Slim::Schema->forceCommit;
 
 		$class->addTracks($dbh, \$changes, $paths, $next, $onDiskOnlyCount, $onDiskOnlySQL, $args);
 

--- a/Slim/Utils/Scanner/Local.pm
+++ b/Slim/Utils/Scanner/Local.pm
@@ -283,16 +283,6 @@ sub rescan {
 				WHERE  scanned_files.url LIKE '$basedir%'
 		} );
 
-		# and a table of albums being changed
-		$log->error("Build temporary table for changed albums") unless main::SCANNER && $main::progress;
-		$dbh->do('DROP TABLE IF EXISTS changed_albums');
-		$dbh->do( qq{
-			CREATE $createTemporary TABLE changed_albums AS
-				SELECT DISTINCT(tracks.album) AS album
-				FROM   changed
-				JOIN   tracks ON changed.url = tracks.url
-		} );
-
 		my $changedOnlySQL = qq{
 			SELECT url
 			FROM   changed
@@ -316,6 +306,18 @@ sub rescan {
 			SELECT COUNT(*) FROM ( $changedOnlySQL ) AS t1
 		} ) if !(main::SCANNER && $main::wipe);
 
+		# if we've got changed tracks, add a table of albums being changed
+		if ( $changedOnlyCount ) {
+			$log->error("Build temporary table for changed albums") unless main::SCANNER && $main::progress;
+			$dbh->do('DROP TABLE IF EXISTS changed_albums');
+			$dbh->do( qq{
+				CREATE $createTemporary TABLE changed_albums AS
+					SELECT DISTINCT(tracks.album) AS album
+					FROM   changed
+					JOIN   tracks ON changed.url = tracks.url
+			} );
+		}
+
 		$class->deleteTracks($dbh, \$changes, $paths, $next, {
 			name  => 'deleted audio files',
 			count => $inDBOnlyCount,
@@ -326,28 +328,30 @@ sub rescan {
 		$class->updateTracks($dbh, \$changes, $paths, $next, $changedOnlyCount, $changedOnlySQL, $args);
 
 		# Completely rebuild contributor_album for all changed albums...
-		# ... first, now that tracks has been updated, add albums referenced now which weren't referenced before (in case the user has moved a track to a different album)
-		$log->error("Adding to temporary table for changed albums") unless main::SCANNER && $main::progress;
-		$dbh->do( qq{
-			INSERT INTO changed_albums
-			SELECT DISTINCT(tracks.album) AS album
-			FROM   changed
-			JOIN   tracks ON changed.url = tracks.url
-			WHERE NOT EXISTS (SELECT * FROM changed_albums WHERE changed_albums.album = tracks.album)
-		} );
-		# ... now, rebuild contributor_album
-		$dbh->do( qq{
-			DELETE FROM contributor_album
-			WHERE contributor_album.album IN (SELECT album FROM changed_albums)
-		} );
-		$dbh->do( qq{
-			INSERT INTO contributor_album (role,contributor,album) 
-			SELECT DISTINCT role,contributor, tracks.album 
-			FROM contributor_track
-			JOIN tracks ON tracks.id=contributor_track.track
-			JOIN changed_albums ON tracks.album = changed_albums.album
-		} );
-		main::SCANNER && Slim::Schema->forceCommit;
+		if ( $changedOnlyCount ) {
+			# ... first, now that tracks has been updated, add albums referenced now which weren't referenced before (in case the user has moved a track to a different album)
+			$log->error("Adding to temporary table for changed albums") unless main::SCANNER && $main::progress;
+			$dbh->do( qq{
+				INSERT INTO changed_albums
+				SELECT DISTINCT(tracks.album) AS album
+				FROM   changed
+				JOIN   tracks ON changed.url = tracks.url
+				WHERE NOT EXISTS (SELECT * FROM changed_albums WHERE changed_albums.album = tracks.album)
+			} );
+			# ... now, rebuild contributor_album
+			$dbh->do( qq{
+				DELETE FROM contributor_album
+				WHERE contributor_album.album IN (SELECT album FROM changed_albums)
+			} );
+			$dbh->do( qq{
+				INSERT INTO contributor_album (role,contributor,album) 
+				SELECT DISTINCT role,contributor, tracks.album 
+				FROM contributor_track
+				JOIN tracks ON tracks.id=contributor_track.track
+				JOIN changed_albums ON tracks.album = changed_albums.album
+			} );
+			main::SCANNER && Slim::Schema->forceCommit;
+		}
 
 		$class->addTracks($dbh, \$changes, $paths, $next, $onDiskOnlyCount, $onDiskOnlySQL, $args);
 


### PR DESCRIPTION
Changed strategy for keeping the contributor_albums table in line through a "New & Changed" scan.

(It turned out that my change in this area just before Xmas introduced a bug as well as fixing one!)

Rather than continue complicating the rescan routine in Contributors.pm, I've introduced code based on the commented out code in schema_optimize.sql, but running it only for albums that have changed, in Utils/Scanner/Local.pm.

I've also changed the update to the albums table to prioritise ALBUMARTIST if there is one. This already happens when creating a new album, but ALBUMARTIST was being ignored in the update, which just seemed wrong.

I've tested it, but it really needs independent testing and scrutiny.