### PR TITLE
issue of streaming track fully streamed and adding one more

### DIFF
--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -190,10 +190,10 @@ sub addTracks {
 	my $playlist = playList($client);
 
 	my $maxPlaylistLength = $prefs->get('maxPlaylistLength');
-
-	# do we need to plan for restart of streaming?
+	
+	# we need to plan for restart of streaming in case the streaming song is the last one
 	my $restart = (Slim::Player::Source::playingSongIndex($client) == Slim::Player::Source::streamingSongIndex($client)) &&
-				  (Slim::Player::Source::playingSongIndex($client) == count($client) - 1);
+				  (Slim::Player::Source::streamingSongIndex($client) == count($client) - 1);
 
 	# How many tracks might we need to remove to make space?
 	my $need = $maxPlaylistLength ? (scalar @{$playlist} + scalar @{$tracksRef}) - $maxPlaylistLength : 0;
@@ -357,7 +357,7 @@ sub removeTrack {
 		return 0;
 	}
 	if ($tracknum + $nTracks > count($client)) {
-		$log->warn("Arrempting to remove too many tracks ($nTracks)");
+		$log->warn("Attempting to remove too many tracks ($nTracks)");
 		$nTracks = count($client) - $tracknum;
 	}
 

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -1213,10 +1213,10 @@ sub _Stream {				# play -> Buffering, Streaming
 
 	# Bug 5103, the firmware can handle only 2 tracks at a time: one playing and one streaming,
 	# and on very short tracks we may get multiple decoder underrun events during playback of a single
-	# track.  We need to ignore decoder underrun events if there's already a streaming track in the queue
-	# Check that we are not trying to stream too many tracks (test moved from _StreamIfReady)
+	# track. Trying to _Stream() more than 1 shoud never happen as it is blocked in the ReadyToStream
+	# event (_NextIfMore and _RetryOrNext() methods)) and the _Stream() is delayed to Started event
 	if (scalar @$queue > 2) {
-		main::INFOLOG && $log->info("aborting streaming because songqueue too long: ", scalar @$queue);
+		$log->error("we should not be here: aborting streaming because songqueue too long: ", scalar @$queue);
 		shift @$queue while (scalar @$queue > 2);
 		return;
 	}


### PR DESCRIPTION
This is WiP, please don't merge yet

Let's continue here. This is a proper attempt to solve the issue that happens with very large buffers. You know my opinion on that, but still, where you have a point is that it's not so much about large buffer, but about tracks that are small compared to the buffer size. 

LMS currently handles "short tracks" in a sort of incomplete way which means that when N plays, if N+1 has already been fully buffered, then any action on N+2 (move/remove/insert) will be messed-up. The reason is that as soon as N+1 is streamed out, N+2 is requested and held into the streamer backburner. It is not streamed, but it's requested. 

So if you do anything that impacts it, then it will fail because you can't really touch that backburner. Well, you can, but there are so many permutation and combination that I don't want to think about it. The other solution is to prevent it from getting into the backburner, in other words when N+1 is streamed, we don't request N+2, we delay the request to when N+1 will start *playing*.

It will probably work nicely except that **really** short tracks might now be messed up. The issue is that N+1 will be streamed of course, N+2 will not be requested and as soon as N+1 starts, N+2 is requested. But, if N+1 *stops* even before N+2 is available, then playback will stop. 

I'm not sure which evil is worse...

