### PR TITLE
Add a 'V' query that will return the maximum seek point in seconds within the current track duration for a 'live' radio stream

### DIFF
--- a/HTML/EN/html/docs/cli-api.html
+++ b/HTML/EN/html/docs/cli-api.html
@@ -5584,7 +5584,7 @@ http://&lt;server&gt;:&lt;port&gt;/music/current/cover.jpg?player=&lt;playerid&g
 			live_edge
 		</td>
 		<td>
-			If implemented for a live remote radio stream, holds the current maximum available seek point. Will be less than or equal to the value of track duration.
+			When implemented for a live remote radio stream, holds the current maximum available seek point. Will be less than or equal to the value of track duration.
 		</td>
 	</tr>
 </table>

--- a/HTML/EN/html/docs/cli-api.html
+++ b/HTML/EN/html/docs/cli-api.html
@@ -5576,6 +5576,17 @@ http://&lt;server&gt;:&lt;port&gt;/music/current/cover.jpg?player=&lt;playerid&g
 			Replay gain (in dB), if any
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<b>V</b>
+		</td>
+		<td>
+			live_edge
+		</td>
+		<td>
+			If implemented for a live remote radio stream, holds the current maximum available seek point. Will be less than or equal to the value of track duration.
+		</td>
+	</tr>
 </table>
 <p>
 	Example:

--- a/HTML/EN/html/docs/cli-api.html
+++ b/HTML/EN/html/docs/cli-api.html
@@ -5584,7 +5584,7 @@ http://&lt;server&gt;:&lt;port&gt;/music/current/cover.jpg?player=&lt;playerid&g
 			live_edge
 		</td>
 		<td>
-			When implemented for a live remote radio stream, holds the current maximum available seek point. Will be less than or equal to the value of track duration.
+			The Live edge of a remote stream.  -1 is not live, 0 is live at the edge, >0 is number of seconds from the live edge.
 		</td>
 	</tr>
 </table>

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5014,17 +5014,17 @@ sub _songData {
 
 			$remoteMeta->{V} = -1;
             # Distance from the live edge of live remote stream. -1 is not live, 0 is live at the edge, >0 is distance in seconds from the live edge.
-            if ( my $client = $request->client ) {
-                if (my $song = $client->currentSongForUrl($url)) {
-                    if ( $handler->can('isLive') )  {
-                        if ( $handler->isLive($song) ) {# Distance form the live edge, if available.
-                            $remoteMeta->{V} = $remoteMeta->{live_edge} ? $remoteMeta->{live_edge} : 0;
-                        } else { # Not Live
-                            $remoteMeta->{V} = -1;
-                        }
-                    } else { # only live if the song has isLive set
-                        $remoteMeta->{V} = $song->isLive() ? 0 : -1;
-                    }
+			if ( my $client = $request->client ) {
+				if (my $song = $client->currentSongForUrl($url)) {
+					if ( $handler->can('isLive') )  {
+						if ( $handler->isLive($song) ) {# Distance form the live edge, if available.
+							$remoteMeta->{V} = $remoteMeta->{live_edge} ? $remoteMeta->{live_edge} : 0;
+						} else { # Not Live
+							$remoteMeta->{V} = -1;
+						}
+					} else { # only live if the song has isLive set
+						$remoteMeta->{V} = $song->isLive() ? 0 : -1;
+					}
 				}
 			}
 		}

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5011,7 +5011,7 @@ sub _songData {
 			$remoteMeta->{T} = $remoteMeta->{samplerate};
 			$remoteMeta->{I} = $remoteMeta->{samplesize};
 			$remoteMeta->{W} = $remoteMeta->{releasetype};
-			$remoteMeta->{V} = $remoteMeta->{live_edge};
+			$remoteMeta->{V} = $remoteMeta->{live_edge}; # live edge only applicable to adaptive streaming formats (e.g. hls or dash ) currently only supported in 3rd party plugins
 		}
 	}
 

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4828,6 +4828,7 @@ my %tagMap = (
 	  'L' => ['info_link',        '',              'info_link'],        # special trackinfo link for i.e. Pandora
 	  'N' => ['remote_title'],                                          # remote stream title
 	  'E' => ['extid',            '',              'extid'],            # a track's external identifier (eg. on an online music service)
+	  'V' => ['live_edge',        '',              'live_edge'],        # a remote live streams maximum available seek point in seconds within the current duration.
 
 	  'g' => ['genre',            'GENRE',         'genrename'],        #->genre_track->genre.name
 	  'p' => ['genre_id',         '',              'genreid'],          #->genre_track->genre.id
@@ -5010,6 +5011,7 @@ sub _songData {
 			$remoteMeta->{T} = $remoteMeta->{samplerate};
 			$remoteMeta->{I} = $remoteMeta->{samplesize};
 			$remoteMeta->{W} = $remoteMeta->{releasetype};
+			$remoteMeta->{V} = $remoteMeta->{live_edge};
 		}
 	}
 

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5011,7 +5011,22 @@ sub _songData {
 			$remoteMeta->{T} = $remoteMeta->{samplerate};
 			$remoteMeta->{I} = $remoteMeta->{samplesize};
 			$remoteMeta->{W} = $remoteMeta->{releasetype};
-			$remoteMeta->{V} = $remoteMeta->{live_edge}; # live edge only applicable to adaptive streaming formats (e.g. hls or dash ) currently only supported in 3rd party plugins
+
+			$remoteMeta->{V} = -1;
+            # Distance from the live edge of live remote stream. -1 is not live, 0 is live at the edge, >0 is distance in seconds from the live edge.
+            if ( my $client = $request->client ) {
+                if (my $song = $client->currentSongForUrl($url)) {
+                    if ( $handler->can('isLive') )  {
+                        if ( $handler->isLive($song) ) {# Distance form the live edge, if available.
+                            $remoteMeta->{V} = $remoteMeta->{live_edge} ? $remoteMeta->{live_edge} : 0;
+                        } else { # Not Live
+                            $remoteMeta->{V} = -1;
+                        }
+                    } else { # only live if the song has isLive set
+                        $remoteMeta->{V} = $song->isLive() ? 0 : -1;
+                    }
+				}
+			}
 		}
 	}
 

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5018,14 +5018,8 @@ sub _songData {
 			$remoteMeta->{W} = $remoteMeta->{releasetype};
 
 			# Distance from the live edge of live remote stream. -1 is not live, 0 is live at the edge, >0 is distance in seconds from the live edge.
-			$remoteMeta->{V} = -1;
-			if ( $song ) {
-				$remoteMeta->{V} = $song->isLive() ? 0 : -1;
-				#$remoteMeta->{live_edge} will only be populated by 3rd party handlers that support dynamic adaptive live streams
-				if ( $song->isLive() && $remoteMeta->{live_edge} ) {# Distance form the live edge, if available.
-					$remoteMeta->{V} = $remoteMeta->{live_edge};
-				}
-			}
+			# $remoteMeta->{live_edge} contains distance from live edge. Will only be populated by 3rd party handlers that support dynamic adaptive live streams.
+			$remoteMeta->{V} = $remoteMeta->{live_edge} // ($song && $song->isLive() ? 0 : -1);
 		}
 	}
 


### PR DESCRIPTION
As per the discussion here : [ https://forums.slimdevices.com/forum/developer-forums/developers/1667479-live-streams-tag
](url)
This adds a 'V' :  Live_Edge query.

It will contain the maximum seek point in seconds of the currently live radio stream that has a defined duration.

This adds the ability for a client to know what is the maximum available downloadable data.  
It also provides the information to a controller to display the maximum seek point.

For Example for the following scenario :
A live radio stream could be streaming a programme that is  2 hours long.  
The programme is currently being broadcast live and is 1 hour into the broadcast.  The Listener is currently 50 minutes into listening to the programme as they paused for 10 minutes.

The query that contained the tags:dV  (duration and live_meta) would return:
result->time : 3000
result->remoteMeta->duration : 7200
result->remoteMeta->live_edge : 3600






