### PR TITLE
New Release Types mode for grouping albums views

### DIFF
--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -69,7 +69,8 @@
 
 		[% IF !prefs.pref_ignoreReleaseTypes; WRAPPER settingGroup title="" desc="" %]
 			<select class="stdedit" name="pref_groupArtistAlbumsByReleaseType" id="groupArtistAlbumsByReleaseType">
-				<option [% IF prefs.pref_groupArtistAlbumsByReleaseType %]selected [% END %]value="1">[% 'SETUP_GROUP_BY_RELEASE_TYPES_1' | string %]</option>
+				<option [% IF prefs.pref_groupArtistAlbumsByReleaseType == 1 %]selected [% END %]value="1">[% 'SETUP_GROUP_BY_RELEASE_TYPES_1' | string %]</option>
+				<option [% IF prefs.pref_groupArtistAlbumsByReleaseType == 2 %]selected [% END %]value="2">[% 'SETUP_GROUP_BY_RELEASE_TYPES_2' | string %]</option>
 				<option [% IF NOT prefs.pref_groupArtistAlbumsByReleaseType %]selected [% END %]value="0">[% 'SETUP_GROUP_BY_RELEASE_TYPES_0' | string %]</option>
 			</select>
 		[% END; ELSE %]

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1401,8 +1401,8 @@ sub _albumsOrReleases {
 	# We only display the grouped albums if:
 	# 1. the feature is enabled
 	if (!$prefs->get('ignoreReleaseTypes') && $prefs->get('groupArtistAlbumsByReleaseType')
-		# 2. a specific artist is requested
-		&& (grep /^artist_id:/, @searchTags)
+		# 2. a specific artist is requested or user wants release type groups always
+		&& ( $prefs->get('groupArtistAlbumsByReleaseType') == 2 || grep /^artist_id:/, @searchTags )
 		# 3. any one of the following is true:
 		#    3a. we don't apply a role filter (eg. drilling down from a "Composers" menu)
 		&& ($prefs->get('noRoleFilter')

--- a/strings.txt
+++ b/strings.txt
@@ -9323,16 +9323,22 @@ SETUP_CLEANUP_RELEASE_TYPES
 	NL	Probeer om EPs en Singles automatisch te herkennen als releasetype informatie afwezig is.
 
 SETUP_GROUP_BY_RELEASE_TYPES_0
-	DE	Die Veröffentlichungen eines Interpreten nicht gruppieren
-	EN	Don't group an artist's releases
-	FR	Ne pas regrouper les sorties d'un artiste par type
-	NL	Releases van een artiest niet groeperen op type
+	DE	Die Veröffentlichungen nicht gruppieren
+	EN	Don't group releases
+	FR	Ne pas regrouper les sorties par type
+	NL	Releases niet groeperen op type
 
 SETUP_GROUP_BY_RELEASE_TYPES_1
 	DE	Die Veröffentlichungen eines Interpreten nach Typ gruppieren
-	EN	Group an artist's releases by type
+	EN	Group an artist's lists by release type
 	FR	Regrouper les sorties d'un artiste par type
 	NL	Releases van een artiest groeperen op type
+
+SETUP_GROUP_BY_RELEASE_TYPES_2
+	DE	Gruppieren Sie alle Veröffentlichungen nach Typ
+	EN	Group all lists by release type
+	FR	Regrouper tous les sorties par type
+	NL	Groepeer alle releases op type
 
 SETUP_GROUPDISCS
 	CS	Disky skupiny


### PR DESCRIPTION
There's a new Material feature which subdivides album lists into release types, even when showing all albums (ie with no artist_id search criteria)

This PR introduces a third mode for the Release Type grouping option so that users can choose whether or not to use this new feature. 

I've also amended Releases.pm so that this new option works for the Default web ui, Squeezer, etc. The way I've done this is by removing `@$searchTags` from the searchTags list passed in to the various release type items. We haven't needed these anyway since we started passing in an album_id list. As it was, the menu items created by Releases.pm didn't work properly when an empty artist_id was passed in, as it will be under this new option.

I've tested with Default Skin, Squeezer and SB Touch.

Hope this makes sense.