### PR TITLE
clone song bug + add one method

### DIFF
--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -12,6 +12,7 @@ use strict;
 use base qw(Slim::Utils::Accessor);
 
 use Fcntl qw(SEEK_CUR SEEK_SET);
+use Clone qw(clone);
 
 use Slim::Utils::Log;
 use Slim::Schema;
@@ -168,7 +169,7 @@ sub clonePlaylistSong {
 	);
 
 	foreach ('handler', @_playlistCloneAttributes) {
-		$new->init_accessor($_ => $old->$_());
+		$new->init_accessor($_ => clone($old->$_()));
 	}
 
 	$_liveCount++;

--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -366,6 +366,11 @@ sub _Playing {
 		main::INFOLOG && $log->info("Song " . $last_song->index() . " has now started playing");
 		$last_song->setStatus(Slim::Player::Song::STATUS_PLAYING);
 		$last_song->retryData(undef);	# we are playing so we must be done retrying
+		if ($last_song->currentTrackHandler()->can('onPlay')) {
+			foreach my $player (@{$self->{'players'}}) {
+				$last_song->currentTrackHandler()->onPlay($player, $last_song);
+			}
+		}
 	}
 	
 	# Update a few timestamps


### PR DESCRIPTION
Two changes 

1- small one is adding a method as a provision for 8.5 when a track has started, we call the PH in case it wants to do something for each player. Not important but might be useful one day and as 8.5 will probably be widely used, better do that now.

2- The other one, which lead me to try 1- as a workaround drove me nuts... In the Deezer plugin, I could not get metadata changes to happen at the time (was way in advance, as in current plugin). After a lot of swearing and sweating, I realized that the $song->pluginData of the *next* track was in fact pointing to current track's pluginData. So when changing some of it in the next, it was of course being modified in the current one. It happens because when cloning song, it's a simple copy of attributes, including hashrefs. 
There is a user-level workaround to initialize the new $song's pluginData object with an empty hash before setting anything in it. Still, I don't think that was the intent when cloning a song so I think we should do a proper clone of all its attribute, unless you think it was purposely done a shallow copy.