### PR TITLE
Correction to Album listing (Default Skin) Track favourites link

### DIFF
--- a/HTML/Default/xmlbrowser.html
+++ b/HTML/Default/xmlbrowser.html
@@ -166,8 +166,8 @@ useSpecialExt="-browse" %]
 
 		[% IF item.favorites == 1 %]
 			[% WRAPPER favaddlink noTarget=1 %]
-				[% IF item.type == 'audio' && item.favorites_url %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.favorites_url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
+				[% IF item.type == 'audio' && item.url %]
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
 				[% ELSIF songinfo.favorites %]
 				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.values.-1 | html %]');"
 				[% ELSIF item.simpleAlbumLink && item.favorites_url %]
@@ -178,8 +178,8 @@ useSpecialExt="-browse" %]
 			[% END %]
 		[% ELSIF item.favorites == 2 %]
 			[% WRAPPER favdellink noTarget=1 %]
-				[% IF item.type == 'audio' && item.favorites_url %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.favorites_url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
+				[% IF item.type == 'audio' && item.url %]
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
 				[% ELSIF songinfo.favorites %]
 				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.values.-1 | html %]');"
 				[% ELSE %]

--- a/HTML/Default/xmlbrowser.html
+++ b/HTML/Default/xmlbrowser.html
@@ -166,7 +166,9 @@ useSpecialExt="-browse" %]
 
 		[% IF item.favorites == 1 %]
 			[% WRAPPER favaddlink noTarget=1 %]
-				[% IF songinfo.favorites %]
+				[% IF item.type == 'audio' && item.favorites_url %]
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.favorites_url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
+				[% ELSIF songinfo.favorites %]
 				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.values.-1 | html %]');"
 				[% ELSIF item.simpleAlbumLink && item.favorites_url %]
 				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.favorites_url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
@@ -176,7 +178,9 @@ useSpecialExt="-browse" %]
 			[% END %]
 		[% ELSIF item.favorites == 2 %]
 			[% WRAPPER favdellink noTarget=1 %]
-				[% IF songinfo.favorites %]
+				[% IF item.type == 'audio' && item.favorites_url %]
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.favorites_url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
+				[% ELSIF songinfo.favorites %]
 				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.values.-1 | html %]');"
 				[% ELSE %]
 				onclick="Browse.XMLBrowser.toggleFavorite(this, '[% (item.index || index _ (start + loop.index)) | uri | replace("'", "%27") %]', '[% pageinfo.startitem %]', '[% sess %]');"

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1795,8 +1795,6 @@ sub _tracks {
 					delete $_->{'artwork_track_id'};
 					$_->{'playall'} = 1;
 				}
-
-				$_->{'favorites_url'} = $_->{'url'};
 			}
 
 			my $params = _tagsToParams(\@searchTags);

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1795,6 +1795,8 @@ sub _tracks {
 					delete $_->{'artwork_track_id'};
 					$_->{'playall'} = 1;
 				}
+
+				$_->{'favorites_url'} = $_->{'url'};
 			}
 
 			my $params = _tagsToParams(\@searchTags);


### PR DESCRIPTION
See https://forums.slimdevices.com/forum/user-forums/logitech-media-server/1681581-track-favourites-in-default-skin

The problem is that $songinfo (in Slim/Web/XMLBrowser.pm) always contains the album header info in the album view, so it should not be used to create a track favourite. I'm looking at $item instead, if it's a track (type==audio).

I've tried to be as light-touch as possible in this change, but:
1. Has it really been wrong effectively for ever?
2. Is this the best way of addressing the problem?