### PR TITLE
honor favorites_type

### DIFF
--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -1001,7 +1001,7 @@ sub handleFeed {
 				my $name = $item->{'favorites_title'} || $item->{'name'};
 				my $icon = $item->{'favorites_icon'} || $item->{'image'} || $item->{'icon'} || Slim::Player::ProtocolHandlers->iconForURL($furl);
 
-				if ( $item->{'play'}
+				if ( ($item->{'play'} && !$item->{'favorites_type'}) 
 				    || ($type eq 'playlist' && $furl =~ /^(file|db):/)
 				) {
 					$type = 'audio';


### PR DESCRIPTION
in Web::XMLBrowser, when a key 'favorites_type' is set by plugin/user code, it is overwritten by LMS at favorite creation if the type of the feed item is 'audio'. Such type is itself forced when a 'play' key has been set in the OPML item, regardless of the key 'type'.

The consequence is that if an object is of type 'playlist' but has a 'play' key set, it will not be stored in favorites as per favorites_type wants (e.g. 'playlist'), it will be only 'audio'. Later, from favorites list at the root level, when user clicks on it and because it's an 'audio', LMS won't call explodePlaylist which means content cannot be viewed exploded in OPML feed before being played.

The solution is not really to *not* add a 'play' key in the original feed when type is 'playlist' because then, even if the object is a stored as a 'playlist' in favorite, LMS does not display the "MoreInfo" icon when the key 'play' is missing (see xmlbrowser.html, usage of key 'mixersLink').

So I need the key 'play' to get the "moreInfo" displayed but I need no key 'play' to have the favorites being stored as required by favorites_type. Long story short, and regardless, the favorites_type should always be honored and it happens to solve the issue 😄 

