### PR TITLE
Add icon to favorites when using toggleButtonHandler

### DIFF
--- a/HTML/Default/xmlbrowser.html
+++ b/HTML/Default/xmlbrowser.html
@@ -170,7 +170,7 @@ useSpecialExt="-browse" %]
 		[% IF item.favorites == 1 %]
 			[% WRAPPER favaddlink noTarget=1 %]
 				[% IF songinfo.favorites && item.type != 'audio' %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% songinfo.favorites_title | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 				[% ELSIF item.simpleAlbumLink && item.favorites_url %]
 				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.favorites_url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
 				[% ELSE %]
@@ -180,7 +180,7 @@ useSpecialExt="-browse" %]
 		[% ELSIF item.favorites == 2 %]
 			[% WRAPPER favdellink noTarget=1 %]
 				[% IF songinfo.favorites && item.type != 'audio' %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% songinfo.favorites_title | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 				[% ELSE %]
 				onclick="Browse.XMLBrowser.toggleFavorite(this, '[% (item.index || index _ (start + loop.index)) | uri | replace("'", "%27") %]', '[% pageinfo.startitem %]', '[% sess %]');"
 				[% END %]
@@ -209,11 +209,11 @@ useSpecialExt="-browse" %]
 	[%- BLOCK allcontrol -%]
 		[% IF songinfo.favorites == 1 %]
 			[% WRAPPER favaddlink noTarget=1 %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% songinfo.favorites_title | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 			[% END %]
 		[% ELSIF songinfo.favorites == 2 %]
 			[% WRAPPER favdellink noTarget=1 %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', [% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% songinfo.favorites_title | html | replace("'", "%27") %]', [% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 			[% END %]
 		[% END %]
 

--- a/HTML/Default/xmlbrowser.html
+++ b/HTML/Default/xmlbrowser.html
@@ -170,7 +170,7 @@ useSpecialExt="-browse" %]
 		[% IF item.favorites == 1 %]
 			[% WRAPPER favaddlink noTarget=1 %]
 				[% IF songinfo.favorites && item.type != 'audio' %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 				[% ELSIF item.simpleAlbumLink && item.favorites_url %]
 				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% item.favorites_url | uri | replace("'", "%27") %]', '[% (item.name _ " " _ stringBY _ " " _ item.artist) | uri | replace("'", "%27") %]');"
 				[% ELSE %]
@@ -180,7 +180,7 @@ useSpecialExt="-browse" %]
 		[% ELSIF item.favorites == 2 %]
 			[% WRAPPER favdellink noTarget=1 %]
 				[% IF songinfo.favorites && item.type != 'audio' %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 				[% ELSE %]
 				onclick="Browse.XMLBrowser.toggleFavorite(this, '[% (item.index || index _ (start + loop.index)) | uri | replace("'", "%27") %]', '[% pageinfo.startitem %]', '[% sess %]');"
 				[% END %]
@@ -209,11 +209,11 @@ useSpecialExt="-browse" %]
 	[%- BLOCK allcontrol -%]
 		[% IF songinfo.favorites == 1 %]
 			[% WRAPPER favaddlink noTarget=1 %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', '[% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 			[% END %]
 		[% ELSIF songinfo.favorites == 2 %]
 			[% WRAPPER favdellink noTarget=1 %]
-				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]');"
+				onclick="SqueezeJS.Utils.toggleFavorite(this, '[% songinfo.favorites_url | uri | replace("'", "%27") %]', '[% crumb.name | html | replace("'", "%27") %]', [% songinfo.favorites_icon | uri | replace("'", "%27") %]');"
 			[% END %]
 		[% END %]
 

--- a/HTML/EN/cmdwrappers
+++ b/HTML/EN/cmdwrappers
@@ -263,7 +263,7 @@ END %]
 			END; 
 
 			WRAPPER $linktype noTarget=1;
-				IF !ajaxRequest %]href="javascript:void(0);" onClick="[% IF useExtJS; 'SqueezeJS.Utils.'; END %]toggleFavorite(this, '[% (itemobj.url || item.url) | uri  | replace("'", "%27") %]', '[% (item.text || item.title || itemobj.title || item.name) | uri  | replace("'", "%27") %]')"[% END;
+				IF !ajaxRequest %]href="javascript:void(0);" onClick="[% IF useExtJS; 'SqueezeJS.Utils.'; END %]toggleFavorite(this, '[% (itemobj.url || item.url) | uri  | replace("'", "%27") %]', '[% (item.text || item.title || itemobj.title || item.name) | uri  | replace("'", "%27") %]', '[% (itemobj.icon || item.icon) | uri  | replace("'", "%27") %]')"[% END;
 			END;
 		END -%]
 [% END %]

--- a/HTML/EN/html/SqueezeJS/Base.js
+++ b/HTML/EN/html/SqueezeJS/Base.js
@@ -853,7 +853,7 @@ SqueezeJS.Utils = {
 		return (remaining ? '-' : '') + formattedTime;
 	},
 
-	toggleFavorite : function(el, url, title) {
+	toggleFavorite : function(el, url, title, icon) {
 		var el = Ext.get(el);
 		if (el) {
 			if (SqueezeJS.UI)
@@ -861,7 +861,7 @@ SqueezeJS.Utils = {
 
 			el.getUpdateManager().showLoadIndicator = false;
 			el.load({
-				url: 'plugins/Favorites/favcontrol.html?url=' + url + '&title=' + title + '&player=' + player,
+				url: 'plugins/Favorites/favcontrol.html?url=' + url + '&title=' + title + '&icon=' + icon + '&player=' + player,
 				method: 'GET'
 			});
 		}

--- a/HTML/EN/html/global.js
+++ b/HTML/EN/html/global.js
@@ -42,10 +42,10 @@ function ajaxUpdate(url, params) {
 	} );
 }
 
-function toggleFavorite(el, url, title) {
+function toggleFavorite(el, url, title, icon) {
 	new Ajax.Updater( { success: el }, 'plugins/Favorites/favcontrol.html', {
 		method: 'post',
-		postBody: 'url=' + url + '&title=' + title,
+		postBody: 'url=' + url + '&title=' + title + '&icon=' + icon,
 		asynchronous: true,
 		onFailure: function(t) {
 			alert('Error -- ' + t.responseText);

--- a/Slim/Plugin/Favorites/Plugin.pm
+++ b/Slim/Plugin/Favorites/Plugin.pm
@@ -258,6 +258,7 @@ sub toggleButtonHandler {
 	$params->{itemobj} = {
 		url => $params->{url},
 		title => $params->{title},
+		icon => $params->{icon},
 	};
 
 	if ($favs && $params->{url}) {
@@ -270,7 +271,7 @@ sub toggleButtonHandler {
 
 		else {
 
-			$favs->add( $params->{url}, $params->{title} || $params->{url} );
+			$favs->add( $params->{url}, $params->{title} || $params->{url}, undef, undef, undef, $params->{icon} );
 			$params->{item}->{isFavorite} = defined $favs->findUrl($params->{url});
 		}
 	}

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -984,6 +984,7 @@ sub handleFeed {
 
 				if ($feed->{'favorites_url'} && $favs) {
 					$details->{'favorites_url'} = $feed->{'favorites_url'};
+					$details->{'favorites_icon'} = $feed->{'favorites_icon'};
 					$details->{'favorites'} = $favs->hasUrl($feed->{'favorites_url'}) ? 2 : 1;
 				}
 

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -983,6 +983,8 @@ sub handleFeed {
 				}
 
 				if ($feed->{'favorites_url'} && $favs) {
+					my $icon = $feed->{'favorites_icon'} || $feed->{'icon'} || $feed->{'image'} || $feed->{'cover'};
+					$details->{'favorites_icon'} = $icon if $icon;					
 					$details->{'favorites_url'} = $feed->{'favorites_url'};
 					$details->{'favorites_icon'} = $feed->{'favorites_icon'} if $feed->{'favorites_icon'};
 					$details->{'favorites'} = $favs->hasUrl($feed->{'favorites_url'}) ? 2 : 1;

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -983,8 +983,7 @@ sub handleFeed {
 				}
 
 				if ($feed->{'favorites_url'} && $favs) {
-					my $icon = $feed->{'favorites_icon'} || $feed->{'icon'} || $feed->{'image'} || $feed->{'cover'};
-					$details->{'favorites_icon'} = $icon if $icon;					
+					$details->{'favorites_icon'} = $feed->{'favorites_icon'} || $feed->{'icon'} || $feed->{'image'} || $feed->{'cover'} || Slim::Player::ProtocolHandlers->iconForURL($feed->{'favorites_url'}, $client);
 					$details->{'favorites_url'} = $feed->{'favorites_url'};
 					$details->{'favorites_title'} = $feed->{'favorites_title'} || $feed->{'title'} || $feed->{'name'};
 					$details->{'favorites'} = $favs->hasUrl($feed->{'favorites_url'}) ? 2 : 1;

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -986,6 +986,7 @@ sub handleFeed {
 					my $icon = $feed->{'favorites_icon'} || $feed->{'icon'} || $feed->{'image'} || $feed->{'cover'};
 					$details->{'favorites_icon'} = $icon if $icon;					
 					$details->{'favorites_url'} = $feed->{'favorites_url'};
+					$details->{'favorites_title'} = $feed->{'favorites_title'} || $feed->{'title'} || $feed->{'name'};
 					$details->{'favorites'} = $favs->hasUrl($feed->{'favorites_url'}) ? 2 : 1;
 				}
 
@@ -1079,7 +1080,7 @@ sub handleFeed {
 		}
 	}
 
-#	$log->error(Data::Dump::dump($stash->{'items'}));
+
 
 	my $output = processTemplate($template, $stash);
 

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -986,7 +986,6 @@ sub handleFeed {
 					my $icon = $feed->{'favorites_icon'} || $feed->{'icon'} || $feed->{'image'} || $feed->{'cover'};
 					$details->{'favorites_icon'} = $icon if $icon;					
 					$details->{'favorites_url'} = $feed->{'favorites_url'};
-					$details->{'favorites_icon'} = $feed->{'favorites_icon'} if $feed->{'favorites_icon'};
 					$details->{'favorites'} = $favs->hasUrl($feed->{'favorites_url'}) ? 2 : 1;
 				}
 

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -984,7 +984,7 @@ sub handleFeed {
 
 				if ($feed->{'favorites_url'} && $favs) {
 					$details->{'favorites_url'} = $feed->{'favorites_url'};
-					$details->{'favorites_icon'} = $feed->{'favorites_icon'};
+					$details->{'favorites_icon'} = $feed->{'favorites_icon'} if $feed->{'favorites_icon'};
 					$details->{'favorites'} = $favs->hasUrl($feed->{'favorites_url'}) ? 2 : 1;
 				}
 


### PR DESCRIPTION
To complete previous PR, this allows as well adding an icon when the method used to add a favorite is "toggleButtonHandler" which is using the songinfo data. The url might not always have an icon or a plugin might want to overwrite that icon. It is doable today when favs are added using Browse.XMLBrowser.toggleFavorite because the feed/tree is re-drilled and the "favorites_icon" key is honored, but when using SqueezeJS.Utils.toggleFavorite (songinfo) then the favorite_icon is ignored.