### PR TITLE
use proper order of options in feed for title

### DIFF
--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -1001,7 +1001,8 @@ sub handleFeed {
 
 				my $type = $item->{'favorites_type'} || $item->{'type'} || 'link';
 				my $name = $item->{'favorites_title'} || $item->{'name'};
-				my $icon = $item->{'favorites_icon'} || $item->{'image'} || $item->{'icon'} || Slim::Player::ProtocolHandlers->iconForURL($furl, $client);
+				my $icon = $item->{'favorites_icon'} || $item->{'image'} || $item->{'icon'} || 
+						   Slim::Player::ProtocolHandlers->iconForURL($furl, $client) || 'html/images/favorites.png';
 
 				if ( ($item->{'play'} && !$item->{'favorites_type'})
 				    || ($type eq 'playlist' && $furl =~ /^(file|db):/)

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -985,7 +985,7 @@ sub handleFeed {
 				if ($feed->{'favorites_url'} && $favs) {
 					$details->{'favorites_icon'} = $feed->{'favorites_icon'} || $feed->{'icon'} || $feed->{'image'} || $feed->{'cover'} || Slim::Player::ProtocolHandlers->iconForURL($feed->{'favorites_url'}, $client);
 					$details->{'favorites_url'} = $feed->{'favorites_url'};
-					$details->{'favorites_title'} = $feed->{'favorites_title'} || $feed->{'title'} || $feed->{'name'};
+					$details->{'favorites_title'} = $feed->{'favorites_title'} || $feed->{'name'} || $feed->{'title'};
 					$details->{'favorites'} = $favs->hasUrl($feed->{'favorites_url'}) ? 2 : 1;
 				}
 


### PR DESCRIPTION
I uses the wrong order to the title of the favorites when gong album->track->text->heart, that causes the "information" to be added, as it is the title of the window