### PR TITLE
Add install recommended third party plugins to the wizard

### DIFF
--- a/HTML/EN/settings/server/wizard.html
+++ b/HTML/EN/settings/server/wizard.html
@@ -130,6 +130,12 @@
 				width: 400px;
 			}
 
+			.largeleftbox {
+                width: 75%;
+                max-width: 690px;
+                margin: 20 0 0 20px; 
+            }
+
 			.box-top {
 				background-image: linear-gradient(to bottom, #FFFFFF 0%, #CCCCCC);
 				border: 1px solid #666666;
@@ -340,6 +346,32 @@
 					<div>
 						<input type="text" name="playlistdir" id="playlistdir" value="[% prefs.playlistdir | html %]" class="wz_path">
 					</div>
+				</div>
+			</div>
+
+			<div id="plugins_p" class="wz_page">
+				<div id="plugins_h" class="pagetitle">[% "SETUP_WIZARD_PLUGINS_HEADER" | string %]</div>				
+				<div class="wz_desc">
+					<div class="box largeleftbox">
+						<div class="box-top">
+							<h1>[% "SETUP_WIZARD_PLUGINS_DESC" | string %]</h1>
+						</div>
+						<div class="box-inner">
+							<p>[% "SETUP_WIZARD_PLUGINS_GUIDANCE" | string %]</p>
+							<br/>
+							<input name="installthirdpartyplugins" id="installthirdpartyplugins" type="checkbox" [% IF prefs.installthirdpartyplugins %] checked [% END %]>
+							<label for="installthirdpartyplugins">[% "SETUP_WIZARD_PLUGINS_LABEL" | string %]</label>
+							<br/>
+							<ul class="howto">								
+								[% FOREACH plugin = plugins %]
+									<li><strong>[% plugin.title %]</strong> - [% plugin.desc %] [% "BY" | string %] [% plugin.creator %]</li>
+								[% END %]        
+							</ul> 
+						</div>
+						<div class="box-bottom">
+							&nbsp;
+						</div>
+					</div>					
 				</div>
 			</div>
 

--- a/strings.txt
+++ b/strings.txt
@@ -9446,6 +9446,18 @@ SETUP_WIZARD_SUMMARY_MUSICSOURCE
 	RU	Источник музыки
 	SV	Musikkälla
 
+SETUP_WIZARD_PLUGINS_HEADER
+	EN	Install recommended 3rd Party Plugins
+
+SETUP_WIZARD_PLUGINS_DESC
+	EN	Add some community plugins!
+
+SETUP_WIZARD_PLUGINS_GUIDANCE
+	EN	The following are plugins have been created and recommended by the community, select below to automatically install them.  The server will need to be restarted once you have completed setup to complete install.
+
+SETUP_WIZARD_PLUGINS_LABEL
+	EN	Install the third party plugins listed below
+
 SETUP_WIZARD_DONE
 	CS	Nastavení Lyrion Music Serveru bylo dokončeno!
 	DA	Konfigurationen af Lyrion Music Server er gennemført.


### PR DESCRIPTION
This is a first pass ready for discussion.  Not for merging!

As discussed in the forum, I've added this code to the first time run wizard as a suggestion for an 'opt in' install of recommended community plugins.  
Some of the things to discuss:

1.  I suggest we have a specific dedicated repo with the small subset of recommended plugins hosted in the same place as the 'extensions.xml' and updated by the same github actions .  At the moment for testing I'm hosting a 'recommendedextensions.xml' with a few plugins in it and temporarily hardcoded that into code : https://plugins.expectingtofly.co.uk/recommendedextensions.xml  .  That means I can simply reuse the existing repo code.
2. The wizard html/css itself probably needs a bit of a refresh to make it look a bit more modern and easier to use on a touchscreen (somebody with appropriate UX skills should probably do that :-) )
3. I think we need to make Material the default web interface if a user chooses to install the recommended plugins.  Agreed?    If so, I think we should ask Material to check for the a server preference on install (recommended 3rd party plugins installed setting) and make itself the default skin if that is set to true, rather than hard code Material into LMS.  Agreed?
4. Obviously, the server needs a restart after the plugins have been downloaded.  I wasn't sure when the best moment to trigger that is, or ask the user to restart?  Any suggestions?
5. Not sure how we choose the recommended plugins,  obviously Material and MAI, but the services themselves, its a bit tricky which ones to pick.  I guess we ask the community?

![image](https://github.com/LMS-Community/slimserver/assets/73394021/97935308-8dc2-4be7-8d74-ec7ae5bea0f9)




