### PR TITLE
Fix RemoteTrack.pm for grouping

### DIFF
--- a/Slim/Schema/RemoteTrack.pm
+++ b/Slim/Schema/RemoteTrack.pm
@@ -58,6 +58,7 @@ my @allAttributes = (qw(
 	error
 
 	work
+	grouping
 ));
 
 {


### PR DESCRIPTION
This was difficult to find: if the selected Settings->Interface->Title Format included GROUPING, Qobuz items could not be added to the playlist.

This is the fix.