### PR TITLE
Works artists - output standard Artist(s), Orchestra, Conductor 

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -825,23 +825,27 @@ sub albumsQuery {
 			$tags =~ /W/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'release_type', $wantsReleaseTypes ? $c->{'albums.release_type'} : 'ALBUM');
 			$tags =~ /E/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'extid', $c->{'albums.extid'});
 			$tags =~ /X/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'album_replay_gain', $c->{'albums.replay_gain'});
-			$tags =~ /S/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist_id', $contributorID || $c->{'albums.contributor'});
 
-			if ($tags =~ /a/) {
-				# Bug 15313, this used to use $eachitem->artists which
-				# contains a lot of extra logic.
+			#Don't use albums.contributor to set artist_id/artist for Works, it may well be completely wrong!
+			if ( !$work ) {
+				$tags =~ /S/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist_id', $contributorID || $c->{'albums.contributor'});
 
-				# Bug 17542: If the album artist is different from the current track's artist,
-				# use the album artist instead of the track artist (if available)
-				if ($contributorID && $c->{'albums.contributor'} && $contributorID != $c->{'albums.contributor'}) {
-					$contributorNameSth ||= $dbh->prepare_cached('SELECT name FROM contributors WHERE id = ?');
-					my ($name) = @{ $dbh->selectcol_arrayref($contributorNameSth, undef, $c->{'albums.contributor'}) };
-					$c->{'contributors.name'} = $name if $name;
+				if ($tags =~ /a/) {
+					# Bug 15313, this used to use $eachitem->artists which
+					# contains a lot of extra logic.
+
+					# Bug 17542: If the album artist is different from the current track's artist,
+					# use the album artist instead of the track artist (if available)
+					if ($contributorID && $c->{'albums.contributor'} && $contributorID != $c->{'albums.contributor'} && !$work) {
+						$contributorNameSth ||= $dbh->prepare_cached('SELECT name FROM contributors WHERE id = ?');
+						my ($name) = @{ $dbh->selectcol_arrayref($contributorNameSth, undef, $c->{'albums.contributor'}) };
+						$c->{'contributors.name'} = $name if $name;
+					}
+
+					utf8::decode( $c->{'contributors.name'} ) if exists $c->{'contributors.name'};
+
+					$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist', $c->{'contributors.name'});
 				}
-
-				utf8::decode( $c->{'contributors.name'} ) if exists $c->{'contributors.name'};
-
-				$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist', $c->{'contributors.name'});
 			}
 
 			if ($tags =~ /s/) {
@@ -857,10 +861,32 @@ sub albumsQuery {
 				$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'textkey', $textKey);
 			}
 
+			# Override $contributorSql if we're dealing with a Work: output Artist, Orchestra, Conductor in that order.
+			if ( defined $work ) {
+				my @roles = ( 'ARTIST', 'BAND', 'CONDUCTOR' );
+				$contributorSql = sprintf( qq{
+					WITH temp as (
+					SELECT CASE WHEN contributor_track.role = 1 THEN 'ARTIST' WHEN contributor_track.role = 3 THEN 'CONDUCTOR' WHEN contributor_track.role = 4 THEN 'BAND' END role,
+					GROUP_CONCAT(DISTINCT contributors.name) AS name, GROUP_CONCAT(DISTINCT contributors.id) AS id
+					FROM tracks
+					JOIN contributor_track ON tracks.id = contributor_track.track
+					JOIN contributors ON contributors.id = contributor_track.contributor
+					WHERE tracks.album = ? AND tracks.work = ? AND contributor_track.role IN (%s) AND tracks.grouping %s
+					GROUP BY contributor_track.role
+					ORDER BY role)
+					SELECT GROUP_CONCAT(DISTINCT name) AS name, GROUP_CONCAT(DISTINCT id) AS id FROM temp
+				},
+				join(',', map { Slim::Schema::Contributor->typeToRole($_) } @roles),
+				$c->{'tracks.grouping'} ? "= ?" : "IS NULL");
+				$contributorSth = $dbh->prepare_cached($contributorSql);
+			}
 			# want multiple artists?
 			if ( $contributorSql && $c->{'albums.contributor'} != $vaObjId && !$c->{'albums.compilation'} ) {
 				$contributorSth ||= $dbh->prepare_cached($contributorSql);
-				$contributorSth->execute($c->{'albums.id'});
+				my $bindVars = [$c->{'albums.id'}];
+				push @$bindVars, $work if $work;
+				push @$bindVars, $c->{'tracks.grouping'} if $work && $c->{'tracks.grouping'};
+				$contributorSth->execute(@$bindVars);
 
 				my $contributor = $contributorSth->fetchrow_hashref;
 				$contributorSth->finish;
@@ -868,10 +894,12 @@ sub albumsQuery {
 				# XXX - what if the artist name itself contains ','?
 				if ( $tags =~ /aa/ && $contributor->{name} ) {
 					utf8::decode($contributor->{name});
+					$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist', (split(/,/, $contributor->{name}))[0]) if $work;
 					$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artists', $contributor->{name});
 				}
 
 				if ( $tags =~ /SS/ && $contributor->{id} ) {
+					$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist_id', (split(/,/, $contributor->{id}))[0]) if $work;
 					$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artist_ids', $contributor->{id});
 				}
 			}

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -865,15 +865,22 @@ sub albumsQuery {
 			if ( defined $work ) {
 				my @roles = ( 'ARTIST', 'BAND', 'CONDUCTOR' );
 				$contributorSql = sprintf( qq{
-					WITH temp as (
-					SELECT CASE WHEN contributor_track.role = 1 THEN 'ARTIST' WHEN contributor_track.role = 3 THEN 'CONDUCTOR' WHEN contributor_track.role = 4 THEN 'BAND' END role,
-					GROUP_CONCAT(DISTINCT contributors.name) AS name, GROUP_CONCAT(DISTINCT contributors.id) AS id
-					FROM tracks
-					JOIN contributor_track ON tracks.id = contributor_track.track
-					JOIN contributors ON contributors.id = contributor_track.contributor
-					WHERE tracks.album = ? AND tracks.work = ? AND contributor_track.role IN (%s) AND tracks.grouping %s
-					GROUP BY contributor_track.role
-					ORDER BY role)
+					WITH temp AS (
+						SELECT
+							CASE
+								WHEN contributor_track.role = 1 THEN 'ARTIST'
+								WHEN contributor_track.role = 3 THEN 'CONDUCTOR'
+								WHEN contributor_track.role = 4 THEN 'BAND'
+							END AS role,
+							GROUP_CONCAT(DISTINCT contributors.name) AS name,
+							GROUP_CONCAT(DISTINCT contributors.id) AS id
+						FROM tracks
+						JOIN contributor_track ON tracks.id = contributor_track.track
+						JOIN contributors ON contributors.id = contributor_track.contributor
+						WHERE tracks.album = ? AND tracks.work = ? AND contributor_track.role IN (%s) AND tracks.grouping %s
+						GROUP BY contributor_track.role
+						ORDER BY role
+					)
 					SELECT GROUP_CONCAT(DISTINCT name) AS name, GROUP_CONCAT(DISTINCT id) AS id FROM temp
 				},
 				join(',', map { Slim::Schema::Contributor->typeToRole($_) } @roles),

--- a/Slim/Menu/AlbumInfo.pm
+++ b/Slim/Menu/AlbumInfo.pm
@@ -246,6 +246,8 @@ sub infoContributors {
 
 				next unless $contributor->isInLibrary($library_id);
 
+				next if $filter->{work_id} && !$album->artistPerformsOnWork($filter->{work_id}, $filter->{grouping}, $contributor->id);
+
 				if ($linkRoles{$role}) {
 					my $id = $contributor->id;
 

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1931,8 +1931,10 @@ sub _tracks {
 				$albumId =~ s/album_id:// if $albumId;
 				my ($workId) = grep {/work_id:/} @searchTags;
 				$workId =~ s/work_id:// if $workId;
+				my ($grouping) = grep {/grouping:/} @searchTags;
+				$grouping =~ s/grouping:// if $grouping;
 				my $album = Slim::Schema->find( Album => $albumId );
-				my $feed  = Slim::Menu::AlbumInfo->menu( $client, $album->url, $album, undef, { library_id => $library_id, work_id => $workId, track_count => scalar @$items} ) if $album;
+				my $feed  = Slim::Menu::AlbumInfo->menu( $client, $album->url, $album, undef, { library_id => $library_id, work_id => $workId, grouping => $grouping, track_count => scalar @$items} ) if $album;
 				$albumMetadata = $feed->{'items'} if $feed;
 
 				$image = 'music/' . $album->artwork . '/cover' if $album && $album->artwork;


### PR DESCRIPTION
This follows a standard for classical music - showing artist(s), orchestra, conductor in that order.

Also makes sure that unrelated artists (ie ones only associated with other works on the album) are not shown.