### PR TITLE
Releases passthrough fix

### DIFF
--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -16,12 +16,14 @@ my $prefs = preferences('server');
 sub _releases {
 	my ($client, $callback, $args, $pt) = @_;
 	my @searchTags = $pt->{'searchTags'} ? @{$pt->{'searchTags'}} : ();
-	my $wantMeta   = $pt->{'wantMetadata'};
 	my $tags       = 'lWRSw';
 	my $library_id = $args->{'library_id'} || $pt->{'library_id'};
 	my $orderBy    = $args->{'orderBy'} || $pt->{'orderBy'};
 	my $menuMode   = $args->{'params'}->{'menu_mode'};
 	my $menuRoles  = $args->{'params'}->{'menu_roles'};
+
+	my $ptNoSearchTags = Storable::dclone($pt);
+	delete $ptNoSearchTags->{'searchTags'};
 
 	# map menuRoles to name for readability
 	$menuRoles = join(',', map { Slim::Schema::Contributor->roleToType($_) } split(',', $menuRoles || ''));
@@ -158,13 +160,13 @@ sub _releases {
 
 		if ($releaseTypes{uc($releaseType)}) {
 			push @items, _createItem($name, $releaseType eq 'COMPILATION'
-					? [ { searchTags => [@$searchTags, 'compilation:1', "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]
-					: [ { searchTags => [@$searchTags, "compilation:0", "release_type:$releaseType", "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]);
+					? [ { %$ptNoSearchTags, searchTags => [@$searchTags, 'compilation:1', "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]
+					: [ { %$ptNoSearchTags, searchTags => [@$searchTags, "compilation:0", "release_type:$releaseType", "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]);
 		}
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSERALBUM}) {
-		push @items, _createItem(cstring($client, 'COMPOSERALBUMS'), [ { searchTags => [@$searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)] } ]);
+		push @items, _createItem(cstring($client, 'COMPOSERALBUMS'), [ { %$ptNoSearchTags, searchTags => [@$searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)] } ]);
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSER}) {
@@ -180,12 +182,12 @@ sub _releases {
 	}
 
 	if (my $albumIds = delete $contributions{TRACKARTIST}) {
-		push @items, _createItem(cstring($client, 'APPEARANCES'), [ { searchTags => [@$searchTags, "role_id:TRACKARTIST", "album_id:" . join(',', @$albumIds)] } ]);
+		push @items, _createItem(cstring($client, 'APPEARANCES'), [ { %$ptNoSearchTags, searchTags => [@$searchTags, "role_id:TRACKARTIST", "album_id:" . join(',', @$albumIds)] } ]);
 	}
 
 	foreach my $role (sort keys %contributions) {
 		my $name = cstring($client, $role) if Slim::Utils::Strings::stringExists($role);
-		push @items, _createItem($name || ucfirst($role), [ { searchTags => [@$searchTags, "role_id:$role", "album_id:" . join(',', @{$contributions{$role}})] } ]);
+		push @items, _createItem($name || ucfirst($role), [ { %$ptNoSearchTags, searchTags => [@$searchTags, "role_id:$role", "album_id:" . join(',', @{$contributions{$role}})] } ]);
 	}
 
 	# Add item for Classical Works if the artist has any.
@@ -229,7 +231,7 @@ sub _releases {
 			type        => 'playlist',
 			playlist    => \&_tracks,
 			url         => \&_albums,
-			passthrough => [{ searchTags => $pt->{'searchTags'} || [] }],
+			passthrough => [ $pt ],
 		};
 
 		my $result = $quantity == 1 ? {


### PR DESCRIPTION
To ensure that `$pt` elements other than `searchTags` from `_albumsOrReleases` are passed on to submenus in `Releases.pm`.

Previously, they were not passed through unless dropping through due to there being only one (or none) category identified.

I have also removed the locally declared `$wantMeta` (looks like it was sort of thought about!) because it is not used, and is now covered with this change.

Also see #1074 for 8.5 version.