### PR TITLE
Release types $pt refactoring

### DIFF
--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -16,14 +16,13 @@ my $prefs = preferences('server');
 sub _releases {
 	my ($client, $callback, $args, $pt) = @_;
 	my @searchTags = $pt->{'searchTags'} ? @{$pt->{'searchTags'}} : ();
+	my @originalSearchTags = @searchTags;
 	my $tags       = 'lWRSw';
 	my $library_id = $args->{'library_id'} || $pt->{'library_id'};
 	my $orderBy    = $args->{'orderBy'} || $pt->{'orderBy'};
 	my $menuMode   = $args->{'params'}->{'menu_mode'};
 	my $menuRoles  = $args->{'params'}->{'menu_roles'};
-
-	my $ptNoSearchTags = Storable::dclone($pt);
-	delete $ptNoSearchTags->{'searchTags'};
+$log->error("DK \$pt=" . Data::Dump::dump($pt));
 
 	# map menuRoles to name for readability
 	$menuRoles = join(',', map { Slim::Schema::Contributor->roleToType($_) } split(',', $menuRoles || ''));
@@ -153,16 +152,20 @@ sub _releases {
 
 	foreach my $releaseType (@sortedReleaseTypes) {
 		my $name = Slim::Schema::Album->releaseTypeName($releaseType, $client);
+		my $compilation = $releaseType eq 'COMPILATION' ? 1 : 0;
 
 		if ($releaseTypes{uc($releaseType)}) {
-			push @items, _createItem($name, $releaseType eq 'COMPILATION'
-					? [ { %$ptNoSearchTags, searchTags => [@searchTags, 'compilation:1', "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]
-					: [ { %$ptNoSearchTags, searchTags => [@searchTags, "compilation:0", "release_type:$releaseType", "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]);
+			$pt->{'searchTags'} = $releaseType eq 'COMPILATION'
+				? [@searchTags, 'compilation:1', "album_id:" . join(',', @{$albumList{$releaseType}})]
+				: [@searchTags, "compilation:0", "release_type:$releaseType", "album_id:" . join(',', @{$albumList{$releaseType}})];
+			push @items, _createItem($name, [ $pt ]);
+
 		}
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSERALBUM}) {
-		push @items, _createItem(cstring($client, 'COMPOSERALBUMS'), [ { %$ptNoSearchTags, searchTags => [@searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)] } ]);
+		$pt->{'searchTags'} = [@searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)];
+		push @items, _createItem(cstring($client, 'COMPOSERALBUMS'), [ $pt ]);
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSER}) {
@@ -178,12 +181,14 @@ sub _releases {
 	}
 
 	if (my $albumIds = delete $contributions{TRACKARTIST}) {
-		push @items, _createItem(cstring($client, 'APPEARANCES'), [ { %$ptNoSearchTags, searchTags => [@searchTags, "role_id:TRACKARTIST", "album_id:" . join(',', @$albumIds)] } ]);
+		$pt->{'searchTags'} = [@searchTags, "role_id:TRACKARTIST", "album_id:" . join(',', @$albumIds)];
+		push @items, _createItem(cstring($client, 'APPEARANCES'), [ $pt ]);
 	}
 
 	foreach my $role (sort keys %contributions) {
 		my $name = cstring($client, $role) if Slim::Utils::Strings::stringExists($role);
-		push @items, _createItem($name || ucfirst($role), [ { %$ptNoSearchTags, searchTags => [@searchTags, "role_id:$role", "album_id:" . join(',', @{$contributions{$role}})] } ]);
+		$pt->{'searchTags'} = [@searchTags, "role_id:$role", "album_id:" . join(',', @{$contributions{$role}})];
+		push @items, _createItem($name || ucfirst($role), [ $pt ]);
 	}
 
 	# Add item for Classical Works if the artist has any.
@@ -203,6 +208,9 @@ sub _releases {
 		passthrough => [ { searchTags => [@searchTags, "work_id:-1", "wantMetadata:1", "wantIndex:1"] } ],
 	} if ( $request->getResult('count') > 1 || ( scalar @items && $request->getResult('count') ) );
 
+	# restore original search tags
+	$pt->{'searchTags'} = [@originalSearchTags];
+	
 	# if there's only one category, display it directly
 	if (scalar @items == 1 && (my $handler = $items[0]->{url})) {
 		$handler->($client, $callback, $args, $pt);
@@ -247,6 +255,7 @@ sub _releases {
 
 sub _createItem {
 	my ($name, $pt) = @_;
+$log->error("DK \$pt=" . Data::Dump::dump($pt));
 
 	return {
 		name        => $name,


### PR DESCRIPTION
Before looking at backporting the recent changes to 8.5, I have attempted to tidy up: I didn't like the `dclone` I introduced very much, so replaced with direct manipulation of `$pt->{searchTags}`.

For me, at least, this is now cleaner and easier to understand. 

Thoughts?