### PR TITLE
utf8 decode for cache key

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -6057,7 +6057,7 @@ sub _getTagDataForTracks {
 	if ( $count_only || (my $limit = $args->{limit}) ) {
 		# Let the caller worry about the limit values
 
-		my $cacheKey = md5_hex($sql . join( '', @{$p}, @$w ) . (Slim::Utils::Text::ignoreCase($search, 1) || ''));
+		my $cacheKey = md5_hex($sql . utf8::decode(join( '', @{$p}, @$w )) . (Slim::Utils::Text::ignoreCase($search, 1) || ''));
 
 		# use short lived cache, as we might be dealing with changing data (eg. playcount)
 		if ( my $cached = $bmfCache{$cacheKey} ) {


### PR DESCRIPTION
`md5_hex` is failing when there are un-decoded utf8 characters in the input. This has arisen in the `_getTagDataForTracks` query because grouping may be part of the query. (Example: grouping="Kanka/Klepác")

I wonder if we should apply this to all `md5_hex` usages in Queries.pm where `$p` is part of the input string, just to be safe?