### PR TITLE
Backport fixes to Releases.pm (passthrough) and Commands.pm (adding multiple albums to playlist)

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -3432,7 +3432,7 @@ sub _playlistXtracksCommand_parseSearchTerms {
 
 		if ($sort && ($sort eq $albumSort || $sort eq $albumYearSort)) {
 			if ( $find{'me.album'} && ref $find{'me.album'} eq '') {
-				# Don't need album-sort if we have a specific album-id
+				# Don't need album-sort if we have a specific single album-id
 				$sort = undef;
 			} else {
 				# Bug: 3629 - if we're sorting by album - be sure to include it in the join table.

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -2035,10 +2035,16 @@ sub playlistcontrolCommand {
 		}
 
 		if (defined(my $album_id = $request->getParam('album_id'))) {
-			$what->{'album.id'} = $album_id;
-			my $album = Slim::Schema->find('Album', $album_id);
-			@info    = ( $album->title, $album->contributors->first->name );
-			$artwork = $album->artwork || 0;
+			if ( scalar split(/,/,$album_id) == 1 ) {
+				$what->{'album.id'} = $album_id;
+				my $album = Slim::Schema->find('Album', $album_id);
+				@info    = ( $album->title, $album->contributors->first->name );
+				$artwork = $album->artwork || 0;
+			} else {
+				$what->{'album.id'} = {
+					in => [ split(/,/,$album_id) ]
+				};
+			}
 		}
 
 		if (defined(my $year = $request->getParam('year'))) {
@@ -3425,7 +3431,7 @@ sub _playlistXtracksCommand_parseSearchTerms {
 		}
 
 		if ($sort && ($sort eq $albumSort || $sort eq $albumYearSort)) {
-			if ($find{'me.album'}) {
+			if ( $find{'me.album'} && ref $find{'me.album'} eq '') {
 				# Don't need album-sort if we have a specific album-id
 				$sort = undef;
 			} else {

--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -16,7 +16,7 @@ my $prefs = preferences('server');
 sub _releases {
 	my ($client, $callback, $args, $pt) = @_;
 	my @searchTags = $pt->{'searchTags'} ? @{$pt->{'searchTags'}} : ();
-	my $wantMeta   = $pt->{'wantMetadata'};
+	my @originalSearchTags = @searchTags;
 	my $tags       = 'lWRSw';
 	my $library_id = $args->{'library_id'} || $pt->{'library_id'};
 	my $orderBy    = $args->{'orderBy'} || $pt->{'orderBy'};
@@ -31,9 +31,6 @@ sub _releases {
 		# library_id:-1 is supposed to clear/override the global library_id
 		$_ && $_ !~ /(?:library_id\s*:\s*-1|remote_library)/
 	} @searchTags;
-
-	# we want all roles, as we're going to group
-	push @searchTags, 'role_id:' . join(',', Slim::Schema::Contributor->contributorRoleIds);
 
 	my @artistIds = grep /artist_id:/, @searchTags;
 	my $artistId;
@@ -137,8 +134,7 @@ sub _releases {
 
 	my @items;
 
-	my $searchTags = [ "library_id:$library_id" ];
-	push @$searchTags, "artist_id:$artistId" if $artistId;
+	@searchTags = grep { $_ !~ /^tags:/ }  @searchTags;
 
 	my @primaryReleaseTypes = map { uc($_) } @{Slim::Schema::Album->primaryReleaseTypes};
 	push @primaryReleaseTypes, 'COMPILATION';    # we handle compilations differently, it's not part of the primaryReleaseTypes
@@ -154,14 +150,16 @@ sub _releases {
 		my $name = Slim::Schema::Album->releaseTypeName($releaseType, $client);
 
 		if ($releaseTypes{uc($releaseType)}) {
-			push @items, _createItem($name, $releaseType eq 'COMPILATION'
-					? [ { searchTags => [@$searchTags, 'compilation:1', "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]
-					: [ { searchTags => [@$searchTags, "compilation:0", "release_type:$releaseType", "album_id:" . join(',', @{$albumList{$releaseType}})], orderBy => $orderBy } ]);
+			$pt->{'searchTags'} = $releaseType eq 'COMPILATION'
+				? [@searchTags, 'compilation:1', "album_id:" . join(',', @{$albumList{$releaseType}})]
+				: [@searchTags, "compilation:0", "release_type:$releaseType", "album_id:" . join(',', @{$albumList{$releaseType}})];
+			push @items, _createItem($name, [{%$pt}]);
 		}
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSERALBUM}) {
-		push @items, _createItem(cstring($client, 'COMPOSERALBUMS'), [ { searchTags => [@$searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)] } ]);
+		$pt->{'searchTags'} = [@searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)];
+		push @items, _createItem(cstring($client, 'COMPOSERALBUMS'), [{%$pt}]);
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSER}) {
@@ -172,18 +170,23 @@ sub _releases {
 			playlist    => \&_tracks,
 			# for compositions we want to have the compositions only, not the albums
 			url         => \&_tracks,
-			passthrough => [ { searchTags => [@$searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)] } ],
+			passthrough => [ { searchTags => [@searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)] } ],
 		};
 	}
 
 	if (my $albumIds = delete $contributions{TRACKARTIST}) {
-		push @items, _createItem(cstring($client, 'APPEARANCES'), [ { searchTags => [@$searchTags, "role_id:TRACKARTIST", "album_id:" . join(',', @$albumIds)] } ]);
+		$pt->{'searchTags'} = [@searchTags, "role_id:TRACKARTIST", "album_id:" . join(',', @$albumIds)];
+		push @items, _createItem(cstring($client, 'APPEARANCES'), [{%$pt}]);
 	}
 
 	foreach my $role (sort keys %contributions) {
 		my $name = cstring($client, $role) if Slim::Utils::Strings::stringExists($role);
-		push @items, _createItem($name || ucfirst($role), [ { searchTags => [@$searchTags, "role_id:$role", "album_id:" . join(',', @{$contributions{$role}})] } ]);
+		$pt->{'searchTags'} = [@searchTags, "role_id:$role", "album_id:" . join(',', @{$contributions{$role}})];
+		push @items, _createItem($name || ucfirst($role), [{%$pt}]);
 	}
+
+	# restore original search tags
+	$pt->{'searchTags'} = [@originalSearchTags];
 
 	# if there's only one category, display it directly
 	if (scalar @items == 1 && (my $handler = $items[0]->{url})) {
@@ -209,7 +212,7 @@ sub _releases {
 			type        => 'playlist',
 			playlist    => \&_tracks,
 			url         => \&_albums,
-			passthrough => [{ searchTags => $pt->{'searchTags'} || [] }],
+			passthrough => [ $pt ],
 		};
 
 		my $result = $quantity == 1 ? {


### PR DESCRIPTION
This backports #1083, #1084 and #1087 to 8.5.

As requested here https://github.com/LMS-Community/slimserver/pull/1083#issuecomment-2106649599 I tried a test merge of this into 9.0: 

It won't merge automatically with a standard merge:
```
<<<<<<< HEAD
	# Add item for Classical Works if the artist has any.
	push @searchTags, "role_id:$menuRoles" if $menuRoles && $menuMode && $menuMode ne 'artists';
	main::INFOLOG && $log->is_info && $log->info("works ($index, $quantity): tags ->", join(', ', @searchTags));
	my $requestRef = [ 'works', 0, MAX_ALBUMS, @searchTags ];
	my $request = Slim::Control::Request->new( $client ? $client->id() : undef, $requestRef );
	$request->execute();
	$log->error($request->getStatusText()) if $request->isStatusError();

	push @items, {
		name        => cstring($client, 'WORKS_CLASSICAL'),
		image       => 'html/images/works.png',
		type        => 'playlist',
		playlist    => \&_tracks,
		url         => \&_works,
		passthrough => [ { searchTags => [@searchTags, "work_id:-1", "wantMetadata:1", "wantIndex:1"] } ],
	} if ( $request->getResult('count') > 1 || ( scalar @items && $request->getResult('count') ) );

=======
>>>>>>> backport-releases-pt
```
 but since we don't need any actual code changes to 9.0 as a result of the merge, `git merge -s ours ...` does the job.


