### PR TITLE
Remove SQL Common Table Expressions (incompatible with old Sqlite binaries) 

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -753,7 +753,7 @@ sub albumsQuery {
 			if ( defined $work ) {
 				my @roles = ( 'ARTIST', 'BAND', 'CONDUCTOR' );
 				$contributorSql = sprintf( qq{
-					WITH temp AS (
+					SELECT GROUP_CONCAT(DISTINCT c.name) AS name, GROUP_CONCAT(DISTINCT c.id) AS id FROM (
 						SELECT
 							CASE
 								WHEN contributor_track.role = 1 THEN 'ARTIST'
@@ -769,8 +769,7 @@ sub albumsQuery {
 							AND ( (:grouping IS NULL AND tracks.grouping IS NULL) OR tracks.grouping = :grouping )
 						GROUP BY contributor_track.role
 						ORDER BY role
-					)
-					SELECT GROUP_CONCAT(DISTINCT name) AS name, GROUP_CONCAT(DISTINCT id) AS id FROM temp
+					) as c
 				},
 				join(',', map { Slim::Schema::Contributor->typeToRole($_) } @roles));
 			} else {

--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -565,10 +565,8 @@ sub _rebuildIndex {
 	$scanlog->error("Create fulltext index for works");
 	$progress && $progress->update(string('WORKS'));
 	Slim::Schema->forceCommit if main::SCANNER;
-	$sql = SQL_DROP_WORKTEMP;
-	$dbh->do($sql) or $scanlog->error($dbh->errstr);
-	$sql = SQL_CREATE_WORKTEMP;
-	$dbh->do($sql) or $scanlog->error($dbh->errstr);
+	$dbh->do(SQL_DROP_WORKTEMP) or $scanlog->error($dbh->errstr);
+	$dbh->do(SQL_CREATE_WORKTEMP) or $scanlog->error($dbh->errstr);
 	$sql = sprintf(SQL_CREATE_WORK_ITEM, '', '');
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
 	main::idleStreams() unless main::SCANNER;


### PR DESCRIPTION
The fulltext works creation now uses a temporary table, doesn't effect performance with the 43000 track classical test database, takes about 10 seconds old and new.

I've also replaced the CTE in albumsquery with a sub-select.