### PR TITLE
[Feature] Add Restart Button to Server Settings

### DIFF
--- a/HTML/EN/settings/server/basic.html
+++ b/HTML/EN/settings/server/basic.html
@@ -95,7 +95,7 @@
 
 	[% IF can_restart %]
 		[% WRAPPER setting title="SETUP_RESTART" desc="SETUP_RESTART_DESC" %]
-			<input name="pref_restart" type="submit" class="stdclick disableOnScan" value="[% "SETUP_RESTART_BUTTON" | string %]" [% IF scanning %]disabled[% END %]>
+			<input name="do_restart" type="submit" class="stdclick disableOnScan" value="[% "SETUP_RESTART_BUTTON" | string %]" [% IF scanning %]disabled[% END %]>
 		[% END %]
 	[% END %]
 

--- a/HTML/EN/settings/server/basic.html
+++ b/HTML/EN/settings/server/basic.html
@@ -93,4 +93,10 @@
 		<a id="progressLink" href="[% webroot %]settings/server/status.html?player=[% playerid %]">[% IF scanning %][% "SETUP_VIEW_SCANNING" | string %][% ELSE %][% "SETUP_VIEW_NOT_SCANNING" | string %][% END %]</a>
 	[% END %]
 
+	[% IF os_can_restart %]
+		[% WRAPPER setting title="SETUP_RESTART" desc="SETUP_RESTART_DESC" %]
+			<input name="pref_restart" type="submit" class="stdclick disableOnScan" value="[% "SETUP_RESTART_BUTTON" | string %]" [% IF scanning %]disabled[% END %]>
+		[% END %]
+	[% END %]
+
 [% PROCESS settings/footer.html %]

--- a/HTML/EN/settings/server/basic.html
+++ b/HTML/EN/settings/server/basic.html
@@ -93,7 +93,7 @@
 		<a id="progressLink" href="[% webroot %]settings/server/status.html?player=[% playerid %]">[% IF scanning %][% "SETUP_VIEW_SCANNING" | string %][% ELSE %][% "SETUP_VIEW_NOT_SCANNING" | string %][% END %]</a>
 	[% END %]
 
-	[% IF os_can_restart %]
+	[% IF can_restart %]
 		[% WRAPPER setting title="SETUP_RESTART" desc="SETUP_RESTART_DESC" %]
 			<input name="pref_restart" type="submit" class="stdclick disableOnScan" value="[% "SETUP_RESTART_BUTTON" | string %]" [% IF scanning %]disabled[% END %]>
 		[% END %]

--- a/Slim/Web/Settings/Server/Basic.pm
+++ b/Slim/Web/Settings/Server/Basic.pm
@@ -59,6 +59,9 @@ sub handler {
 
 		Slim::Control::Request::executeRequest(undef, $rescanType);
 		$runScan = 1;
+	} elsif ($paramRef->{'pref_restart'}) {
+		$paramRef->{restart} = 1;
+		$paramRef = Slim::Web::Settings::Server::Plugins->restartServer($paramRef, 1);
 	}
 
 	if ( $paramRef->{'saveSettings'} ) {

--- a/Slim/Web/Settings/Server/Basic.pm
+++ b/Slim/Web/Settings/Server/Basic.pm
@@ -59,7 +59,7 @@ sub handler {
 
 		Slim::Control::Request::executeRequest(undef, $rescanType);
 		$runScan = 1;
-	} elsif ($paramRef->{'pref_restart'}) {
+	} elsif ($paramRef->{'do_restart'}) {
 		$paramRef->{restart} = 1;
 		$paramRef = Slim::Web::Settings::Server::Plugins->restartServer($paramRef, 1);
 	}

--- a/Slim/Web/Settings/Server/Basic.pm
+++ b/Slim/Web/Settings/Server/Basic.pm
@@ -159,6 +159,7 @@ sub handler {
 sub beforeRender {
 	my ($class, $paramRef) = @_;
 	$paramRef->{'scanning'} = Slim::Music::Import->stillScanning;
+	$paramRef->{'os_can_restart'} = Slim::Utils::OSDetect->getOS()->canRestartServer();
 }
 
 1;

--- a/Slim/Web/Settings/Server/Basic.pm
+++ b/Slim/Web/Settings/Server/Basic.pm
@@ -162,7 +162,7 @@ sub handler {
 sub beforeRender {
 	my ($class, $paramRef) = @_;
 	$paramRef->{'scanning'} = Slim::Music::Import->stillScanning;
-	$paramRef->{'os_can_restart'} = Slim::Utils::OSDetect->getOS()->canRestartServer();
+	$paramRef->{'can_restart'} = main::canRestartServer();
 }
 
 1;

--- a/strings.txt
+++ b/strings.txt
@@ -24670,3 +24670,14 @@ SETUP_YEARMENU_1
 	FR	Afficher les années des albums et des pistes
 	NL	Toon album- en trackjaren
 
+SETUP_RESTART
+	DE	Neustart
+	EN	Restart
+
+SETUP_RESTART_BUTTON
+	DE	Neu starten
+	EN	Restart
+
+SETUP_RESTART_DESC
+	DE	Klicken Sie auf 'Neu starten', damit Logitech Media Server neu startet.
+	EN	Click Restart to have Logitech Media Server restarted.


### PR DESCRIPTION
Added a button to the server's basic settings.
Have to find out how to do a restart from web correctly (maybe re-using Plugin package is possible).
Any help is appreciated.

A restart button can be helpful in multiple occasions:

- Changed settings that need a restart to be active
  - Plugins not setting needsRestart (e.g. Community FW plugin)
- During development
