### PR TITLE
Re-branding the RPM package to lyrionmusicserver

### DIFF
--- a/Slim/Utils/OS/RedHat.pm
+++ b/Slim/Utils/OS/RedHat.pm
@@ -41,21 +41,21 @@ sub dirsFor {
 
 	} elsif ($dir =~ /^(?:Firmware|Graphics|HTML|IR|MySQL|SQL|lib|Bin)$/) {
 
-		push @dirs, "/usr/share/squeezeboxserver/$dir";
+		push @dirs, "/usr/share/lyrionmusicserver/$dir";
 
 	} elsif ($dir eq 'Plugins') {
 
 		push @dirs, $class->SUPER::dirsFor($dir);
-		push @dirs, "/usr/share/squeezeboxserver/Plugins";
+		push @dirs, "/usr/share/lyrionmusicserver/Plugins";
 		push @dirs, "/usr/lib/perl5/vendor_perl/Slim/Plugin";
 
 	} elsif ($dir =~ /^(?:strings|revision|repositories)$/) {
 
-		push @dirs, "/usr/share/squeezeboxserver";
+		push @dirs, "/usr/share/lyrionmusicserver";
 
 	} elsif ($dir eq 'libpath') {
 
-		push @dirs, "/usr/share/squeezeboxserver";
+		push @dirs, "/usr/share/lyrionmusicserver";
 
 	# Because we use the system MySQL, we need to point to the right
 	# directory for the errmsg. files. Default to english.
@@ -65,19 +65,19 @@ sub dirsFor {
 
 	} elsif ($dir =~ /^(?:types|convert)$/) {
 
-		push @dirs, "/etc/squeezeboxserver";
+		push @dirs, "/etc/lyrionmusicserver";
 
 	} elsif ($dir eq 'prefs') {
 
-		push @dirs, $::prefsdir || "/var/lib/squeezeboxserver/prefs";
+		push @dirs, $::prefsdir || "/var/lib/lyrionmusicserver/prefs";
 
 	} elsif ($dir eq 'log') {
 
-		push @dirs, $::logdir || "/var/log/squeezeboxserver";
+		push @dirs, $::logdir || "/var/log/lyrionmusicserver";
 
 	} elsif ($dir eq 'cache') {
 
-		push @dirs, $::cachedir || "/var/lib/squeezeboxserver/cache";
+		push @dirs, $::cachedir || "/var/lib/lyrionmusicserver/cache";
 
 	} elsif ($dir =~ /^(?:music|playlists)$/) {
 
@@ -93,11 +93,11 @@ sub dirsFor {
 
 
 sub scanner {
-	return '/usr/libexec/squeezeboxserver-scanner';
+	return '/usr/libexec/lyrionmusicserver-scanner';
 }
 
 sub gdresized {
-	return '/usr/libexec/squeezeboxserver-resized';
+	return '/usr/libexec/lyrionmusicserver-resized';
 }
 
 sub canAutoUpdate { $_[0]->SUPER::runningFromSource ? 0 : 1 }

--- a/Slim/Utils/OSDetect.pm
+++ b/Slim/Utils/OSDetect.pm
@@ -96,12 +96,12 @@ sub init {
 				require Slim::Utils::OS::Debian;
 				$os = Slim::Utils::OS::Debian->new();
 
-			} elsif ($os =~ /red hat/i && $0 =~ m{^/usr/libexec/squeezeboxserver}) {
+			} elsif ($os =~ /red hat/i && $0 =~ m{^/usr/libexec/lyrionmusicserver}) {
 
 				require Slim::Utils::OS::RedHat;
 				$os = Slim::Utils::OS::RedHat->new();
 
-			} elsif ($os =~ /suse/i && $0 =~ m{^/usr/libexec/squeezeboxserver}) {
+			} elsif ($os =~ /suse/i && $0 =~ m{^/usr/libexec/lyrionmusicserver}) {
 
 				require Slim::Utils::OS::Suse;
 				$os = Slim::Utils::OS::Suse->new();


### PR DESCRIPTION
The two file RedHat.pm and OSDetect.pm in the slimserver project must be amended to support the re-branding of all components in the RPM package to lyrionmusicserver.

This pull request must be committed together with my pull request for slimserver-platforms.