### PR TITLE
Fix stat returning an empty size for most files

### DIFF
--- a/Slim/Utils/Scanner/Local/Async.pm
+++ b/Slim/Utils/Scanner/Local/Async.pm
@@ -150,10 +150,7 @@ sub find {
 
 		$count++;
 
-		# XXX Not sure why, but sometimes there is no cached stat data available?!
-		if ( !(stat _)[9] ) {
-			stat $file;
-		}
+		stat $file;
 
 		$sth->execute(
 			Slim::Utils::Misc::fileURLFromPath($file),


### PR DESCRIPTION
I've had that same issue for ages https://github.com/LMS-Community/slimserver/issues/333 Most of my music files are discarded by the scanner. I also run nixos.

I took the time to debug and found out that `stat` is reporting an empty size for most of the files the scanner finds. Because of that, they are not added to the table `tracks`.

This PR fixes the issue.

If I understand it correctly `stat _` returns the last call to `stat` with an actual filename. However, I cannot see in the code where it is called before the call to get the size `(stat _)[7]`??? Calling it explicitly with an actual filename fixes the issue for me.

I don't quite understand how it used to work for most people. Maybe something related to a filesystem option on nixos or something like that :thinking: 