### PR TITLE
Bugfix/update default plugins url

### DIFF
--- a/Slim/Utils/ExtensionsManager.pm
+++ b/Slim/Utils/ExtensionsManager.pm
@@ -115,7 +115,7 @@ my %repos = (
 	'https://lyrion.org/lms-plugin-repository/extensions.xml' => 1,
 );
 
-my $UNSUPPORTED_REPO = 'https://lms-community.github.io/lms-plugin-repository/unsupported.xml';
+my $UNSUPPORTED_REPO = 'https://lyrion.org/lms-plugin-repository/unsupported.xml';
 
 $prefs->setChange(\&initUnsupportedRepo, 'useUnsupported');
 

--- a/Slim/Utils/ExtensionsManager.pm
+++ b/Slim/Utils/ExtensionsManager.pm
@@ -112,7 +112,7 @@ $prefs->init({ repos => [], plugin => {}, auto => 0, useUnsupported => 0 });
 
 my %repos = (
 	# default repos mapped to weight which defines the order they are sorted in
-	'https://lms-community.github.io/lms-plugin-repository/extensions.xml' => 1,
+	'https://lyrion.org/lms-plugin-repository/extensions.xml' => 1,
 );
 
 my $UNSUPPORTED_REPO = 'https://lms-community.github.io/lms-plugin-repository/unsupported.xml';


### PR DESCRIPTION
The default plugins URL responds 2 chained permanent redirections, and it seems to be causing an issue when displaying the plugins page.
As they are permanent redirections, the ExtensionsManager might as well use the final value directly.

The error message I had was this, when displaying the plugins page:
Répertoire incorrect https://lms-community.github.io/lms-plugin-repository/extensions.xml - Timed out waiting for data

The URL in UNSUPPORTED_REPO is updated too, as it has the same 2x301 redirections.