### PR TITLE
Remove unnecessary delay reporting volume changes

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -3631,12 +3631,6 @@ sub statusQuery_filter {
 		return 1;
 	}
 
-	# suppress frequent updates during volume changes
-	if ($request->isCommand([['mixer'], ['volume']])) {
-
-		return 3;
-	}
-
 	# give it a tad more time for muting to leave room for the fade to finish
 	# see bug 5255
 	if ($request->isCommand([['mixer'], ['muting']])) {


### PR DESCRIPTION
The lines of code being removed were added by commit #bbe2afe in 2007, with the description "don't send frequent status updates during volume changes (it increases volume display jitter on jive)". Now, 17 years later, it serves no purpose other than to delay player volume changes from being displayed smoothly in modern client apps (including jive), introducing an irksome and unnecessary 1.7-second delay, as I discovered while testing changes to introduce polling-based volume synchronization into the Denon AVR Control plugin. I have tested with all client apps available to me with no ill effects.