### PR TITLE
Cometd.pm: enable basic CLI functionality

### DIFF
--- a/Changelog9.html
+++ b/Changelog9.html
@@ -37,6 +37,7 @@
 	<ul>
 		<li><a href="https://github.com/LMS-Community/slimserver/issues/1027">#1027</a> - Play count increase with in-track jumps (thanks @darrel-k!)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1116">#1116</a> - Fix album info track count when there are more than 50 tracks in an album (thanks @darrel-k!)</li>
+		<li><a href="https://github.com/LMS-Community/slimserver/pull/1146">#1146</a> - Restore partial Cometd support for CLI clients (thanks @sodface!)</li>
 	</ul>
 	<br />
 


### PR DESCRIPTION
Leverage existing code to enable basic CLI functionality. This allows /slim/request over CLI port 9090 to return JSON formatted responses.

See also: https://forums.slimdevices.com/forum/developer-forums/developers/1721698-comet-json-over-cli-9090