### PR TITLE
CLI: fix connection tracking and cleanup for CometD over CLI

### DIFF
--- a/Slim/Web/Cometd.pm
+++ b/Slim/Web/Cometd.pm
@@ -178,6 +178,9 @@ sub handler {
 			elsif ( $obj->{channel} eq '/meta/handshake' ) {
 				$clid = Slim::Utils::Misc::createUUID();
 				$manager->add_client( $clid );
+				if ( $isCLI ) {
+					$manager->register_connection( $clid, $conn );
+				}
 			}
 			elsif ( $obj->{channel} =~ m{^/slim/(?:subscribe|request)} && $obj->{data} ) {
 				# Pull clientId out of response channel

--- a/Slim/Web/Cometd/Manager.pm
+++ b/Slim/Web/Cometd/Manager.pm
@@ -74,7 +74,7 @@ sub clid_for_connection {
 	my $result;
 
 	while ( my ($clid, $c) = each %{ $self->{conn} } ) {
-		if ( $conn eq $c ) {
+		if ( $conn eq $c->[0] ) {
 			$result = $clid;
 		}
 	}


### PR DESCRIPTION
This is a follow up to https://github.com/LMS-Community/slimserver/pull/1146 that registers the CLI client with the Connection Manager during the CometD handshake. This is needed so `cliCloseHandler` can lookup the `clientId` for the TCP socket and remove the client from the Connection Manager when the client disconnects.

Also fixed `clid_for_connection` in CometD/Manager.pm which was failing to lookup and return the clientId based on the TCP socket. This sub is only called by `cliCloseHandler` for CLI clients so should pose no risk to HTTP client functionality.