### PR TITLE
Works search performance

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -3202,25 +3202,28 @@ sub searchQuery {
 		}
 
 		if ( $libraryID ) {
-			my $exists;
 			if ( $type eq 'contributor') {
-				$exists = 'EXISTS (SELECT * FROM contributor_track, library_track WHERE library_track.track = contributor_track.track AND contributor_track.contributor = me.id';
+				$sql .= 'JOIN contributor_track ON contributor_track.contributor = me.id ';
+				$sql .= 'JOIN library_track ON library_track.track = contributor_track.track ';
 			}
 			elsif ( $type eq 'work') {
-				$exists = 'EXISTS (SELECT * FROM tracks, library_track WHERE library_track.track = tracks.id AND tracks.work = me.id';
+				$sql .= 'JOIN tracks ON tracks.work = me.id ';
+				$sql .= 'JOIN library_track ON library_track.track = tracks.id ';
 			}
 
 			elsif ( $type eq 'album' ) {
-				$exists = 'EXISTS (SELECT * FROM tracks, library_track WHERE library_track.track = tracks.id AND tracks.album = me.id';
+				$sql .= 'JOIN tracks ON tracks.album = me.id ';
+				$sql .= 'JOIN library_track ON library_track.track = tracks.id ';
 			}
 			elsif ( $type eq 'genre' ) {
-				$exists = 'EXISTS (SELECT * FROM genre_track, library_track WHERE library_track.track = genre_track.track AND genre_track.genre = me.id';
+				$sql .= 'JOIN genre_track ON genre_track.genre = me.id ';
+				$sql .= 'JOIN library_track ON library_track.track = genre_track.track ';
 			}
 			elsif ( $type eq 'track' ) {
-				$exists = 'EXISTS (SELECT * FROM library_track WHERE library_track.track = me.id';
+				$sql .= 'JOIN library_track ON library_track.track = me.id ';
 			}
 
-			push @{$w}, "$exists AND library_track.library = ?)";
+			push @{$w}, 'library_track.library = ?';
 			push @{$p}, $libraryID;
 		}
 

--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -266,7 +266,6 @@ sub createHelperTable {
 
 	my $name = $args->{name};
 	my $type = $args->{type};
-	my $createPrimaryKey = $args->{createPrimaryKey} || 0;
 
 	my ($tokens, $isLarge);
 	my $orderOrLimit = '';
@@ -288,19 +287,14 @@ sub createHelperTable {
 	$orderOrLimit = 'LIMIT 0' if !$tokens;
 
 	# The first 32 bytes of the ID are either an MD5 of the ID, or some buster to make it "non searchable" - remove that prefix
-	my $searchSQL = "SELECT SUBSTR(fulltext.id, 33) AS id, FULLTEXTWEIGHT(matchinfo(fulltext)) AS fulltextweight FROM fulltext WHERE fulltext MATCH 'type:$type $tokens' $orderOrLimit";
-	if ($createPrimaryKey) {
-		$dbh->do("CREATE $temp TABLE $name (id integer primary key, fulltextweight integer)");
-		$searchSQL = "INSERT INTO $name $searchSQL";
-	} else {
-		$searchSQL = "CREATE $temp TABLE $name AS $searchSQL";
-	}
+	my $searchSQL = "INSERT INTO $name SELECT SUBSTR(fulltext.id, 33) AS id, FULLTEXTWEIGHT(matchinfo(fulltext)) AS fulltextweight FROM fulltext WHERE fulltext MATCH 'type:$type $tokens' $orderOrLimit";
 
 	if ( main::DEBUGLOG ) {
 		my $log2 = $sqllog->is_debug ? $sqllog : $log;
 		$log2->is_debug && $log2->debug( "Fulltext search query ($type): $searchSQL" );
 	}
 
+	$dbh->do("CREATE $temp TABLE $name (id INTEGER PRIMARY KEY, fulltextweight INTEGER)");
 	$dbh->do($searchSQL);
 }
 


### PR DESCRIPTION
Add parameter to create search helper tables with a primary key. This is the magic bullet.

Works Query: replace joins to `library_track` with `EXISTS` check - runs much faster with large libraries. The Works search query can be made even faster by using different SQL when `$search` is passed in, but this is pretty good already and avoids possible inadvertent logic changes. 

Tested with a large library (25,000 albums, 288,000 tracks, 8400 works, 20,000 contributors).

The livesearch still takes about 30 seconds when restricting to local music only  (on an old Chromebook running Debian) to resolve for example "beethoven 5" with the above library because as we know it runs 5 queries for every typed character. 

It's substantially faster when searching all music (ie without the `library_track` check) so that might be improved further with more work on join columns and/or indexes. But I think we should go with this and see what the users think.

 
