### PR TITLE
Also select user-defined roles for artists and tracks lists

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -1043,7 +1043,12 @@ sub artistsQuery {
 			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } split(/,/, $roleID ) ];
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
-			$roles = Slim::Schema->artistOnlyRoles();
+			# include user-defined roles
+			my @udr;
+			foreach (keys %{$prefs->get('userDefinedRoles')}) {
+				push @udr, $_;
+			}
+			$roles = Slim::Schema->artistOnlyRoles(@udr);
 		}
 		else {
 			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } Slim::Schema::Contributor->contributorRoles() ];
@@ -6062,9 +6067,9 @@ sub _getTagDataForTracks {
 			# Bug 16791: Need to include ALBUMARTIST too
 			@roles = ( 'ARTIST', 'TRACKARTIST', 'ALBUMARTIST' );
 
-			# Loop through each pref to see if the user wants to show that contributor role.
+			# Loop through each pref to see if the user wants to show that contributor role. Also include user-defined roles.
 			foreach (Slim::Schema::Contributor->contributorRoles) {
-				if ($prefs->get(lc($_) . 'InArtists')) {
+				if ( $prefs->get(lc($_) . 'InArtists') || Slim::Schema::Contributor->typeToRole($_) > 20 ) {
 					push @roles, $_;
 				}
 			}

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -1044,7 +1044,7 @@ sub artistsQuery {
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
 			# include user-defined roles that user wants in artist list
-			$roles = Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude());
+			$roles = Slim::Schema->artistOnlyRoles( Slim::Schema::Contributor->getUserDefinedRolesToInclude(),'TRACKARTIST' );
 		}
 		else {
 			# include user-defined roles that user wants in artist list

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -1043,15 +1043,18 @@ sub artistsQuery {
 			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } split(/,/, $roleID ) ];
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
-			# include user-defined roles
+			# include user-defined roles that user wants in artist list
 			my @udr;
 			foreach (keys %{$prefs->get('userDefinedRoles')}) {
-				push @udr, $_;
+				push @udr, $_ if !$prefs->get('userDefinedRoles')->{$_}->{'exclude'};
 			}
 			$roles = Slim::Schema->artistOnlyRoles(@udr);
 		}
 		else {
-			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } Slim::Schema::Contributor->contributorRoles() ];
+			# include user-defined roles that user wants in artist list
+			my $udr = $prefs->get('userDefinedRoles');
+			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } grep { Slim::Schema::Contributor->typeToRole($_) <= 20 || $udr->{$_} && !$udr->{$_}->{'exclude'} }
+				Slim::Schema::Contributor->contributorRoles() ];
 		}
 
 		if ( defined $genreID ) {

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -1044,11 +1044,7 @@ sub artistsQuery {
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
 			# include user-defined roles that user wants in artist list
-			my @udr;
-			foreach (keys %{$prefs->get('userDefinedRoles')}) {
-				push @udr, $_ if $prefs->get('userDefinedRoles')->{$_}->{'include'};
-			}
-			$roles = Slim::Schema->artistOnlyRoles(@udr);
+			$roles = Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude());
 		}
 		else {
 			# include user-defined roles that user wants in artist list

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -1046,14 +1046,14 @@ sub artistsQuery {
 			# include user-defined roles that user wants in artist list
 			my @udr;
 			foreach (keys %{$prefs->get('userDefinedRoles')}) {
-				push @udr, $_ if !$prefs->get('userDefinedRoles')->{$_}->{'exclude'};
+				push @udr, $_ if $prefs->get('userDefinedRoles')->{$_}->{'include'};
 			}
 			$roles = Slim::Schema->artistOnlyRoles(@udr);
 		}
 		else {
 			# include user-defined roles that user wants in artist list
 			my $udr = $prefs->get('userDefinedRoles');
-			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } grep { Slim::Schema::Contributor->typeToRole($_) <= 20 || $udr->{$_} && !$udr->{$_}->{'exclude'} }
+			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } grep { Slim::Schema::Contributor->typeToRole($_) <= 20 || $udr->{$_} && $udr->{$_}->{'include'} }
 				Slim::Schema::Contributor->contributorRoles() ];
 		}
 

--- a/Slim/Menu/AlbumInfo.pm
+++ b/Slim/Menu/AlbumInfo.pm
@@ -238,7 +238,7 @@ sub infoContributors {
 			allAvailableActionsDefined => 1,
 			items => {
 				command     => ['browselibrary', 'items'],
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id },
+				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => $role},
 			},
 			play => {
 				command     => ['playlistcontrol'],
@@ -272,13 +272,6 @@ sub infoContributors {
 	if ($album->isa('Slim::Schema::Album')) {
 		my @roles = Slim::Schema::Contributor->contributorRoles;
 
-		# Loop through each pref to see if the user wants to link to that contributor role.
-		my %linkRoles = map {$_ => $prefs->get(lc($_) . 'InArtists')} @roles;
-		$linkRoles{'ARTIST'} = 1;
-		$linkRoles{'TRACKARTIST'} = 1;
-		$linkRoles{'ALBUMARTIST'} = 1;
-
-
 		# Loop through the contributor types and append
 		for my $role (@roles) {
 			for my $contributor ( $album->artistsForRoles($role) ) {
@@ -287,16 +280,7 @@ sub infoContributors {
 
 				next if $filter->{work_id} && !$album->artistPerformsOnWork($filter->{work_id}, $filter->{performance}, $contributor->id);
 
-				if ($linkRoles{$role}) {
-					$_addContributorItem->($items, $contributor, $role);
-				} else {
-					my $item = {
-						type    => 'text',
-						name    => $contributor->name,
-						label   => uc $role,
-					};
-					push @{$items}, $item;
-				}
+				$_addContributorItem->($items, $contributor, $role);
 			}
 		}
 	}

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1101,15 +1101,7 @@ sub _artists {
 			} @roles  if @roles;
 
 			if ( $mode && $mode eq 'artists' ) {
-				push @roles, 'ARTIST', 'TRACKARTIST', 'ALBUMARTIST';
-
-				# Loop through each pref to see if the user wants to show that contributor role.
-				foreach (Slim::Schema::Contributor->contributorRoles) {
-					if (_getPref(lc($_) . 'InArtists', $remote_library)) {
-						push @roles, $_;
-					}
-				}
-
+				push @roles, Slim::Schema::Contributor->unifiedArtistsListRoles();
 				push @ptSearchTags, 'role_id:' . join(',', @roles);
 			}
 		}

--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -52,7 +52,7 @@ sub _releases {
 	main::INFOLOG && $log->is_info && $log->info("$query ($index, $quantity): tags ->", join(', ', @searchTags));
 
 	# get the artist's albums list to create releases sub-items etc.
-	my $request = Slim::Control::Request->new( undef, [ $query, 0, MAX_ALBUMS, @searchTags, 'role_id:'. $menuRoles ? $menuRoles : join(',',Slim::Schema::Contributor->contributorRoles) ] );
+	my $request = Slim::Control::Request->new( undef, [ $query, 0, MAX_ALBUMS, @searchTags, 'role_id:'. ($menuRoles ? $menuRoles : join(',',Slim::Schema::Contributor->contributorRoles)) ] );
 	$request->execute();
 
 	$log->error($request->getStatusText()) if $request->isStatusError();

--- a/Slim/Menu/TrackInfo.pm
+++ b/Slim/Menu/TrackInfo.pm
@@ -361,7 +361,7 @@ sub infoContributors {
 			allAvailableActionsDefined => 1,
 			items => {
 				command     => ['browselibrary', 'items'],
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id },
+				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => $role },
 			},
 			play => {
 				command     => ['playlistcontrol'],
@@ -396,25 +396,10 @@ sub infoContributors {
 	if ( $track->isa('Slim::Schema::Track') ) {
 		my @roles = Slim::Schema::Contributor->contributorRoles;
 
-		# Loop through each pref to see if the user wants to link to that contributor role.
-		my %linkRoles = map {$_ => $prefs->get(lc($_) . 'InArtists')} @roles;
-		$linkRoles{'ARTIST'} = 1;
-		$linkRoles{'TRACKARTIST'} = 1;
-		$linkRoles{'ALBUMARTIST'} = 1;
-
 		# Loop through the contributor types and append
 		for my $role ( @roles ) {
 			for my $contributor ( $track->contributorsOfType($role) ) {
-				if ($linkRoles{$role}) {
-					$_addContributorItem->($items, $contributor, $role);
-				} else {
-					my $item = {
-						type    => 'text',
-						name    => $contributor->name,
-						label   => uc $role,
-					};
-					push @{$items}, $item;
-				}
+				$_addContributorItem->($items, $contributor, $role);
 			}
 		}
 	}

--- a/Slim/Plugin/ExtendedBrowseModes/HTML/EN/plugins/ExtendedBrowseModes/settings/browsemodes.html
+++ b/Slim/Plugin/ExtendedBrowseModes/HTML/EN/plugins/ExtendedBrowseModes/settings/browsemodes.html
@@ -74,16 +74,19 @@
 			<tr>
 				<th>[% "PLUGIN_EXTENDED_BROWSEMODES_ROLE" | string %]</th>
 				<th>[% "PLUGIN_EXTENDED_BROWSEMODES_ROLE_TEXT" | string %]</th>
+				<th>[% "PLUGIN_EXTENDED_BROWSEMODES_ROLE_EXCLUDE" | string %]</th>
 			</tr>
 			[% FOREACH tag = customTags.keys.sort %]
 				<tr>
 					<td><input type="text" name="[% tag | html %]_tag" value="[% tag | html %]" class="stdedit"/></td>
 					<td><input type="text" name="[% tag | html %]_name" value="[% customTags.$tag.name | html %]" class="stdedit" style="width: 200px;"/></td>
+					<td style="text-align:center;"><input type="checkbox" [% IF customTags.$tag.exclude %]checked="1" [% END %] name="[% tag | html %]_exclude" value="1" class="stdedit" /></td>
 				</tr>
 			[% END %]
 			<tr>
 				<td><input type="text" name="new_tag" value="" class="stdedit"/></td>
 				<td><input type="text" name="new_name" value="" class="stdedit" style="width: 200px;"/></td>
+				<td style="text-align:center;"><input type="checkbox" name="new_exclude" class="stdedit" /></td>
 			</tr>
 		</table>
 	[% END; END %]

--- a/Slim/Plugin/ExtendedBrowseModes/HTML/EN/plugins/ExtendedBrowseModes/settings/browsemodes.html
+++ b/Slim/Plugin/ExtendedBrowseModes/HTML/EN/plugins/ExtendedBrowseModes/settings/browsemodes.html
@@ -74,19 +74,19 @@
 			<tr>
 				<th>[% "PLUGIN_EXTENDED_BROWSEMODES_ROLE" | string %]</th>
 				<th>[% "PLUGIN_EXTENDED_BROWSEMODES_ROLE_TEXT" | string %]</th>
-				<th>[% "PLUGIN_EXTENDED_BROWSEMODES_ROLE_EXCLUDE" | string %]</th>
+				<th>[% "PLUGIN_EXTENDED_BROWSEMODES_ROLE_INCLUDE" | string %]</th>
 			</tr>
 			[% FOREACH tag = customTags.keys.sort %]
 				<tr>
 					<td><input type="text" name="[% tag | html %]_tag" value="[% tag | html %]" class="stdedit"/></td>
 					<td><input type="text" name="[% tag | html %]_name" value="[% customTags.$tag.name | html %]" class="stdedit" style="width: 200px;"/></td>
-					<td style="text-align:center;"><input type="checkbox" [% IF customTags.$tag.exclude %]checked="1" [% END %] name="[% tag | html %]_exclude" value="1" class="stdedit" /></td>
+					<td style="text-align:center;"><input type="checkbox" [% IF customTags.$tag.include %]checked="1" [% END %] name="[% tag | html %]_include" value="1" class="stdedit" /></td>
 				</tr>
 			[% END %]
 			<tr>
 				<td><input type="text" name="new_tag" value="" class="stdedit"/></td>
 				<td><input type="text" name="new_name" value="" class="stdedit" style="width: 200px;"/></td>
-				<td style="text-align:center;"><input type="checkbox" name="new_exclude" class="stdedit" /></td>
+				<td style="text-align:center;"><input type="checkbox" name="new_include" class="stdedit" checked="1"/></td>
 			</tr>
 		</table>
 	[% END; END %]

--- a/Slim/Plugin/ExtendedBrowseModes/HTML/EN/plugins/ExtendedBrowseModes/settings/browsemodes.html
+++ b/Slim/Plugin/ExtendedBrowseModes/HTML/EN/plugins/ExtendedBrowseModes/settings/browsemodes.html
@@ -86,7 +86,7 @@
 			<tr>
 				<td><input type="text" name="new_tag" value="" class="stdedit"/></td>
 				<td><input type="text" name="new_name" value="" class="stdedit" style="width: 200px;"/></td>
-				<td style="text-align:center;"><input type="checkbox" name="new_include" class="stdedit" checked="1"/></td>
+				<td style="text-align:center;"><input type="checkbox" name="new_include" class="stdedit" value="1" checked="1"/></td>
 			</tr>
 		</table>
 	[% END; END %]

--- a/Slim/Plugin/ExtendedBrowseModes/Settings.pm
+++ b/Slim/Plugin/ExtendedBrowseModes/Settings.pm
@@ -9,14 +9,13 @@ package Slim::Plugin::ExtendedBrowseModes::Settings;
 use strict;
 use base qw(Slim::Web::Settings);
 use Storable;
+use List::Util qw(max);
 
 use Slim::Music::VirtualLibraries;
 use Slim::Plugin::ExtendedBrowseModes::Plugin;
-use Slim::Utils::Log;
 use Slim::Utils::Misc;
 use Slim::Utils::Strings qw(string);
 use Slim::Utils::Prefs;
-use List::Util qw(max);
 
 use constant AUDIOBOOKS_MENUS => [{
 	name    => 'PLUGIN_EXTENDED_BROWSEMODES_AUDIOBOOKS',
@@ -33,7 +32,6 @@ use constant AUDIOBOOKS_MENUS => [{
 	weight  => 15,
 	enabled => 0,
 }];
-my $log   = logger('prefs');
 my $prefs = preferences('plugin.extendedbrowsemodes');
 my $serverPrefs = preferences('server');
 
@@ -56,12 +54,7 @@ sub handler {
 	if ($params->{'saveSettings'} && !$class->needsClient) {
 		# custom role handling
 		my $currentRoles = $serverPrefs->get('userDefinedRoles');
-
-		my $id = 20;
-		foreach (keys %{ $currentRoles }) {
-			$id = max($id, $currentRoles->{$_}->{id});
-		}
-		$id++;
+		my $id = %$currentRoles ? max(map { $_->{id} } values %$currentRoles) + 1 : 21;
 
 		my $customTags = {};
 		my $changed = 0;
@@ -78,8 +71,7 @@ sub handler {
 						include => $params->{$key . '_include'},
 					};
 					if ( !$currentRoles->{$tag}
-						|| $currentRoles->{$tag}
-							&& ( $currentRoles->{$tag}->{name} ne $customTags->{$tag}->{name} || $currentRoles->{$tag}->{include} ne $customTags->{$tag}->{include} ) ) {
+						|| $currentRoles->{$tag}->{name} ne $customTags->{$tag}->{name} || $currentRoles->{$tag}->{include} ne $customTags->{$tag}->{include} ) {
 						Slim::Utils::Strings::storeExtraStrings([{
 							strings => { EN => $customTags->{$tag}->{name}},
 							token   => $tag,

--- a/Slim/Plugin/ExtendedBrowseModes/Settings.pm
+++ b/Slim/Plugin/ExtendedBrowseModes/Settings.pm
@@ -16,6 +16,7 @@ use Slim::Utils::Log;
 use Slim::Utils::Misc;
 use Slim::Utils::Strings qw(string);
 use Slim::Utils::Prefs;
+use List::Util qw(max);
 
 use constant AUDIOBOOKS_MENUS => [{
 	name    => 'PLUGIN_EXTENDED_BROWSEMODES_AUDIOBOOKS',
@@ -32,7 +33,7 @@ use constant AUDIOBOOKS_MENUS => [{
 	weight  => 15,
 	enabled => 0,
 }];
-
+my $log   = logger('prefs');
 my $prefs = preferences('plugin.extendedbrowsemodes');
 my $serverPrefs = preferences('server');
 
@@ -55,8 +56,14 @@ sub handler {
 	if ($params->{'saveSettings'} && !$class->needsClient) {
 		# custom role handling
 		my $currentRoles = $serverPrefs->get('userDefinedRoles');
+
+		my $id = 20;
+		foreach (keys %{ $currentRoles }) {
+			$id = max($id, $currentRoles->{$_}->{id});
+		}
+		$id++;
+
 		my $customTags = {};
-		my $id = 21;
 		my $changed = 0;
 
 		foreach my $pref (keys %{$params}) {
@@ -67,16 +74,18 @@ sub handler {
 				if ( $tag ) {
 					$customTags->{$tag} = {
 						name => $params->{$key . '_name'} || $tag,
-						id => $id,
+						id => $currentRoles->{$tag} ? $currentRoles->{$tag}->{id} : $id++,
+						exclude => $params->{$key . '_exclude'},
 					};
-					if ( !$currentRoles->{$tag} || $currentRoles->{$tag}->{name} ne $customTags->{$tag}->{name} ) {
+					if ( !$currentRoles->{$tag}
+						|| $currentRoles->{$tag}
+							&& ( $currentRoles->{$tag}->{name} ne $customTags->{$tag}->{name} || $currentRoles->{$tag}->{exclude} ne $customTags->{$tag}->{exclude} ) ) {
 						Slim::Utils::Strings::storeExtraStrings([{
 							strings => { EN => $customTags->{$tag}->{name}},
 							token   => $tag,
-						}]) if !Slim::Utils::Strings::stringExists($tag);
+						}]);
 						$changed = 1;
 					}
-					$id++;
 				}
 			}
 		}

--- a/Slim/Plugin/ExtendedBrowseModes/Settings.pm
+++ b/Slim/Plugin/ExtendedBrowseModes/Settings.pm
@@ -75,11 +75,11 @@ sub handler {
 					$customTags->{$tag} = {
 						name => $params->{$key . '_name'} || $tag,
 						id => $currentRoles->{$tag} ? $currentRoles->{$tag}->{id} : $id++,
-						exclude => $params->{$key . '_exclude'},
+						include => $params->{$key . '_include'},
 					};
 					if ( !$currentRoles->{$tag}
 						|| $currentRoles->{$tag}
-							&& ( $currentRoles->{$tag}->{name} ne $customTags->{$tag}->{name} || $currentRoles->{$tag}->{exclude} ne $customTags->{$tag}->{exclude} ) ) {
+							&& ( $currentRoles->{$tag}->{name} ne $customTags->{$tag}->{name} || $currentRoles->{$tag}->{include} ne $customTags->{$tag}->{include} ) ) {
 						Slim::Utils::Strings::storeExtraStrings([{
 							strings => { EN => $customTags->{$tag}->{name}},
 							token   => $tag,

--- a/Slim/Plugin/ExtendedBrowseModes/strings.txt
+++ b/Slim/Plugin/ExtendedBrowseModes/strings.txt
@@ -347,11 +347,11 @@ PLUGIN_EXTENDED_BROWSEMODES_ROLE_TEXT
 	HU	Szöveg megjelenítése
 	NL	Tekst weergeven
 
-PLUGIN_EXTENDED_BROWSEMODES_ROLE_EXCLUDE
-	EN	Exclude from artist lists
-	DE	Aus Künstlerlisten ausschließen
-	FR	Exclure des listes d'artistes
-	ES	Excluir de las listas de artistas
-	HU	Kizárás az előadók listájáról
-	NL	Uitsluiten van artiestenlijsten
+PLUGIN_EXTENDED_BROWSEMODES_ROLE_INCLUDE
+	EN	Include with artist lists
+	DE	In Künstlerlisten aufnehmen
+	FR	Inclure avec les listes d'artistes
+	ES	Incluir con listas de artistas
+	HU	Tartalmazza az előadók listáját
+	NL	Opnemen bij artiestenlijsten
 

--- a/Slim/Plugin/ExtendedBrowseModes/strings.txt
+++ b/Slim/Plugin/ExtendedBrowseModes/strings.txt
@@ -340,10 +340,18 @@ PLUGIN_EXTENDED_BROWSEMODES_ROLE
 	NL	Rol tag
 
 PLUGIN_EXTENDED_BROWSEMODES_ROLE_TEXT
-	EN	Display Text
+	EN	Display text
 	DE	Text anzeigen
 	FR	Afficher le texte
 	ES	Mostrar texto
 	HU	Szöveg megjelenítése
 	NL	Tekst weergeven
+
+PLUGIN_EXTENDED_BROWSEMODES_ROLE_EXCLUDE
+	EN	Exclude from artist lists
+	DE	Aus Künstlerlisten ausschließen
+	FR	Exclure des listes d'artistes
+	ES	Excluir de las listas de artistas
+	HU	Kizárás az előadók listájáról
+	NL	Uitsluiten van artiestenlijsten
 

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2347,7 +2347,7 @@ sub artistOnlyRoles {
 
 	# And if the user has asked for ALL, give them it.
 	if ($roles{'ALL'}) {
-		return undef;
+		return [ Slim::Schema::Contributor->contributorRoleIds ];
 	}
 
 	# Loop through each pref to see if the user wants to show that contributor role.
@@ -2359,13 +2359,7 @@ sub artistOnlyRoles {
 		}
 	}
 
-	# If we're using all roles, don't bother with the constraint.
-	if (scalar keys %roles != Slim::Schema::Contributor->totalContributorRoles) {
-
-		return [ sort map { Slim::Schema::Contributor->typeToRole($_) } keys %roles ];
-	}
-
-	return undef;
+	return [ sort map { Slim::Schema::Contributor->typeToRole($_) } keys %roles ];
 }
 
 sub registerRatingImplementation {

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -103,6 +103,15 @@ sub roleToType {
 	return $roleToContributorMap{$_[1]};
 }
 
+sub getUserDefinedRolesToInclude {
+	my $prefs = preferences('server');
+	my @udr;
+	foreach (keys %{$prefs->get('userDefinedRoles')}) {
+		push @udr, $_ if $prefs->get('userDefinedRoles')->{$_}->{'include'};
+	}
+	return @udr;
+}
+
 sub extIds {
 	my ($self) = @_;
 	return [ split(',', $self->extid || '') ];

--- a/Slim/Schema/ResultSet/Contributor.pm
+++ b/Slim/Schema/ResultSet/Contributor.pm
@@ -45,7 +45,9 @@ sub countTotal {
 
 	my $cond  = {};
 	my @joins = ();
-	my $roles = $prefs->get('useUnifiedArtistsList') ? Slim::Schema->artistOnlyRoles : [ Slim::Schema::Contributor->contributorRoleIds ];
+	my $roles = $prefs->get('useUnifiedArtistsList')
+		? Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude(), 'TRACKARTIST')
+		: [ Slim::Schema::Contributor->contributorRoleIds ];
 
 	# The user may not want to include all the composers / conductors
 	if ($roles) {

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -184,6 +184,7 @@ sub init {
 		'composerInArtists'     => 0,
 		'conductorInArtists'    => 0,
 		'bandInArtists'         => 0,
+		'userDefinedRoles'      => {},
 		'variousArtistAutoIdentification' => 1,
 		'useUnifiedArtistsList' => 0,
 		'useTPE2AsAlbumArtist'  => 1,
@@ -631,10 +632,7 @@ L<Slim::Utils::Prefs::OldPrefs>
 =cut
 
 
-# FIXME - support functions - should these be here?
-
-use FindBin qw($Bin);
-use File::Spec::Functions qw(:ALL);
+use File::Spec::Functions qw(catdir splitdir);
 use Digest::MD5;
 
 sub makeSecuritySecret {

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -400,25 +400,12 @@ sub init {
 	$prefs->setChange( sub {
 		my $newRoles = $_[1];
 		my $oldRoles = $_[3];
-		my $changed = 0;
-		if (%$oldRoles != %$newRoles) {
-			$changed = 1;
-		} else {
-			my %cmp = map { $_ => 1 } keys %$oldRoles;
-			for my $key (keys %$newRoles) {
-				last unless exists $cmp{$key};
-				delete $cmp{$key};
-			}
-			if (%cmp) {
-				$changed = 1;
-			}
-		}
-		if ( $changed ) {
+
+		if ( %$oldRoles - %$newRoles || (scalar grep {!exists $newRoles->{$_}} keys %$oldRoles) ) {
 			Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]);
+			Slim::Schema::Contributor->initializeRoles()
 		}
 	}, 'userDefinedRoles' );
-
-	$prefs->setChange( sub { Slim::Schema::Contributor->initializeRoles() }, 'userDefinedRoles');
 
 	$prefs->setChange( sub { Slim::Utils::Misc::setPriority($_[1]) }, 'serverPriority');
 
@@ -558,7 +545,7 @@ sub init {
 		# Rebuild Jive cache if VA setting is changed
 		$prefs->setChange( sub {
 			Slim::Schema->wipeCaches();
-		}, 'variousArtistAutoIdentification', 'composerInArtists', 'conductorInArtists', 'bandInArtists', 'useUnifiedArtistsList');
+		}, 'variousArtistAutoIdentification', 'composerInArtists', 'conductorInArtists', 'bandInArtists', 'useUnifiedArtistsList', 'userDefinedRoles');
 
 		$prefs->setChange( sub {
 			Slim::Control::Queries->wipeCaches();

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -509,11 +509,9 @@ sub _initActiveRoles {
 		$params->{'search'}->{'contributor_namesearch'}->{'active' . $_} = 1 if $params->{'search.contributor_namesearch.active' . $_};
 	}
 
-	my @udr;
-	foreach (keys %{$serverPrefs->get('userDefinedRoles')}) {
-		push @udr, $_ if $serverPrefs->get('userDefinedRoles')->{$_}->{'include'};
-	}
-	$params->{'search'}->{'contributor_namesearch'} = { map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(@udr) } } unless keys %{$params->{'search'}->{'contributor_namesearch'}};
+	$params->{'search'}->{'contributor_namesearch'} = {
+		map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(getUserDefinedRolesToInclude()) }
+	} unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }
 
 sub _getSavedSearches {

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -510,7 +510,7 @@ sub _initActiveRoles {
 	}
 
 	$params->{'search'}->{'contributor_namesearch'} = {
-		map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(getUserDefinedRolesToInclude()) }
+		map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude()) }
 	} unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }
 

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -28,6 +28,7 @@ use constant MAX_ADV_RESULTS => 200;
 my $log = logger('network.http');
 my $sqlLog = logger('database.sql');
 my $prefs = preferences('advancedSearch');
+my $serverPrefs = preferences('server');
 
 sub init {
 
@@ -508,7 +509,11 @@ sub _initActiveRoles {
 		$params->{'search'}->{'contributor_namesearch'}->{'active' . $_} = 1 if $params->{'search.contributor_namesearch.active' . $_};
 	}
 
-	$params->{'search'}->{'contributor_namesearch'} = { map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles } } unless keys %{$params->{'search'}->{'contributor_namesearch'}};
+	my @udr;
+	foreach (keys %{$serverPrefs->get('userDefinedRoles')}) {
+		push @udr, $_ if $serverPrefs->get('userDefinedRoles')->{$_}->{'include'};
+	}
+	$params->{'search'}->{'contributor_namesearch'} = { map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(@udr) } } unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }
 
 sub _getSavedSearches {

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -510,7 +510,7 @@ sub _initActiveRoles {
 	}
 
 	$params->{'search'}->{'contributor_namesearch'} = {
-		map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude()) }
+		map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude(), 'TRACKARTIST') }
 	} unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }
 

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -10,10 +10,7 @@ package Slim::Web::Pages::Search;
 use strict;
 
 use Date::Parse qw(str2time);
-use File::Spec::Functions qw(:ALL);
-use Digest::MD5 qw(md5_hex);
-use Scalar::Util qw(blessed);
-use Storable;
+use Storable ();
 
 use Slim::Music::VirtualLibraries;
 use Slim::Utils::Misc;
@@ -28,7 +25,6 @@ use constant MAX_ADV_RESULTS => 200;
 my $log = logger('network.http');
 my $sqlLog = logger('database.sql');
 my $prefs = preferences('advancedSearch');
-my $serverPrefs = preferences('server');
 
 sub init {
 
@@ -510,7 +506,9 @@ sub _initActiveRoles {
 	}
 
 	$params->{'search'}->{'contributor_namesearch'} = {
-		map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude(), 'TRACKARTIST') }
+		map { ('active' . $_) => 1 } @{
+			Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude(), 'TRACKARTIST')
+		}
 	} unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }
 

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -42,7 +42,7 @@ if ( !main::SCANNER ) {
 
 	$prefs->setChange( \&wipeCaches, qw(itemsPerPage thumbSize showArtist showYear additionalPlaylistButtons noGenreFilter noRoleFilter searchSubString browseagelimit
 		composerInArtists conductorInArtists bandInArtists variousArtistAutoIdentification titleFormat titleFormatWeb language useUnifiedArtistsList
-		groupArtistAlbumsByReleaseType ignoreReleaseTypes releaseTypesToIgnore showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears) );
+		groupArtistAlbumsByReleaseType ignoreReleaseTypes releaseTypesToIgnore showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears userDefinedRoles) );
 }
 
 tie my %cacheables, 'Tie::RegexpHash';


### PR DESCRIPTION
Addendum to #1168 

1. include user-defined roles in track selection.
2. add new option in role setup to exclude certain roles from main artist lists
3. refine on change processing so that rescan is only triggered when the actual tags change.