### PR TITLE
Drop unused imports from Slim::Web::ImageProxy

### DIFF
--- a/.perlimports.toml
+++ b/.perlimports.toml
@@ -1,0 +1,17 @@
+# Run `perlimports -i Slim` to tidy `use` and `require` statements.
+# https://metacpan.org/dist/App-perlimports/view/script/perlimports
+
+cache                           = false
+ignore_modules                  = []
+ignore_modules_filename         = ""
+ignore_modules_pattern          = "^Tie::"
+ignore_modules_pattern_filename = ""
+libs                            = ["lib", "CPAN", "."]
+log_filename                    = ""
+log_level                       = "warn"
+never_export_modules            = []
+never_export_modules_filename   = ""
+padding                         = false
+preserve_duplicates             = false
+preserve_unused                 = false
+tidy_whitespace                 = true

--- a/.perlimports.toml
+++ b/.perlimports.toml
@@ -14,4 +14,4 @@ never_export_modules_filename   = ""
 padding                         = false
 preserve_duplicates             = false
 preserve_unused                 = false
-tidy_whitespace                 = true
+tidy_whitespace                 = false

--- a/Slim/Web/ImageProxy.pm
+++ b/Slim/Web/ImageProxy.pm
@@ -72,7 +72,9 @@ original artwork is of considerable size, where the bandwidth to download the im
 =cut
 
 use strict;
-use HTTP::Status qw(RC_MOVED_PERMANENTLY);
+use HTTP::Status qw(
+	RC_MOVED_PERMANENTLY
+);
 use Tie::RegexpHash;
 use URI::Escape qw(uri_escape_utf8);
 

--- a/Slim/Web/ImageProxy.pm
+++ b/Slim/Web/ImageProxy.pm
@@ -72,12 +72,7 @@ original artwork is of considerable size, where the bandwidth to download the im
 =cut
 
 use strict;
-use Digest::MD5;
-use File::Spec::Functions qw(catdir);
-use File::Slurp ();
-use HTTP::Status qw(
-	RC_MOVED_PERMANENTLY
-);
+use HTTP::Status qw(RC_MOVED_PERMANENTLY);
 use Tie::RegexpHash;
 use URI::Escape qw(uri_escape_utf8);
 


### PR DESCRIPTION
Whilst looking at `Slim::Web::ImageProxy`, I noticed that some of the `use`d packaged weren’t actually used.

There is a command [`perlimports`](https://metacpan.org/dist/App-perlimports/view/script/perlimports) that can work this out for us, so I have added a configuration file for it.  We could run this on everything in `Slim/`, but it isn’t perfect, and there is a risk it would remove something that we actually need, so I haven’t done that yet.