### PR TITLE
Include track artists in combined artist list

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -1043,7 +1043,7 @@ sub artistsQuery {
 			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } split(/,/, $roleID ) ];
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
-			$roles = Slim::Schema->artistOnlyRoles();
+			$roles = Slim::Schema->artistOnlyRoles('TRACKARTIST');
 		}
 		else {
 			$roles = [ map { Slim::Schema::Contributor->typeToRole($_) } Slim::Schema::Contributor->contributorRoles() ];

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2335,6 +2335,7 @@ sub artistOnlyRoles {
 	my %roles = (
 		'ARTIST'      => 1,
 		'ALBUMARTIST' => 1,
+		'TRACKARTIST' => 1,
 	);
 
 	# If the user has requested explict roles to be added, do so.

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2335,7 +2335,6 @@ sub artistOnlyRoles {
 	my %roles = (
 		'ARTIST'      => 1,
 		'ALBUMARTIST' => 1,
-		'TRACKARTIST' => 1,
 	);
 
 	# If the user has requested explict roles to be added, do so.

--- a/Slim/Schema/ResultSet/Contributor.pm
+++ b/Slim/Schema/ResultSet/Contributor.pm
@@ -23,7 +23,7 @@ sub searchNames {
 	};
 
 	# Bug: 2479 - Don't include roles if the user has them unchecked.
-	if (my $roles = Slim::Schema->artistOnlyRoles('TRACKARTIST')) {
+	if (my $roles = Slim::Schema->artistOnlyRoles()) {
 
 		$cond->{'contributorAlbums.role'} = { 'in' => $roles };
 		push @joins, 'contributorAlbums';

--- a/Slim/Schema/ResultSet/Contributor.pm
+++ b/Slim/Schema/ResultSet/Contributor.pm
@@ -23,7 +23,7 @@ sub searchNames {
 	};
 
 	# Bug: 2479 - Don't include roles if the user has them unchecked.
-	if (my $roles = Slim::Schema->artistOnlyRoles()) {
+	if (my $roles = Slim::Schema->artistOnlyRoles('TRACKARTIST')) {
 
 		$cond->{'contributorAlbums.role'} = { 'in' => $roles };
 		push @joins, 'contributorAlbums';
@@ -45,7 +45,7 @@ sub countTotal {
 
 	my $cond  = {};
 	my @joins = ();
-	my $roles = $prefs->get('useUnifiedArtistsList') ? Slim::Schema->artistOnlyRoles : [ Slim::Schema::Contributor->contributorRoleIds ];
+	my $roles = $prefs->get('useUnifiedArtistsList') ? Slim::Schema->artistOnlyRoles('TRACKARTIST') : [ Slim::Schema::Contributor->contributorRoleIds ];
 
 	# The user may not want to include all the composers / conductors
 	if ($roles) {

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -508,7 +508,7 @@ sub _initActiveRoles {
 		$params->{'search'}->{'contributor_namesearch'}->{'active' . $_} = 1 if $params->{'search.contributor_namesearch.active' . $_};
 	}
 
-	$params->{'search'}->{'contributor_namesearch'} = { map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles } } unless keys %{$params->{'search'}->{'contributor_namesearch'}};
+	$params->{'search'}->{'contributor_namesearch'} = { map { ('active' . $_) => 1 } @{ Slim::Schema->artistOnlyRoles('TRACKARTIST') } } unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }
 
 sub _getSavedSearches {


### PR DESCRIPTION
See https://forums.slimdevices.com/forum/user-forums/logitech-media-server/112121-online-music-library-integration-an-observation?p=1729247#post1729247

It's always seemed an anomaly that when using the combined artist list, you don't see contributors who are only ever track artists.