### PR TITLE
albuminfo/trackinfo - don't pass role for artist roles

### DIFF
--- a/Slim/Menu/AlbumInfo.pm
+++ b/Slim/Menu/AlbumInfo.pm
@@ -238,7 +238,8 @@ sub infoContributors {
 			allAvailableActionsDefined => 1,
 			items => {
 				command     => ['browselibrary', 'items'],
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => $role},
+				# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
+				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => ((grep /^$role$/, ('ARTIST','ALBUMARTIST','TRACKARTIST')) ? undef : $role) },
 			},
 			play => {
 				command     => ['playlistcontrol'],

--- a/Slim/Menu/TrackInfo.pm
+++ b/Slim/Menu/TrackInfo.pm
@@ -361,7 +361,8 @@ sub infoContributors {
 			allAvailableActionsDefined => 1,
 			items => {
 				command     => ['browselibrary', 'items'],
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => $role },
+				# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
+				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => ((grep /^$role$/, ('ARTIST','ALBUMARTIST','TRACKARTIST')) ? undef : $role) },
 			},
 			play => {
 				command     => ['playlistcontrol'],


### PR DESCRIPTION
See https://forums.slimdevices.com/forum/user-forums/logitech-media-server/1730589-issue-with-recent-changes

This fixes the change in behaviour caused by https://github.com/LMS-Community/slimserver/pull/1169/commits/bd8c62743e765396e4e5c08814f01c4f03f2e62c - `albumsQuery` is already sorting out roles for artist role types so don't pass `$roles` for those types.