### PR TITLE
fix _GetTagDataForTracks

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -6055,7 +6055,7 @@ sub _getTagDataForTracks {
 			push @roles, 'ARTIST' if $args->{roleId} eq 'ALBUMARTIST' && !$prefs->get('useUnifiedArtistsList');
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
-			@roles = Slim::Schema::Contributor->unifiedArtistsListRoles();
+			@roles = Slim::Schema::Contributor->unifiedArtistsListRoles('TRACKARTIST');
 		}
 		else {
 			@roles = Slim::Schema::Contributor->contributorRoles();

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -366,7 +366,7 @@ sub albumsQuery {
 					push @roles, 'ARTIST' if $roleID eq 'ALBUMARTIST' && !$prefs->get('useUnifiedArtistsList');
 				}
 				elsif ($prefs->get('useUnifiedArtistsList')) {
-					@roles = Slim::Schema::Contributor->unifiedArtistsListRoles();
+					@roles = Slim::Schema::Contributor->activeContributorRoles(1);
 				}
 				else {
 					@roles = Slim::Schema::Contributor->contributorRoles();
@@ -1037,13 +1037,15 @@ sub artistsQuery {
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
 			# include user-defined roles that user wants in artist list
-			$roles = Slim::Schema->artistOnlyRoles( Slim::Schema::Contributor->getUserDefinedRolesToInclude() );
+			$roles = [ map {
+				Slim::Schema::Contributor->typeToRole($_);
+			} Slim::Schema::Contributor->activeContributorRoles(0) ];
 		}
 		else {
 			# include user-defined roles that user wants in artist list
 			$roles = [ map {
 				Slim::Schema::Contributor->typeToRole($_);
-			} Slim::Schema::Contributor->defaultContributorRoles(), Slim::Schema::Contributor->getUserDefinedRolesToInclude() ];
+			} Slim::Schema::Contributor->defaultContributorRoles(), Slim::Schema::Contributor->userDefinedRoles(1) ];
 		}
 
 		if ( defined $genreID ) {
@@ -6055,7 +6057,7 @@ sub _getTagDataForTracks {
 			push @roles, 'ARTIST' if $args->{roleId} eq 'ALBUMARTIST' && !$prefs->get('useUnifiedArtistsList');
 		}
 		elsif ($prefs->get('useUnifiedArtistsList')) {
-			@roles = Slim::Schema::Contributor->unifiedArtistsListRoles('TRACKARTIST');
+			@roles = Slim::Schema::Contributor->activeContributorRoles(1);
 		}
 		else {
 			@roles = Slim::Schema::Contributor->contributorRoles();

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1101,7 +1101,7 @@ sub _artists {
 			} @roles  if @roles;
 
 			if ( $mode && $mode eq 'artists' ) {
-				push @roles, Slim::Schema::Contributor->unifiedArtistsListRoles();
+				push @roles, Slim::Schema::Contributor->activeContributorRoles(1);
 				push @ptSearchTags, 'role_id:' . join(',', @roles);
 			}
 		}

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -90,7 +90,11 @@ sub defaultContributorRoles {
 }
 
 sub unifiedArtistsListRoles {
+	my $self  = shift;
+	my @add   = @_;
+
 	my @roles = ( 'ARTIST', 'ALBUMARTIST' );
+	push @roles, @add if scalar @add;
 
 	# Loop through each pref to see if the user wants to show that contributor role. Also include user-defined roles.
 	push @roles, grep { $prefs->get(lc($_) . 'InArtists') } contributorRoles();

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -103,7 +103,7 @@ sub activeContributorRoles {
 	my $includeTrackArtist = shift;
 
 	my @roles = ( 'ARTIST', 'ALBUMARTIST' );
-	push @roles, 'TRACKARTIST' if $includeTrackArtist;
+	push @roles, 'TRACKARTIST' if $includeTrackArtist && !$prefs->get('trackartistInArtists');
 
 	# Loop through each pref to see if the user wants to show that contributor role. Also include user-defined roles.
 	push @roles, grep { $prefs->get(lc($_) . 'InArtists') } contributorRoles();

--- a/Slim/Schema/ResultSet/Contributor.pm
+++ b/Slim/Schema/ResultSet/Contributor.pm
@@ -46,7 +46,9 @@ sub countTotal {
 	my $cond  = {};
 	my @joins = ();
 	my $roles = $prefs->get('useUnifiedArtistsList')
-		? Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude())
+		? [ map {
+			Slim::Schema::Contributor->typeToRole($_);
+		} Slim::Schema::Contributor->activeContributorRoles(0) ]
 		: [ Slim::Schema::Contributor->contributorRoleIds ];
 
 	# The user may not want to include all the composers / conductors

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -507,7 +507,9 @@ sub _initActiveRoles {
 
 	$params->{'search'}->{'contributor_namesearch'} = {
 		map { ('active' . $_) => 1 } @{
-			Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude())
+			[ map {
+				Slim::Schema::Contributor->typeToRole($_);
+			} Slim::Schema::Contributor->activeContributorRoles(0) ]
 		}
 	} unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }


### PR DESCRIPTION
See https://forums.slimdevices.com/forum/user-forums/logitech-media-server/1730800-lms-9-very-odd-mis-behavior

**Analysis:**

This was caused by `Slim::Control::Queries::statusQuery` failing because the call to`_getTagDataForTracks` was returning nothing in the case when there was only `TRACKARTIST` in the contributor_track table. This can occur particularly in OLMI imports where the user has no control over the role tags.

It is a regression since #1186 because that change meant that `unifiedArtistsListRoles() `no longer returns `TRACKARTIST` unless it is a selected menu role, so otherwise `TRACKARTIST` is no longer passed to `_getTagDataForTracks`.

**Solution:**

We always need to pass `TRACKARTIST` here, in case it's the only track role for the artist. (A separate discussion could be had about why `_getTagDataForTracks` need to restrict to roles at all when it is called with a track number - but let's leave that for now)

This could be done by reverting `unifiedArtistsListRoles()` to always include TRACKARTIST in its return, but I think it is better to parameterise it (and rename to `activeContributorRoles()` to better reflect its output) so that it can optionally return `TRACKARTIST` regardless of whether `TRACKARTIST` is selected as a combined artist menu role or not.

This is because we can then use this function instead of `artistOnlyRoles()`, particularly in `artistsQuery` to retrieve the required roles for the combined artist menu, when we only want to return `TRACKARTIST` if it is a selected combined artist menu role.

I think this will be better for future understanding of what this code is doing, because it will be explicit in the code of the difference due to the parameter passed, rather than leaving people to wonder why there are two functions doing roughly the same thing.

I've set the parameter to `activeContributorRoles()` based on whether the old code forced `TRACKARTIST` or not, in order to maintain previous behaviour.

I have also renamed `getUserDefinedRolesToInclude()` to `userDefinedRoles()` and added a parameter so that the caller decides whether it wants all user-defined roles, or only the ones selected for menu inclusion.

MAI will need a change because of this, I'd suggest using `activeContributorRoles(0)` instead of `artistOnlyRoles(...)`, with a `map` required to convert names to numbers. 