### PR TITLE
Make `TRACKARTIST` a fix part of the unified artists browse list.

### DIFF
--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -12,9 +12,6 @@
 
 	[% IF prefs.pref_useUnifiedArtistsList; WRAPPER settingSection %]
 		[% WRAPPER settingGroup title="SETUP_COMPOSERINARTISTS" desc="SETUP_COMPOSERINARTISTS_DESC" %]
-			<input type="checkbox" [% IF prefs.pref_trackartistInArtists %]checked="1" [% END %] class="stdedit" name="pref_trackartistInArtists" id="trackartistInArtists" value="1" />
-			<label for="trackartistInArtists" class="stdlabel">[% "TRACKARTIST" | string %]</label><br>
-
 			<input type="checkbox" [% IF prefs.pref_composerInArtists %]checked="1" [% END %] class="stdedit" name="pref_composerInArtists" id="composerInArtists" value="1" />
 			<label for="composerInArtists" class="stdlabel">[% "COMPOSER" | string %]</label><br>
 
@@ -25,7 +22,6 @@
 			<label for="bandInArtists" class="stdlabel">[% "BAND" | string %]</label>
 		[% END %]
 	[% END; ELSE %]
-		<input type="hidden" name="pref_trackartistInArtists" value="[% prefs.pref_trackartistInArtists | html %]" />
 		<input type="hidden" name="pref_composerInArtists" value="[% prefs.pref_composerInArtists | html %]" />
 		<input type="hidden" name="pref_conductorInArtists" value="[% prefs.pref_conductorInArtists | html %]" />
 		<input type="hidden" name="pref_bandInArtists" value="[% prefs.pref_bandInArtists | html %]" />

--- a/Slim/Plugin/RemoteLibrary/LMS.pm
+++ b/Slim/Plugin/RemoteLibrary/LMS.pm
@@ -354,7 +354,7 @@ sub _getBrowsePrefs {
 	my $cacheKey = $serverId . '_prefs';
 	my $cached = $cache->get($cacheKey) || {};
 
-	foreach my $pref ( 'noGenreFilter', 'noRoleFilter', 'useUnifiedArtistsList', 'composerInArtists', 'conductorInArtists', 'bandInArtists', 'trackartistInArtists' ) {
+	foreach my $pref ( 'noGenreFilter', 'noRoleFilter', 'useUnifiedArtistsList', 'composerInArtists', 'conductorInArtists', 'bandInArtists' ) {
 		if (!defined $cached->{$pref} && !$passwordProtected{$serverId}) {
 			push @prefsFetcher, sub {
 				__PACKAGE__->remoteRequest($serverId,

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -90,7 +90,7 @@ sub defaultContributorRoles {
 }
 
 sub unifiedArtistsListRoles {
-	my @roles = ( 'ARTIST', 'ALBUMARTIST' );
+	my @roles = ( 'ARTIST', 'TRACKARTIST', 'ALBUMARTIST' );
 
 	# Loop through each pref to see if the user wants to show that contributor role. Also include user-defined roles.
 	push @roles, grep { $prefs->get(lc($_) . 'InArtists') } contributorRoles();

--- a/Slim/Schema/ResultSet/Contributor.pm
+++ b/Slim/Schema/ResultSet/Contributor.pm
@@ -28,7 +28,7 @@ sub searchNames {
 		$cond->{'contributorAlbums.role'} = { 'in' => $roles };
 		push @joins, 'contributorAlbums';
 	}
-	
+
 	my $collate = Slim::Utils::OSDetect->getOS()->sqlHelperClass()->collate();
 
 	$attrs->{'order_by'} ||= "me.namesort $collate";
@@ -45,9 +45,11 @@ sub countTotal {
 
 	my $cond  = {};
 	my @joins = ();
-	my $roles = $prefs->get('useUnifiedArtistsList')
-		? Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude())
-		: [ Slim::Schema::Contributor->contributorRoleIds ];
+	my $roles = [
+		$prefs->get('useUnifiedArtistsList')
+			? sort map { Slim::Schema::Contributor->typeToRole($_) } Slim::Schema::Contributor->unifiedArtistsListRoles()
+			: Slim::Schema::Contributor->contributorRoleIds
+	];
 
 	# The user may not want to include all the composers / conductors
 	if ($roles) {
@@ -64,7 +66,7 @@ sub countTotal {
 
 		push @joins, 'contributorAlbums';
 	}
-	
+
 	my $collate = Slim::Utils::OSDetect->getOS()->sqlHelperClass()->collate();
 
 	return $self->search($cond, {

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -184,7 +184,6 @@ sub init {
 		'composerInArtists'     => 0,
 		'conductorInArtists'    => 0,
 		'bandInArtists'         => 0,
-		'trackartistInArtists'  => 0,
 		'userDefinedRoles'      => {},
 		'variousArtistAutoIdentification' => 1,
 		'useUnifiedArtistsList' => 0,
@@ -547,7 +546,7 @@ sub init {
 		# Rebuild Jive cache if VA setting is changed
 		$prefs->setChange( sub {
 			Slim::Schema->wipeCaches();
-		}, 'variousArtistAutoIdentification', 'composerInArtists', 'conductorInArtists', 'bandInArtists', 'trackartistInArtists', 'useUnifiedArtistsList', 'userDefinedRoles');
+		}, 'variousArtistAutoIdentification', 'composerInArtists', 'conductorInArtists', 'bandInArtists', 'useUnifiedArtistsList', 'userDefinedRoles');
 
 		$prefs->setChange( sub {
 			Slim::Control::Queries->wipeCaches();

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -507,7 +507,11 @@ sub _initActiveRoles {
 
 	$params->{'search'}->{'contributor_namesearch'} = {
 		map { ('active' . $_) => 1 } @{
-			Slim::Schema->artistOnlyRoles(Slim::Schema::Contributor::getUserDefinedRolesToInclude())
+			Slim::Schema->artistOnlyRoles(
+				$prefs->get('useUnifiedArtistsList')
+					? Slim::Schema::Contributor->unifiedArtistsListRoles()
+					: Slim::Schema::Contributor::getUserDefinedRolesToInclude()
+			)
 		}
 	} unless keys %{$params->{'search'}->{'contributor_namesearch'}};
 }

--- a/Slim/Web/Settings/Server/Behavior.pm
+++ b/Slim/Web/Settings/Server/Behavior.pm
@@ -27,7 +27,7 @@ sub prefs {
 	return ($prefs,
 			qw(noGenreFilter noRoleFilter searchSubString ignoredarticles splitList
 				browseagelimit groupdiscs persistPlaylists reshuffleOnRepeat saveShuffled composerInArtists
-				conductorInArtists bandInArtists trackartistInArtists variousArtistAutoIdentification
+				conductorInArtists bandInArtists variousArtistAutoIdentification
 				ignoreReleaseTypes cleanupReleaseTypes groupArtistAlbumsByReleaseType
 				useTPE2AsAlbumArtist variousArtistsString ratingImplementation useUnifiedArtistsList
 				skipsentinel showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears)

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -41,7 +41,7 @@ if ( !main::SCANNER ) {
 	Slim::Control::Request::subscribe( \&wipeCaches, [['library','rescan','favorites'], ['changed','done','changed']] );
 
 	$prefs->setChange( \&wipeCaches, qw(itemsPerPage thumbSize showArtist showYear additionalPlaylistButtons noGenreFilter noRoleFilter searchSubString browseagelimit
-		composerInArtists conductorInArtists bandInArtists trackartistInArtists variousArtistAutoIdentification titleFormat titleFormatWeb language useUnifiedArtistsList
+		composerInArtists conductorInArtists bandInArtists variousArtistAutoIdentification titleFormat titleFormatWeb language useUnifiedArtistsList
 		groupArtistAlbumsByReleaseType ignoreReleaseTypes releaseTypesToIgnore showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears userDefinedRoles) );
 }
 

--- a/strings.txt
+++ b/strings.txt
@@ -8785,33 +8785,33 @@ SETUP_NOROLEFILTER_DESC
 	SV	När du bläddrar genom "Artister" kan du filtrera så att bara album och låtar som matchar den valda rollen ("ALBUMARTIST", "COMPOSER", etc.) visas.
 
 SETUP_COMPOSERINARTISTS
-	CS	Interpret skladby, Skladatel, Skupina a Orchestr v Interpretech
-	DA	Nummerets kunstner, Komponist, band og orkester i Kunstnere
-	DE	Titelinterpret, Komponist, Gruppe und Orchester in Interpreten
-	EN	Track Artist, Composer, Band and Orchestra in Artists
-	ES	Artista de pista, Compositor, banda y orquesta en artistas
-	FI	Raidan artisti, Säveltäjä, yhtye ja orkesteri artisteissa
-	FR	Artiste du morceau, compositeur, groupe/orchestre dans les artistes
-	HE	מלחינים, להקות ותזמורות בין המבצעים,  מבצע הרצועה
-	HU	Zeneszám előadója, Zeneszerző, együttes és zenekar a előadóknál
-	IT	Artista brano, Compositore, gruppo e orchestra in Artisti
+	CS	Skladatel, Skupina a Orchestr v Interpretech
+	DA	Komponist, band og orkester i Kunstnere
+	DE	Komponist, Gruppe und Orchester in Interpreten
+	EN	Composer, Band and Orchestra in Artists
+	ES	Compositor, banda y orquesta en artistas
+	FI	Säveltäjä, yhtye ja orkesteri artisteissa
+	FR	Compositeur, groupe et orchestre dans les artistes
+	HE	מלחינים, להקות ותזמורות בין המבצעים
+	HU	Zeneszerző, együttes és zenekar a előadóknál
+	IT	Compositore, gruppo e orchestra in Artisti
 	JA	「アーチスト」に、作曲家、バンド、オーケストラ
-	NL	Artiest van nummer, Componist, dirigent en band in lijst met artiesten
-	NO	Sporartist, Komponist, band og orkester i Artister
-	PL	Wykonawca utworu, Kompozytor, zespół i orkiestra jako wykonawcy
-	PT	Artista da pista, Compositor, Banda e Orquestra em Artistas
-	RU	Исполнитель дорожки, Поле "Исполнители": композитор, группа и оркестр
-	SV	Spårets artist, Kompositör, band och orkester i Artister
-	ZH_CN	音轨艺人有关艺人的作曲家及乐队信息
+	NL	Componist, dirigent en band in lijst met artiesten
+	NO	Komponist, band og orkester i Artister
+	PL	Kompozytor, zespół i orkiestra jako wykonawcy
+	PT	Compositor, Banda e Orquestra em Artistas
+	RU	Поле "Исполнители": композитор, группа и оркестр
+	SV	Kompositör, band och orkester i Artister
+	ZH_CN	有关艺人的作曲家及乐队信息
 
 SETUP_COMPOSERINARTISTS_DESC
 	CS	Informace o skladatelích, skupinách a orchestrech mohou být přidány do seznamu interpretů pro procházení a vyhledávání.
 	DA	Der kan vises oplysninger om hvem der har komponeret og hvem der spiller de forskellige numre, i listen med kunstnere når du gennemser eller søger i din musiksamling.
-	DE	Titelinformationen über Nummerets kunstner, Komponist, Gruppe und Orchester können in der Interpretenliste und beim Suchen aufgenommen werden.
-	EN	Song information about track artists, composers, bands and orchestras can be included in the artists list for browsing and search.
-	ES	La información de canción sobre artistas de pista, compositores, bandas y orquestas se puede incluir en la lista de artistas para examinar y buscar.
+	DE	Titelinformationen über Komponist, Gruppe und Orchester können in der Interpretenliste und beim Suchen aufgenommen werden.
+	EN	Song information about composers, bands and orchestras can be included in the artists list for browsing and search.
+	ES	La información de canción sobre compositores, bandas y orquestas se puede incluir en la lista de artistas para examinar y buscar.
 	FI	Artistiluetteloon voidaan lisätä kappaletietoja säveltäjistä, yhtyeistä ja orkestereista selaamista ja hakuja varten.
-	FR	Les informations relatives aux artistes des morceaux, compositeurs, groupes/orchestres peuvent être ajoutées à la liste des artistes pour le parcours de bibliothèque et les recherches.
+	FR	Les informations relatives au compositeur, au groupe et à l'orchestre contenues dans les morceaux peuvent être ajoutées à la liste d'artistes pour parcourir ou rechercher.
 	HE	ניתן לכלול פרטי שירים אודות מלחינים, להקות ותזמורות ברשימת המבצעים לצורך עיון וחיפוש.
 	HU	A zeneszerzőkről, együttesekről és zenekarokról szóló dalinformációk böngészéshez és kereséshez felvehetők az előadók listájába.
 	IT	Per ogni brano, nell'elenco degli artisti è possibile includere informazioni su compositore, gruppo e orchestra a fini di consultazione e ricerca.


### PR DESCRIPTION
This reverts PR #1186 in large parts, but adds some more consequent use of `Slim::Schema::Contributor->unifiedArtistsListRoles` instead. I believe the motivation for #1186 was to include custom roles in search result sets. This is one place where this PR does things differently than before #1186.

`TRACKARTIST` had been in the unified artists list for > 10 years. Removing it or making it optional IMHO was our mistake. But I believe we only did so in order to use other methods compiling role lists. This change will hopefully do the best of both...