### PR TITLE
User-defined roles in releases

### DIFF
--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -74,6 +74,7 @@ sub _releases {
 
 		# map to role's name for readability
 		$_->{role_ids} = join(',', map { Slim::Schema::Contributor->roleToType($_) } split(',', $_->{role_ids} || ''));
+		my $roles = Slim::Schema::Contributor->splitDefaultAndCustomRoles($_->{role_ids});
 
 		my $genreMatch = undef;
 		if ( $checkComposerGenres ) {
@@ -101,29 +102,32 @@ sub _releases {
 			$_->{release_type} = 'COMPILATION';
 			$addToMainReleases->();
 			# only list outside the compilations if Composer/Conductor
-			next unless $_->{role_ids} =~ /COMPOSER|CONDUCTOR/ && $_->{role_ids} !~ /ARTIST|BAND/;
+			next unless ( $roles->{defaultRoles} =~ /COMPOSER|CONDUCTOR/ || $roles->{userDefinedRoles} ) && $roles->{defaultRoles} !~ /ARTIST|BAND/;
 		}
 		# Release Types if album artist
 		elsif ( $_->{role_ids} =~ /ALBUMARTIST/ ) {
-			$addToMainReleases->();
-			next;
+			$addToMainReleases->() if $roles->{defaultRoles};
+			next unless $roles->{userDefinedRoles};
 		}
 		# Consider this artist the main (album) artist if there's no other, defined album artist
 		elsif ( $_->{role_ids} =~ /ARTIST/ ) {
-			my $albumArtist = Slim::Schema->first('ContributorAlbum', {
-				album => $_->{id},
-				role  => Slim::Schema::Contributor->typeToRole('ALBUMARTIST'),
-				contributor => { '!=' => $_->{artist_id} }
-			});
+			if ( $roles->{defaultRoles} ) {
+				my $albumArtist = Slim::Schema->first('ContributorAlbum', {
+					album => $_->{id},
+					role  => Slim::Schema::Contributor->typeToRole('ALBUMARTIST'),
+					contributor => { '!=' => $_->{artist_id} }
+				});
 
-			if (!$albumArtist) {
-				$addToMainReleases->();
-				next;
+				if (!$albumArtist) {
+					$addToMainReleases->();
+					next unless $roles->{userDefinedRoles};
+
+				}
 			}
 		}
 
 		# Roles on other releases
-		foreach my $role ( grep { $_ ne 'ALBUMARTIST' } split(',', $_->{role_ids} || '') ) {
+		foreach my $role ( grep { $_ ne 'ALBUMARTIST' && $_ ne 'ARTIST' } split(',', $_->{role_ids} || '') ) {
 			# don't list as trackartist, if the artist is albumartist, too
 			next if $role eq 'TRACKARTIST' && $isPrimaryArtist{$_->{id}};
 

--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -75,8 +75,6 @@ sub _releases {
 		# map to role's name for readability
 		$_->{role_ids} = join(',', map { Slim::Schema::Contributor->roleToType($_) } split(',', $_->{role_ids} || ''));
 		my ($defaultRoles, $userDefinedRoles) = Slim::Schema::Contributor->splitDefaultAndCustomRoles($_->{role_ids});
-$log->error("DK \$defaultRoles=" . Data::Dump::dump($defaultRoles));
-$log->error("DK \$userDefinedRoles=" . Data::Dump::dump($userDefinedRoles));
 
 		my $genreMatch = undef;
 		if ( $checkComposerGenres ) {

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -89,6 +89,20 @@ sub defaultContributorRoles {
 	return grep { __PACKAGE__->typeToRole($_) < MIN_CUSTOM_ROLE_ID } contributorRoles();
 }
 
+sub splitDefaultAndCustomRoles {
+	my $self = shift;
+	my $roles = shift;
+
+	return {
+		defaultRoles => (join(',', grep {
+			my $x = $_; grep {$x eq $_} defaultContributorRoles()
+			} split(',', $roles || ''))),
+		userDefinedRoles => (join(',', grep {
+			my $x = $_; !grep {$x eq $_} defaultContributorRoles()
+			} split(',', $roles || ''))),
+	};
+}
+
 sub userDefinedRoles {
 	my $self  = shift;
 	my $activeOnly = shift;

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -93,14 +93,19 @@ sub splitDefaultAndCustomRoles {
 	my $self = shift;
 	my $roles = shift;
 
-	return {
-		defaultRoles => (join(',', grep {
-			my $x = $_; grep {$x eq $_} defaultContributorRoles()
-			} split(',', $roles || ''))),
-		userDefinedRoles => (join(',', grep {
-			my $x = $_; !grep {$x eq $_} defaultContributorRoles()
-			} split(',', $roles || ''))),
-	};
+	my @allDefaultRoles = defaultContributorRoles();
+	my @roles = split(',', $roles || '');
+	my @defaultRoles;
+	my @userDefinedRoles;
+
+	foreach my $role (@roles) {
+		if ( grep {$_ eq $role} @allDefaultRoles ) {
+			push @defaultRoles, $role;
+		} else {
+			push @userDefinedRoles, $role;
+		}
+	}
+	return (join(',', @defaultRoles), join(',', @userDefinedRoles));
 }
 
 sub userDefinedRoles {

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -86,10 +86,10 @@ sub contributorRoles {
 }
 
 sub isDefaultContributorRole {
-	my $self = shift;
+	my $class = shift;
 	my $role = shift;
 	
-	return __PACKAGE__->typeToRole($role) < MIN_CUSTOM_ROLE_ID;
+	return $class->typeToRole($role) < MIN_CUSTOM_ROLE_ID;
 }
 
 sub defaultContributorRoles {

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -85,21 +85,27 @@ sub contributorRoles {
 	return @contributorRoles;
 }
 
+sub isDefaultContributorRole {
+	my $self = shift;
+	my $role = shift;
+	
+	return __PACKAGE__->typeToRole($role) < MIN_CUSTOM_ROLE_ID;
+}
+
 sub defaultContributorRoles {
-	return grep { __PACKAGE__->typeToRole($_) < MIN_CUSTOM_ROLE_ID } contributorRoles();
+	return grep { __PACKAGE__->isDefaultContributorRole($_) } contributorRoles();
 }
 
 sub splitDefaultAndCustomRoles {
 	my $self = shift;
 	my $roles = shift;
 
-	my @allDefaultRoles = defaultContributorRoles();
 	my @roles = split(',', $roles || '');
 	my @defaultRoles;
 	my @userDefinedRoles;
 
 	foreach my $role (@roles) {
-		if ( grep {$_ eq $role} @allDefaultRoles ) {
+		if ( __PACKAGE__->isDefaultContributorRole($role) ) {
 			push @defaultRoles, $role;
 		} else {
 			push @userDefinedRoles, $role;


### PR DESCRIPTION
I came across this when analysing another bug: the user has a custom role tag which contains "ARTIST" in its name, which meant the tag was being ignored in `Slim::Menu::BrowseLibrary::Releases` as it triggered a `next` in the loop once the standard ARTIST tag was processed.

This change separates out standard from user-defined tags so that they can both be processed correctly. 