### PR TITLE
Add Works criteria and search type to Advanced Search

### DIFF
--- a/HTML/EN/advanced_search.html
+++ b/HTML/EN/advanced_search.html
@@ -148,6 +148,11 @@
 	<input name="search.album_titlesearch" value="[% search.album_titlesearch.value | html %]" size="[% size %]" maxlength="100" type="text">
 [% END %]
 
+[% WRAPPER field title='WORK' %]
+	[% containsBlock(name='search.work_titlesearch.op') %]
+	<input name="search.work_titlesearch" value="[% search.work_titlesearch.value | html %]" size="[% size %]" maxlength="100" type="text">
+[% END %]
+
 [% WRAPPER field title='RELEASE_TYPE' %]
 	[% containsBlock(name='search.album_release_type.op') %]
 	<input name="search.album_release_type" value="[% search.album_release_type.value | html %]" size="[% size %]" maxlength="100" type="text">
@@ -292,6 +297,7 @@
 			<select name="searchType">
 				<option value="Track">[% "SONGS" | string %]</option>
 				<option [% IF searchType == "Album" %]selected[% END %] value="Album">[% "ALBUMS" | string %]</option>
+				<option [% IF searchType == "Work" %]selected[% END %] value="Work">[% "WORKS" | string %]</option>
 			</select>
 			<input value="[% "CLEAR"  | string %]" name="resetAdvSearch" type="submit">
 		</td>
@@ -315,7 +321,16 @@
 		[% IF allLinks; WRAPPER insertlink %][% PROCESS cmdHRef cmdType='insert' %][% END; END %]
 		[% WRAPPER addlink %][% PROCESS cmdHRef cmdType='add' %][% END %]
 		[% IF allLinks; WRAPPER removelink %][% PROCESS cmdHRef cmdType='remove' %][% END; END %]
-		[% WRAPPER morelink %]href="[% webroot %]clixmlbrowser/clicmd=albuminfo+items&album_id=[% item.itemobj.id %]&amp;linktitle=[% stringINFO %]%20([% item.albumTitle %])/?player=[% playerURI %]" target="browser"[% END %]
+		[% WRAPPER morelink %]href="[% webroot %]clixmlbrowser/clicmd=albuminfo+items&album_id=[% item.itemobj.id %]&amp;linktitle=[% stringINFO %]%20([% item.albumTitle | html %])/?player=[% playerURI %]" target="browser"[% END %]
+	[%- END %]
+
+	[% BLOCK workBrowsecontrols %]
+		[%- header='1' width=cmdLinkIconSize height=cmdLinkIconSize -%]
+		[% PROCESS favoritescontrol %]
+		[% WRAPPER playlink %][% PROCESS cmdHRef cmdType='play' %][% END %]
+		[% IF allLinks; WRAPPER insertlink %][% PROCESS cmdHRef cmdType='insert' %][% END; END %]
+		[% WRAPPER addlink %][% PROCESS cmdHRef cmdType='add' %][% END %]
+		[% IF allLinks; WRAPPER removelink %][% PROCESS cmdHRef cmdType='remove' %][% END; END %]
 	[%- END %]
 
 	[% IF browse_items.size %]
@@ -324,6 +339,9 @@
 			[% IF searchType == 'Album';
 				itemInfoTemplate = 'albuminfo';
 				leftControls = 'albumBrowsecontrols';
+			ELSIF searchType == 'Work';
+				itemInfoTemplate = 'workinfo';
+				leftControls = 'workBrowsecontrols';
 			ELSE;
 				itemInfoTemplate = 'trackinfo';
 				leftControls = 'browsecontrols';

--- a/HTML/EN/cmdwrappers
+++ b/HTML/EN/cmdwrappers
@@ -295,7 +295,7 @@ END %]
 [% END %]
 
 [% BLOCK albuminfo %]
-	[% IF item.albumTitle %]
+	[% IF item.albumId || item.itemobj.album.id %]
 		<a [% PROCESS albumItemHRef %] target="browser" class="browseItemLink">[% item.text | html %]</a>
 	[% ELSE %]
 		[% item.text | html %]
@@ -309,7 +309,7 @@ END %]
 [% END %]
 
 [% BLOCK workinfo %]
-	[% IF item.workTitle %]
+	[% IF item.workId || item.itemobj.work.id %]
 		<a [% PROCESS workItemHRef %] target="browser" class="browseItemLink">[% item.text | html %]</a>
 	[% ELSE %]
 		[% item.text | html %]

--- a/HTML/EN/cmdwrappers
+++ b/HTML/EN/cmdwrappers
@@ -295,7 +295,11 @@ END %]
 [% END %]
 
 [% BLOCK albuminfo %]
-	<a [% PROCESS albumItemHRef %] target="browser" class="browseItemLink">[% item.text | html %]</a>
+	[% IF item.albumTitle %]
+		<a [% PROCESS albumItemHRef %] target="browser" class="browseItemLink">[% item.text | html %]</a>
+	[% ELSE %]
+		[% item.text | html %]
+	[% END %]
 
 	[% IF item.showYear %]
 		<a [% PROCESS yearItemHRef %] class="browseItemLink">([% item.year %])</a>
@@ -304,9 +308,19 @@ END %]
 	[% IF item.includeArtist && (artist = item.artistsWithAttributes ? item.artistsWithAttributes.0 : item.itemobj.artist) && artist.name != item.noArtist; PROCESS artistsAsHTML.html itemobj = item.itemobj; END %]
 [% END %]
 
+[% BLOCK workinfo %]
+	[% IF item.workTitle %]
+		<a [% PROCESS workItemHRef %] target="browser" class="browseItemLink">[% item.text | html %]</a>
+	[% ELSE %]
+		[% item.text | html %]
+	[% END %]
+[% END %]
+
 [% BLOCK iteminfo;
 	IF item.levelName == 'album';
 		PROCESS albuminfo;
+	ELSIF item.levelName == 'work';
+		PROCESS workinfo;
 	ELSE;
 		PROCESS trackinfo;
 END; END %]

--- a/HTML/EN/hreftemplate
+++ b/HTML/EN/hreftemplate
@@ -146,6 +146,11 @@ this should be identical to the URL args supplied in cmdHRef plus ajaxRequest=1 
 href="[% webroot %]clixmlbrowser/clicmd=browselibrary+items&amp;mode=tracks&amp;linktitle=[% stringALBUM %]%20([% (item.albumTitle || item.itemobj.album.id) | uri %])&amp;album_id=[% (item.albumId || item.itemobj.album.id) %]&amp;player=[% playerURI %]/"
 [%- END %]
 
+[%# this is the href to the work of item %]
+[% BLOCK workItemHRef -%]
+href="[% webroot %]clixmlbrowser/clicmd=browselibrary+items&amp;mode=albums&amp;linktitle=[% stringWORK %]%20([% (item.workTitle || item.itemobj.work.id) | uri %])&amp;work_id=[% (item.workId || item.itemobj.work.id) %]&amp;player=[% playerURI %]/"
+[%- END %]
+
 [%# this is the href to the year of item %]
 [% BLOCK yearItemHRef -%]
 href="[% webroot %]clixmlbrowser/clicmd=browselibrary+items&amp;mode=albums&amp;linktitle=[% stringYEAR %]%20([% item.year %])&amp;year=[% item.year %][% IF artwork || artwork == 0 %]&amp;artwork=[% artwork %][% END %]&amp;player=[% playerURI %]/"

--- a/HTML/EN/hreftemplate
+++ b/HTML/EN/hreftemplate
@@ -148,7 +148,7 @@ href="[% webroot %]clixmlbrowser/clicmd=browselibrary+items&amp;mode=tracks&amp;
 
 [%# this is the href to the work of item %]
 [% BLOCK workItemHRef -%]
-href="[% webroot %]clixmlbrowser/clicmd=browselibrary+items&amp;mode=albums&amp;linktitle=[% stringWORK %]%20([% (item.workTitle || item.itemobj.work.id) | uri %])&amp;work_id=[% (item.workId || item.itemobj.work.id) %]&amp;player=[% playerURI %]/"
+href="[% webroot %]clixmlbrowser/clicmd=browselibrary+items&amp;mode=albums&amp;linktitle=[% stringWORK %]%20([% (item.text || item.itemobj.work.id) | uri %])&amp;work_id=[% (item.workId || item.itemobj.work.id) %]&amp;player=[% playerURI %]/"
 [%- END %]
 
 [%# this is the href to the year of item %]

--- a/Slim/Schema/Work.pm
+++ b/Slim/Schema/Work.pm
@@ -56,6 +56,10 @@ sub displayAsHTML {
 	my ($self, $form, $descend, $sort) = @_;
 
 	$form->{'text'} = $self->title;
+	$form->{'workId'}    = $self->id;
+	$form->{'item'}       = $form->{'text'};
+	$form->{'workTitle'} = $form->{'text'};
+	$form->{'attributes'} = "&work.id=" . $form->{'workId'};
 }
 
 # Rescan this work.  Make sure at least 1 track for the work exists, otherwise

--- a/Slim/Schema/Work.pm
+++ b/Slim/Schema/Work.pm
@@ -22,6 +22,8 @@ use Slim::Utils::Strings qw(string);
 	$class->has_many('track' => 'Slim::Schema::Track' => 'work');
 	$class->belongs_to('composer' => 'Slim::Schema::Composer');
 
+	$class->utf8_columns(qw/title titlesort/);
+
 	$class->resultset_class('Slim::Schema::ResultSet::Work');
 }
 
@@ -55,10 +57,11 @@ sub contributors {
 sub displayAsHTML {
 	my ($self, $form, $descend, $sort) = @_;
 
-	$form->{'text'} = $self->title;
-	$form->{'workId'}    = $self->id;
-	$form->{'item'}       = $form->{'text'};
-	$form->{'workTitle'} = $form->{'text'};
+	$form->{'workId'}     = $self->id;
+	$form->{'workTitle'}  = $self->title;
+	$form->{'composer'}   = $self->composer->name;
+	$form->{'text'}       = $form->{'composer'} . string('COLON') . ' ' .$form->{'workTitle'};
+	$form->{'item'}       = $form->{'workTitle'};
 	$form->{'attributes'} = "&work.id=" . $form->{'workId'};
 }
 

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -132,7 +132,7 @@ sub advancedSearch {
 		delete $params->{savedSearch};
 	}
 
-	my $type = ($params->{'searchType'} || '') =~ /^(Track|Album)$/ ? $1 : 'Track';
+	my $type = ($params->{'searchType'} || '') =~ /^(Track|Album|Work)$/ ? $1 : 'Track';
 
 	# keep a copy of the search params to be stored in a saved search
 	my %searchParams;
@@ -418,6 +418,11 @@ sub advancedSearch {
 		push @joins, 'album';
 	}
 
+	if ($query{'work.titlesearch'}) {
+
+		push @joins, 'work';
+	}
+
 	if ($query{'comments.value'} || $joins{'comments'}) {
 
 		push @joins, 'comments';
@@ -457,7 +462,14 @@ sub advancedSearch {
 		},{
 			'order_by' => "me.disc, me.titlesort $collate",
 		});
+	} elsif ( $type eq 'Work' ) {
+		$rs = Slim::Schema->search('Work', {
+			'id' => { 'in' => $tracksRs->get_column('work')->as_query },
+		},{
+			'order_by' => "me.titlesort $collate",
+		});
 	}
+
 
 	if ( $params->{'action'} && $params->{'action'} eq 'saveLibraryView' && (my $saveSearch = $params->{saveSearch}) ) {
 		# build our own resultset, as we don't want the result to be sorted

--- a/strings.txt
+++ b/strings.txt
@@ -14492,15 +14492,27 @@ BROWSE_WORKS
 	CS	Procházet díla
 	DE	Werke durchsuchen
 	EN	Browse Works
+	ES	Explorar obras
 	FR	Parcourir les œuvres
 	HU	Tallózás a művek között
 	NL	Door composities bladeren
 	PT	Examinar obras
 
+WORK
+	CS	Díla
+	DE	Werke
+	EN	Work
+	ES	Obra
+	FR	Œuvre
+	HU	Művek
+	NL	Compositie
+	PT	Obra
+
 WORKS
 	CS	Díla
 	DE	Werke
 	EN	Works
+	ES	Obras
 	FR	Œuvres
 	HU	Művek
 	NL	Composities
@@ -14510,6 +14522,7 @@ WORKS_CLASSICAL
 	CS	Klasická díla
 	DE	Klassische Werke
 	EN	Classical Works
+	ES	Obras clásicas
 	FR	Œuvres Classiques
 	HU	Klasszikus művek
 	NL	Klassieke composities


### PR DESCRIPTION
As the title says.

I also discovered a couple of bugs in the Albums advanced search while testing, which I have fixed:
1. The "All Songs" entry was hyperlinked and when clicked led to a list of all songs in the database because of course there is no album_id. It is now text only, like it already was for a Tracks search.
2. The links were not generated correctly with album names containing `"` so I fed it through the `html` filter.
