### PR TITLE
Fix for PR1196

### DIFF
--- a/Slim/Music/TitleFormatter.pm
+++ b/Slim/Music/TitleFormatter.pm
@@ -86,6 +86,20 @@ sub init {
 		return (defined $output ? $output : '');
 	};
 
+	# Override work
+	$parsedFormats{'WORK'} = sub {
+
+		if ( ref $_[0] eq 'HASH' ) {
+			return $_[0]->{work} || $_[0]->{'works.title'} || '';
+		}
+
+		my $output = '';
+		$output = $_[0]->worktitle();
+		$output = '' if !defined($output);
+
+		return (defined $output ? $output : '');
+	};
+
 	# add album related
 	$parsedFormats{'ALBUMSORT'} = sub {
 
@@ -688,7 +702,6 @@ sub infoFormat {
 				'create' => 1,
 			});
 		}
-
 		if (!blessed($track) || !$track->can('id')) {
 
 			return '';

--- a/Slim/Music/TitleFormatter.pm
+++ b/Slim/Music/TitleFormatter.pm
@@ -702,6 +702,7 @@ sub infoFormat {
 				'create' => 1,
 			});
 		}
+
 		if (!blessed($track) || !$track->can('id')) {
 
 			return '';

--- a/Slim/Schema/Track.pm
+++ b/Slim/Schema/Track.pm
@@ -48,7 +48,7 @@ our @allColumns = (qw(
 	# setup our relationships
 	$class->belongs_to('album' => 'Slim::Schema::Album');
 	$class->belongs_to('primary_artist'  => 'Slim::Schema::Contributor');
-	$class->belongs_to('work' => 'Slim::Schema::Work');
+	$class->belongs_to('work' => 'Slim::Schema::Work', 'work', { join_type => 'left' });
 
 	$class->has_many('genreTracks'       => 'Slim::Schema::GenreTrack' => 'track');
 	$class->has_many('comments'          => 'Slim::Schema::Comment'    => 'track');
@@ -86,10 +86,6 @@ sub namesort {
 
 sub namesearch {
 	return shift->titlesearch;
-}
-
-sub work {
-	return shift->work;
 }
 
 sub workid {

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -450,7 +450,10 @@ sub advancedSearch {
 		'joins' => \@joins,
 	);
 
-	$attrs{'order_by'} = "me.disc, me.titlesort $collate" if $type eq 'Track';
+	if ( $type eq 'Track' ) {
+		$attrs{'order_by'} = "me.disc, me.titlesort $collate";
+		$attrs{'prefetch'} = "work";
+	}
 
 	# Create a resultset - have fillInSearchResults do the actual search.
 	my $tracksRs = Slim::Schema->search('Track', \%query, \%attrs)->distinct;
@@ -592,7 +595,9 @@ sub fillInSearchResults {
 	while (my $obj = $rs->next) {
 
 		# ensure work name is in the place expected by TitleFormatter so that it uses name and not id
-		$obj->store_column('work' => $obj->work->get_column('title')) if $type eq 'track' && $obj->work && $obj->work->get_column('title');
+		if ( $type eq 'track' && $obj->workid && $obj->work && $obj->work->title ) {
+			$obj->store_column('work' => $obj->work->title);
+		}
 
 		my %form = (
 			'levelName'    => $type,

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -450,10 +450,7 @@ sub advancedSearch {
 		'joins' => \@joins,
 	);
 
-	if ( $type eq 'Track' ) {
-		$attrs{'order_by'} = "me.disc, me.titlesort $collate";
-		$attrs{'prefetch'} = "work";
-	}
+	$attrs{'order_by'} = "me.disc, me.titlesort $collate" if $type = 'Track';;
 
 	# Create a resultset - have fillInSearchResults do the actual search.
 	my $tracksRs = Slim::Schema->search('Track', \%query, \%attrs)->distinct;
@@ -593,11 +590,6 @@ sub fillInSearchResults {
 
 	# This is very similar to a loop in Slim::Web::Pages::BrowseDB....
 	while (my $obj = $rs->next) {
-
-		# ensure work name is in the place expected by TitleFormatter so that it uses name and not id
-		if ( $type eq 'track' && $obj->workid && $obj->work && $obj->work->title ) {
-			$obj->store_column('work' => $obj->work->title);
-		}
 
 		my %form = (
 			'levelName'    => $type,

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -450,7 +450,7 @@ sub advancedSearch {
 		'joins' => \@joins,
 	);
 
-	$attrs{'order_by'} = "me.disc, me.titlesort $collate" if $type = 'Track';;
+	$attrs{'order_by'} = "me.disc, me.titlesort $collate" if $type eq 'Track';
 
 	# Create a resultset - have fillInSearchResults do the actual search.
 	my $tracksRs = Slim::Schema->search('Track', \%query, \%attrs)->distinct;

--- a/Slim/Web/Pages/Search.pm
+++ b/Slim/Web/Pages/Search.pm
@@ -451,7 +451,6 @@ sub advancedSearch {
 	);
 
 	$attrs{'order_by'} = "me.disc, me.titlesort $collate" if $type eq 'Track';
-	$attrs{'prefetch'} = "work" if $type eq 'Track';
 
 	# Create a resultset - have fillInSearchResults do the actual search.
 	my $tracksRs = Slim::Schema->search('Track', \%query, \%attrs)->distinct;
@@ -592,7 +591,8 @@ sub fillInSearchResults {
 	# This is very similar to a loop in Slim::Web::Pages::BrowseDB....
 	while (my $obj = $rs->next) {
 
-		$obj->store_column('work' => $obj->work->get_column('title')) if $type eq 'track' && $obj->work->get_column('title');
+		# ensure work name is in the place expected by TitleFormatter so that it uses name and not id
+		$obj->store_column('work' => $obj->work->get_column('title')) if $type eq 'track' && $obj->work && $obj->work->get_column('title');
 
 		my %form = (
 			'levelName'    => $type,


### PR DESCRIPTION
To fix a horrible bug in #1196 :

The prefetch was causing no "Song" results where the track was not part of a Work. Sorry!

It turns out that the `store_column` call (slightly amended for when there is no track->work available) gets the correct data anyway, though possibly a bit less efficiently. 

The base problem is that way back, I defined the `belongs_to` work relationship in `Slim::Schema::Track` incorrectly, it should have had `{ join_type => 'left' }` to take account of the fact that not all tracks are part of works. But I'm very nervous of changing this now, so close to the 9.0 release. One to revisit in the future?