### PR TITLE
Fix album list roles

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -766,6 +766,7 @@ sub albumsQuery {
 						AND ( (:performance IS NULL AND tracks.performance IS NULL) OR tracks.performance = :performance )
 						AND contributor_track.role IN (%s)
 					GROUP BY contributor_track.role, contributors.name, contributors.id
+					ORDER BY contributor_track.role, contributors.namesort
 				},
 				join(',', map { Slim::Schema::Contributor->typeToRole($_) } @linkRoles));
 			} else {
@@ -793,6 +794,7 @@ sub albumsQuery {
 					JOIN contributors ON contributors.id = contributor_album.contributor
 					WHERE contributor_album.album = :album
 					AND contributor_album.role IN (%s)
+					ORDER BY contributor_album.role, contributors.namesort
 				}, join(',', map { Slim::Schema::Contributor->typeToRole($_) } @linkRoles) );
 			}
 		}

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1525,7 +1525,7 @@ sub _albums {
 				}
 				else {
 					$_->{'artists'}    = [ $_->{'artist'} ];
-					$_->{'artist_ids'} = [ $_->{'id'} ];
+					$_->{'artist_ids'} = [ $_->{'artist_id'} ];
 				}
 
 				# If an artist was not used in the selection criteria or if one was


### PR DESCRIPTION
This fixes the bug in "combined artist list" mode: if any additional roles (track artist, composer. conductor, band) are selected for the artist list, album list entries no longer show artist or album artist.

Please see notes against the code, which I'm about to add, for details.