### PR TITLE
Update of cleanupReleaseTypes pref requires rescan

### DIFF
--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -395,7 +395,7 @@ sub init {
 
 	$prefs->setChange(
 		sub { Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]) },
-		qw(splitList groupdiscs useTPE2AsAlbumArtist)
+		qw(splitList groupdiscs useTPE2AsAlbumArtist cleanupReleaseTypes)
 	);
 
 	$prefs->setChange( sub {


### PR DESCRIPTION
Must rescan because when going back to what the tags provided, it's the only way.