### PR TITLE
Reset song queue on player stopped and queue finished

### DIFF
--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -2230,6 +2230,13 @@ sub playerStopped {
 		}
 	}
 
+	# If queue finished playing then reset song queue
+	my $currsong = Slim::Player::Source::playingSongIndex($client) + 1;
+	my $count = Slim::Player::Playlist::count($client);
+	if ($currsong == $count) {
+		$self->resetSongqueue(0);
+	}
+
 	_eventAction($self, 'Stopped');
 }
 


### PR DESCRIPTION
I saw #1213 and thought that this one might be interesting for others.

I've had this patch for some time in my tree and it's been working fine for me but I don't know if there are any other use cases that could be affected.
