### PR TITLE
Don't trigger setChange when pref goes from undef to undef

### DIFF
--- a/Slim/Utils/Prefs/Base.pm
+++ b/Slim/Utils/Prefs/Base.pm
@@ -92,7 +92,7 @@ sub set {
 	my $namespace = $root->{'namespace'};
 	my $clientid  = $class->{'clientid'} || '';
 
-	if (!ref $new && defined $new && defined $old && $new eq $old) {
+	if ( !ref $new && ( (defined $new && defined $old && $new eq $old) || (!(defined $new) && !(defined $old)) ) ) {
 		# suppress set when scalar and no change
 		return wantarray ? ($new, 1) : $new;
 	}

--- a/Slim/Utils/Prefs/Base.pm
+++ b/Slim/Utils/Prefs/Base.pm
@@ -92,7 +92,7 @@ sub set {
 	my $namespace = $root->{'namespace'};
 	my $clientid  = $class->{'clientid'} || '';
 
-	if ( !ref $new && ( (defined $new && defined $old && $new eq $old) || (!(defined $new) && !(defined $old)) ) ) {
+	if ( (!defined $new && !defined $old) || (!ref $new && defined $new && defined $old && $new eq $old) ) {
 		# suppress set when scalar and no change
 		return wantarray ? ($new, 1) : $new;
 	}


### PR DESCRIPTION
Since https://github.com/LMS-Community/slimserver/commit/d2b77990b3bdd99453a5c36283ff322b368757db leaving the pref unchecked triggers a rescan every time. 