### PR TITLE
Plural descriptions for user-defined tags

### DIFF
--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -63,16 +63,19 @@
 				<tr>
 					<th>[% "SETUP_USERDEFINEDROLES_TAG" | string %]</th>
 					<th>[% "SETUP_USERDEFINEDROLES_TEXT" | string %]</th>
+					<th>[% "SETUP_USERDEFINEDROLES_TEXT_PLURAL" | string %]</th>
 				</tr>
 				[% FOREACH tag = customTags.keys.sort %]
 					<tr>
 						<td><input type="text" name="[% tag | html %]_tag" value="[% tag | html %]" class="stdedit"/></td>
 						<td><input type="text" name="[% tag | html %]_name" value="[% customTags.$tag.name | html %]" class="stdedit" style="width: 200px;"/></td>
+						<td><input type="text" name="[% tag | html %]_namePlural" value="[% customTags.$tag.namePlural | html %]" class="stdedit" style="width: 200px;"/></td>
 					</tr>
 				[% END %]
 				<tr>
 					<td><input type="text" name="new_tag" value="" class="stdedit"/></td>
 					<td><input type="text" name="new_name" value="" class="stdedit" style="width: 200px;"/></td>
+					<td><input type="text" name="new_namePlural" value="" class="stdedit" style="width: 200px;"/></td>
 				</tr>
 			</table>
 		[% END %]

--- a/Slim/Web/Settings/Server/Behavior.pm
+++ b/Slim/Web/Settings/Server/Behavior.pm
@@ -110,16 +110,24 @@ sub handler {
 				if ( $tag ) {
 					$customTags->{$tag} = {
 						name => $paramRef->{$key . '_name'} || $tag,
+						namePlural => $paramRef->{$key . '_namePlural'} || $paramRef->{$key . '_name'} || $tag,
 						id => $userDefinedRoles->{$tag} ? $userDefinedRoles->{$tag}->{id} : $customRoleId++,
 						include => $userDefinedRoles->{$tag}  ? $userDefinedRoles->{$tag}->{include} : 1,
 						albumLink => $userDefinedRoles->{$tag}  ? $userDefinedRoles->{$tag}->{albumLink} : 1,
 					};
 
-					if ( !$userDefinedRoles->{$tag} || $userDefinedRoles->{$tag}->{name} ne $customTags->{$tag}->{name} ) {
-						Slim::Utils::Strings::storeExtraStrings([{
+					if ( !$userDefinedRoles->{$tag} || $userDefinedRoles->{$tag}->{name} ne $customTags->{$tag}->{name}
+									|| $userDefinedRoles->{$tag}->{namePlural} ne $customTags->{$tag}->{namePlural} ) {
+						Slim::Utils::Strings::storeExtraStrings(
+							[{
 							strings => { EN => $customTags->{$tag}->{name}},
 							token   => $tag,
-						}]);
+							},
+							{
+							strings => { EN => $customTags->{$tag}->{namePlural}},
+							token   => $tag . "_PLURAL",
+							}
+							]);
 						$changed = 1;
 					}
 				}

--- a/Slim/Web/Settings/Server/Behavior.pm
+++ b/Slim/Web/Settings/Server/Behavior.pm
@@ -109,8 +109,8 @@ sub handler {
 
 				if ( $tag ) {
 					$customTags->{$tag} = {
-						name => $paramRef->{$key . '_name'} || $tag,
-						namePlural => $paramRef->{$key . '_namePlural'} || $paramRef->{$key . '_name'} || $tag,
+						name => $paramRef->{$key . '_name'} || ucfirst(lc($tag)),
+						namePlural => $paramRef->{$key . '_namePlural'} || $paramRef->{$key . '_name'} || ucfirst(lc($tag)),
 						id => $userDefinedRoles->{$tag} ? $userDefinedRoles->{$tag}->{id} : $customRoleId++,
 						include => $userDefinedRoles->{$tag}  ? $userDefinedRoles->{$tag}->{include} : 1,
 						albumLink => $userDefinedRoles->{$tag}  ? $userDefinedRoles->{$tag}->{albumLink} : 1,
@@ -119,15 +119,11 @@ sub handler {
 					if ( !$userDefinedRoles->{$tag} || $userDefinedRoles->{$tag}->{name} ne $customTags->{$tag}->{name}
 									|| $userDefinedRoles->{$tag}->{namePlural} ne $customTags->{$tag}->{namePlural} ) {
 						Slim::Utils::Strings::storeExtraStrings(
-							[{
-							strings => { EN => $customTags->{$tag}->{name}},
-							token   => $tag,
-							},
-							{
-							strings => { EN => $customTags->{$tag}->{namePlural}},
-							token   => $tag . "_PLURAL",
-							}
-							]);
+							[
+								{ strings => { EN => $customTags->{$tag}->{name}}, token   => $tag },
+								{ strings => { EN => $customTags->{$tag}->{namePlural}}, token   => $tag . "_PLURAL" }
+							]
+						);
 						$changed = 1;
 					}
 				}

--- a/strings.txt
+++ b/strings.txt
@@ -26685,4 +26685,11 @@ SETUP_USERDEFINEDROLES_TEXT
 	HU	Szöveg megjelenítése
 	NL	Tekst weergeven
 
+SETUP_USERDEFINEDROLES_TEXT_PLURAL
+	EN	Display text (plural)
+	DE	Bezeichnung (Plural)
+	FR	Afficher le texte (pluriel)
+	ES	Mostrar texto (plural)
+	HU	Szöveg megjelenítése (többes számú)
+	NL	Tekst weergeven (meervoud)
 


### PR DESCRIPTION
One for Material: @CDrummond requested plural strings for user-defined roles.