### PR TITLE
Updated strings.txt for 18 slimserver standard plugins with Danish language elements

### DIFF
--- a/Slim/Plugin/ACLFiletest/strings.txt
+++ b/Slim/Plugin/ACLFiletest/strings.txt
@@ -1,5 +1,6 @@
 PLUGIN_ACL_FILETEST
 	CS	Povolení testů souborů ACL
+	DA	Aktivér ACL filtester
 	EN	Enable ACL filetests
 	FR	Activer les contrôles ACL
 	HU	ACL fájlteszteket engedélyezése
@@ -8,6 +9,7 @@ PLUGIN_ACL_FILETEST
 
 PLUGIN_ACL_FILETEST_DESC
 	CS	Tento zásuvný modul umožňuje kontrolovat oprávnění k souborům na základě ACL v některých systémech. Tento doplněk nepovolujte, pokud nevíte, že váš systém podporuje ACL a Perl "use filetest".
+	DA	Med dette pluginmodul kan du kontrollere filrettigheder baseret på ACL (Access-controlled list) på nogle systemer. Brug kun dette plugin hvis du ved, at dit system understøtter ACL'er og Perls 'use filetest'.
 	EN	This plugin allows you to check file permissions based on ACLs on some systems. Do not enable this plugin unless you know your system does support ACLs and Perl's 'use filetest'.
 	FR	Ce plugin permet sur certains systèmes d'exploitation de vérifier les autorisations de fichiers en fonction des ACL (Access Control List). N'activez ce plugin que si vous êtes sûr que votre système prend en charge les ACL et le "use filetest" de Perl.
 	HU	Ez a beépülő modul lehetővé teszi a fájlengedélyek ellenőrzését az ACL-ek alapján egyes rendszereken. Ne engedélyezze ezt a beépülő modult, hacsak nem tudja, hogy a rendszere támogatja az ACL-eket és a Perl fájltesztjét.

--- a/Slim/Plugin/Analytics/strings.txt
+++ b/Slim/Plugin/Analytics/strings.txt
@@ -1,5 +1,6 @@
 PLUGIN_ANALYTICS_MODULE_NAME
 	CS	Poskytování analytických údajů
+	DA	Afrapportér analysedata
 	DE	Analytikdaten teilen
 	EN	Report Analytics Data
 	FR	Partage de données d'analyse
@@ -8,6 +9,7 @@ PLUGIN_ANALYTICS_MODULE_NAME
 
 PLUGIN_ANALYTICS_MODULE_DESC
 	CS	Sdílejte s komunitou LMS verzi serveru, počet přehrávačů, počet skladeb, nainstalované zásuvné moduly, operační systém, verzi Perlu, použitý vzhled a hardwarovou platformu. To nám pomůže stanovit priority dalšího vývoje. Děkujeme, že jste tento doplněk povolili! Další informace naleznete na <a href="https://lyrion.org/analytics/learn-more/" target="_blank">https://lyrion.org/analytics/learn-more/</a>.
+	DA	Rapporterer din server version, antal afspillere, antal numre, installerede plugins, operativsystem, Perl version, anvendt Skin, samt anvendt hardware og del denne information med LMS fællesskabet. Dette hjælper os med at prioritere videre udvikling. Mange tak for at aktivere denne plugin. Du kan lære mere om dette under <a href="https://lyrion.org/analytics/learn-more/" target="_blank">https://lyrion.org/analytics/learn-more/</a>.
 	DE	Teile Analytikdaten wie Serverversion, Anzahl Geräte, Anzahl Titel, installierte Plugins, Betriebssystem, Perlversion, verwendeter Skin und die verwendete Hardware mit der LMS Community. Dies hilft uns, Prioritäten in der Entwicklung richtig zu setzen. Vielen Dank fürs Vertrauen! Mehr Infos unter <a href="https://lyrion.org/analytics/learn-more/" target="_blank">https://lyrion.org/analytics/learn-more/</a>.
 	EN	Share your server version, number of players, number of tracks, installed plugins, operating system, Perl version, skin used, and the hardware platform with the LMS Community. This will help us prioritize further development. Thanks for enabling this plugin! Learn more on <a href="https://lyrion.org/analytics/learn-more/" target="_blank">https://lyrion.org/analytics/learn-more/</a>.
 	FR	Partager des données telles que la version de votre serveur, le nombre de platines, le nombre de morceaux, les plugins installés, le système d'exploitation, la version de Perl, le skin utilisé et la plate-forme matérielle avec la communauté LMS, pour aider à prioriser les futurs développements. Merci pour votre confiance ! Plus d'informations sur <a href="https://lyrion.org/analytics/learn-more/" target="_blank">https://lyrion.org/analytics/learn-more/</a>.

--- a/Slim/Plugin/AudioAddict/strings.txt
+++ b/Slim/Plugin/AudioAddict/strings.txt
@@ -3,6 +3,7 @@ PLUGIN_AUDIO_ADDICT_NAME
 
 PLUGIN_AUDIO_ADDICT_DESC
 	CS	AudioAddict – poskytuje přístup ke ClassicalRadio, DI.fm, JazzRadio, RadioTunes, RockRadio, ZenRadio
+	DA	AudioAddict - giver adgang til ClassicalRadio, DI.fm, JazzRadio, RadioTunes, RockRadio, ZenRadio
 	EN	AudioAddict - providing access to ClassicalRadio, DI.fm, JazzRadio, RadioTunes, RockRadio, ZenRadio
 	FR	AudioAddict - donne accès à ClassicalRadio, DI.fm, JazzRadio, RadioTunes, RockRadio, ZenRadio
 	NL	AudioAddict - biedt toegang tot ClassicalRadio, DI.fm, JazzRadio, RadioTunes, RockRadio, ZenRadio

--- a/Slim/Plugin/AudioScrobbler/strings.txt
+++ b/Slim/Plugin/AudioScrobbler/strings.txt
@@ -144,6 +144,7 @@ SETUP_PLUGIN_AUDIOSCROBBLER_ENABLE_SCROBBLE_NO
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_TITLES
 	CS	Ignorované názvy
+	DA	Ignorér titler
 	DE	Titel ignorieren
 	EN	Ignore Titles
 	FR	Ignorer les titres
@@ -152,6 +153,7 @@ PLUGIN_AUDIOSCROBBLER_IGNORE_TITLES
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_TITLES_DESC
 	CS	Definujte seznam názvů nebo jmen oddělených čárkou. Skladby, které odpovídají jednomu z těchto řetězců, nebudou scroblovány.
+	DA	Definér en kommasepareret liste af titler der skal ignoreres. Numre som matcher en af disse strenge rapporteres (scrobbles) ikke til Last.fm.
 	DE	Geben Sie eine Komma-separierte Liste von Titeln ein. Abgespielte Lieder, die einen dieser Begriffe enthalten, werden nicht an Last.fm gemeldet (gescrobbelt).
 	EN	Define a comma separated list of titles or names. Tracks which match one of these strings will not be scrobbled.
 	FR	Définissez une liste de titres séparés par des virgules. Les morceaux qui correspondent à l'un de ces titres ne seront pas envoyés (scrobblés).
@@ -160,6 +162,7 @@ PLUGIN_AUDIOSCROBBLER_IGNORE_TITLES_DESC
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_ARTISTS
 	CS	Ignorovat interprety
+	DA	Ignorér kunstnere
 	DE	Interpreten ignorieren
 	EN	Ignore Artists
 	FR	Ignorer les artistes
@@ -168,6 +171,7 @@ PLUGIN_AUDIOSCROBBLER_IGNORE_ARTISTS
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_ARTISTS_DESC
 	CS	Definujte seznam jmen interpretů oddělený čárkou. Skladby, které odpovídají jednomu z těchto řetězců, nebudou scroblovány.
+	DA	Definér en kommasepareret liste af kunstnere der skal ignoreres. Numre som matcher en af disse strenge rapporteres (scrobbles) ikke til Last.fm.
 	DE	Geben Sie eine Komma-separierte Liste von Interpreten ein. Abgespielte Lieder, die einen dieser Begriffe enthalten, werden nicht an Last.fm gemeldet (gescrobbelt).
 	EN	Define a comma separated list list of artist names. Tracks which match one of these strings will not be scrobbled.
 	FR	Définissez une liste de noms d'artistes séparés par des virgules. Les morceaux dont l'artiste correspond à l'un de ces noms ne seront pas envoyés (scrobblés).
@@ -176,6 +180,7 @@ PLUGIN_AUDIOSCROBBLER_IGNORE_ARTISTS_DESC
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_ALBUMS
 	CS	Ignorovat názvy alb
+	DA	Ignorér albumtitler
 	DE	Albentitel ignorieren
 	EN	Ignore Album Titles
 	FR	Ignorer les titres des albums
@@ -184,6 +189,7 @@ PLUGIN_AUDIOSCROBBLER_IGNORE_ALBUMS
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_ALBUMS_DESC
 	CS	Definujte seznam názvů alb oddělených čárkou. Skladby, které odpovídají jednomu z těchto řetězců, nebudou scroblovány.
+	DA	Definér en kommasepareret liste af albumtitler der skal ignoreres. Numre som matcher en af disse strenge rapporteres (scrobbles) ikke til Last.fm.
 	DE	Geben Sie eine Komma-separierte Liste von Albumtiteln ein. Abgespielte Lieder, die einen dieser Begriffe enthalten, werden nicht an Last.fm gemeldet (gescrobbelt).
 	EN	Define a comma separated list of album names. Tracks which match one of these strings will not be scrobbled.
 	FR	Définissez une liste de noms d'albums séparés par des virgules. Les morceaux dont l'album correspond à l'un de ces noms ne seront pas envoyés (scrobblés).
@@ -192,6 +198,7 @@ PLUGIN_AUDIOSCROBBLER_IGNORE_ALBUMS_DESC
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_GENRES
 	CS	Ignorovat žánry
+	DA	Ignorér genrer
 	DE	Stilrichtungen ignorieren
 	EN	Ignore Genres
 	FR	Ignorer les genres
@@ -200,6 +207,7 @@ PLUGIN_AUDIOSCROBBLER_IGNORE_GENRES
 
 PLUGIN_AUDIOSCROBBLER_IGNORE_GENRES_DESC
 	CS	Definujte seznam žánrů oddělený čárkou. Skladby, které odpovídají jednomu z těchto řetězců, nebudou scroblovány.
+	DA	Definér en kommasepareret liste af genrer der skal ignoreres. Numre som matcher en af disse strenge rapporteres (scrobbles) ikke til Last.fm.
 	DE	Geben Sie eine Komma-separierte Liste von Stilrichtungen ein. Abgespielte Lieder, die einen dieser Begriffe enthalten, werden nicht an Last.fm gemeldet (gescrobbelt).
 	EN	Define a comma separated list list of genres. Tracks which match one of these strings will not be scrobbled.
 	FR	Définissez une liste de genres séparés par des virgules. Les morceaux dont le genre correspond à l'un de ces genres ne seront pas envoyés (scrobblés).
@@ -526,4 +534,3 @@ PLUGIN_AUDIOSCROBBLER_TRACK_LOVED
 	PL	Ten utwór otrzymał ocenę pozytywną.
 	RU	Эта дорожка понравилась.
 	SV	Spåret har registrerats som älskat.
-

--- a/Slim/Plugin/ClassicalRadio/strings.txt
+++ b/Slim/Plugin/ClassicalRadio/strings.txt
@@ -11,7 +11,7 @@ PLUGIN_CLASSICALRADIO_DESC
 
 PLUGIN_CLASSICALRADIO_MISSING_CREDS
 	CS	Prosím, navštivte ClassicalRadio.com v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
-	DA	Besøg ClassicalRadio.com i Lyrion Music Server Indstillinger for at tilføje dine loginoplysninger.
+	DA	Besøg ClassicalRadio.com i Lyrion Music Server indstillinger for at tilføje dine loginoplysninger.
 	EN	Please visit ClassicalRadio.com in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans ClassicalRadio.com dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar ClassicalRadio.com in de Lyrion Music Server Instellingen om je gegevens toe te voegen.

--- a/Slim/Plugin/ClassicalRadio/strings.txt
+++ b/Slim/Plugin/ClassicalRadio/strings.txt
@@ -3,6 +3,7 @@ PLUGIN_CLASSICALRADIO_NAME
 
 PLUGIN_CLASSICALRADIO_DESC
 	CS	ClassicalRadio.com – Krásně vybraná klasická hudba
+	DA	ClassicalRadio.com - Smukt arrangeret klassisk musik
 	EN	ClassicalRadio.com - Beautifully Curated Classical Music
 	FR	ClassicalRadio.com - Musique classique magnifiquement organisée
 	NL	ClassicalRadio.com - Prachtig samengestelde klassieke muziek
@@ -10,6 +11,7 @@ PLUGIN_CLASSICALRADIO_DESC
 
 PLUGIN_CLASSICALRADIO_MISSING_CREDS
 	CS	Prosím, navštivte ClassicalRadio.com v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
+	DA	Besøg ClassicalRadio.com i Lyrion Music Server Indstillinger for at tilføje dine loginoplysninger.
 	EN	Please visit ClassicalRadio.com in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans ClassicalRadio.com dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar ClassicalRadio.com in de Lyrion Music Server Instellingen om je gegevens toe te voegen.
@@ -17,6 +19,7 @@ PLUGIN_CLASSICALRADIO_MISSING_CREDS
 
 PLUGIN_CLASSICALRADIO_LINK
 	CS	Chcete-li si vytvořit nebo spravovat svůj účet, navštivte <a href="https://www.classicalradio.com" target="_blank">ClassicalRadio.com</a>.
+	DA	Besøg <a href="https://www.classicalradio.com" target="_blank">ClassicalRadio.com</a> for at oprette eller administrere din konto.
 	EN	To create or manage your account please visit <a href="https://www.classicalradio.com" target="_blank">ClassicalRadio.com</a>.
 	FR	Pour créer ou gérer votre compte, veuillez accéder à <a href="https://www.classicalradio.com" target="_blank">ClassicalRadio.com</a>.
 	NL	Ga om een account aan te maken of te beheren naar <a href="https://www.classicalradio.com" target="_blank">ClassicalRadio.com</a>.

--- a/Slim/Plugin/DIfm/strings.txt
+++ b/Slim/Plugin/DIfm/strings.txt
@@ -3,6 +3,7 @@ PLUGIN_DI_FM_NAME
 
 PLUGIN_DI_FM_DESC
 	CS	DI.FM – Návyková elektronická hudba
+	DA	DI.FM - Vanedannende elektronisk musik
 	EN	DI.FM - Addictive Electronic Music
 	FR	DI.FM - Musique électronique addictive
 	NL	DI.FM - Verslavende elektronische muziek
@@ -10,6 +11,7 @@ PLUGIN_DI_FM_DESC
 
 PLUGIN_DI_FM_MISSING_CREDS
 	CS	Prosím, navštivte DI.FM v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
+	DA	Besøg DI.FM i Lyrion Music Server indstillinger for at tilføje dine loginoplysninger.
 	EN	Please visit DI.FM in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans DI.FM dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar DI.FM in de instellingen van de Lyrion Music Server om uw referenties toe te voegen.
@@ -17,6 +19,7 @@ PLUGIN_DI_FM_MISSING_CREDS
 
 PLUGIN_DI_FM_LINK
 	CS	Chcete-li si vytvořit nebo spravovat svůj účet, navštivte <a href="https://www.di.fm" target="_blank">DI.FM</a>.
+	DA	Besøg <a href="https://www.di.fm" target="_blank">DI.FM</a> for at oprette eller administrere din konto.
 	EN	To create or manage your account please visit <a href="https://www.di.fm" target="_blank">DI.FM</a>.
 	FR	Pour créer ou gérer votre compte, veuillez accéder à <a href="https://www.di.fm" target="_blank">DI.FM</a>.
 	NL	Ga om een account aan te maken of te beheren naar <a href="https://www.di.fm" target="_blank">DI.FM</a>.

--- a/Slim/Plugin/DnDPlay/strings.txt
+++ b/Slim/Plugin/DnDPlay/strings.txt
@@ -1,5 +1,6 @@
 PLUGIN_DNDPLAY
 	CS	Přehrávání hudebních souborů přetažením
+	DA	Drag & Drop afspilning af musikfiler
 	DE	Drag & Drop Musikdateien zur Wiedergabe
 	EN	Drag & drop music files to play
 	FR	Glisser-déposer des fichiers audio à lire
@@ -10,6 +11,7 @@ PLUGIN_DNDPLAY
 
 PLUGIN_DNDPLAY_SHORT
 	CS	Přetahování hudebních souborů
+	DA	Drag & Drop musikfiler
 	DE	Musikdatei Drag & Drop
 	EN	Drag & Drop Music Files
 	FR	Glisser-déposer des fichiers audio
@@ -20,6 +22,7 @@ PLUGIN_DNDPLAY_SHORT
 
 PLUGIN_DNDPLAY_DESC
 	CS	Tento zásuvný modul umožňuje přetahovat zvukové soubory ze správce souborů na ploše (Finder, Průzkumník atd.) do webového rozhraní Lyrion Music Serveru a přehrávat je. Soubory, které nejsou k dispozici na Lyrion Music Serveru, jsou pro přehrávání dočasně přeneseny.
+	DA	Dette plugin giver dig mulighed for at trække og slippe lydfiler fra dit skrivebords filhåndtering (Finder, Explorer osv.) til Lyrion Music Server webgrænsefladen for at afspille dem. Filer, der ikke er tilgængelige fra Lyrion Music Server, overføres midlertidigt til afspilning.
 	DE	Dieses Plugin erlaubt es, Musikdateien aus dem Dateimanager des Betriebssystems (Finder, Explorer etc.) ins Lyrion Music Server Web-Interface zu ziehen, um diese wiederzugeben. Dateien, die nicht im Lyrion Music Server verfügbar sind, werden zur Wiedergabe temporär zum Server übertragen.
 	EN	This plugin allows you do drag and drop audio files from your desktop's file manager (Finder, Explorer etc.) to the Lyrion Music Server web interface to play them back. Files which are not available from the Lyrion Music Server are temporarily transfered for the playback.
 	FR	Ce plugin permet de glisser-déposer des fichiers audio depuis le gestionnaire de fichiers de votre ordinateur vers l'interface Web de Lyrion Music Server pour les lire. Les fichiers qui ne sont pas disponibles directement via Lyrion Music Server sont temporairement transférés pour la lecture.
@@ -30,6 +33,7 @@ PLUGIN_DNDPLAY_DESC
 
 PLUGIN_DNDPLAY_NO_ITEMS
 	CS	Nebyly nalezeny žádné přehratelné položky. Přehrát lze pouze zvukové soubory.
+	DA	Fandt ingen afspilbare filer. Kun lydfiler kan afspilles.
 	DE	Keine der Dateien kann wiedergegeben werden. Nur Audio-Dateien werden akzeptiert.
 	EN	No playable items found. Only audio files can be played.
 	FR	Aucun élément lisible trouvé. Seuls les fichiers audio peuvent être lus.
@@ -40,6 +44,7 @@ PLUGIN_DNDPLAY_NO_ITEMS
 
 PLUGIN_DNDPLAY_NO_PLAYER_CONNECTED
 	CS	Bez připojeného přehrávače nelze přehrávat hudbu.
+	DA	Uden en tilsluttet afspiller, kan musik ikke afspilles.
 	DE	Sie können ohne Player nichts wiedergeben.
 	EN	Cannot play music without a player connected.
 	FR	Impossible de lire de la musique sans platine connectée.
@@ -50,6 +55,7 @@ PLUGIN_DNDPLAY_NO_PLAYER_CONNECTED
 
 PLUGIN_DNDPLAY_FILE_TOO_LARGE
 	CS	Velikost souboru (%s) přesahuje maximální velikost pro odesílání (%s).
+	DA	Filstørrelsen (%s) overstiger den maksimale tilladte størrelse (%s).
 	DE	Die Dateigrösse (%s) überschreitet die maximal erlaubte Upload-Grösse (%s).
 	EN	File size (%s) exceeds maximum upload size (%s).
 	FR	La taille du fichier (%s) dépasse la taille de téléchargement maximale (%s).
@@ -60,6 +66,7 @@ PLUGIN_DNDPLAY_FILE_TOO_LARGE
 
 PLUGIN_DNDPLAY_INVALID_DATA
 	CS	Neplatný požadavek.
+	DA	Ugyldig forespørgsel.
 	DE	Ungültige Anfrage.
 	EN	Invalid request.
 	FR	Requête invalide.
@@ -70,6 +77,7 @@ PLUGIN_DNDPLAY_INVALID_DATA
 
 PLUGIN_DNDPLAY_MAX_FILESIZE
 	CS	Maximální velikost nahrávání (v MB)
+	DA	Maksimal tilladt overførselsstørrelse (i MB)
 	DE	Maximale Upload-Grösse (in MB)
 	EN	Maximum Upload Size (in MB)
 	FR	Taille de téléchargement maximale (en Mo)
@@ -80,6 +88,7 @@ PLUGIN_DNDPLAY_MAX_FILESIZE
 
 PLUGIN_DNDPLAY_MAX_FILESIZE_DESC
 	CS	Nahrávání souborů na server bude vyžadovat značné množství paměti na serveru. Maximální velikost souboru je proto ve výchozím nastavení omezena na 100 MB. Pokud cítíte potřebu mít možnost přehrávat větší soubory a váš server nabízí dodatečné zdroje, můžete zde upravit maximální přípustnou velikost souboru.
+	DA	Overførsel af filer til deling kræver meget hukommelse på serveren. Derfor er den maksimale overførselstørrelse som standard begrænset til 100 MB. Hvis du vil afspille større filer, og din server har ressourcer nok, kan du øge denne grænse her.
 	DE	Der Transfer von Dateien für die Freigabe verlangt auf dem Server viel Speicher. Daher ist die maximale Upload-Grösse standardmässig auf 100MB beschränkt. Sollten Sie grössere Dateien abspielen wollen, und verfügt ihr Server über die entsprechenden Ressourcen, dann können Sie diese Beschränkung hier erhöhen.
 	EN	Uploading files to the server will require considerable amounts of memory on the server. The maximum file size therefore is limited to 100MB by default. If you feel a need to be able to play larger files, and your server offers the additional resources, you can adjust the maximum accepted file size here.
 	FR	L'envoi de fichiers nécessite une quantité considérable de mémoire sur le serveur. La taille maximale du fichier est donc limitée à 100 Mo par défaut. Si vous ressentez le besoin de pouvoir lire des fichiers plus volumineux et que votre serveur offre des ressources supplémentaires, vous pouvez ajuster la taille de fichier maximale acceptée ici.

--- a/Slim/Plugin/DontStopTheMusic/strings.txt
+++ b/Slim/Plugin/DontStopTheMusic/strings.txt
@@ -1,5 +1,6 @@
 PLUGIN_DSTM
 	CS	Nezastavuj přehrávání hudby
+	DA	Aldrig stop musikken
 	DE	Musikwiedergabe nie anhalten
 	EN	Don't Stop The Music
 	FR	N'arrêtez pas la musique
@@ -9,6 +10,7 @@ PLUGIN_DSTM
 
 PLUGIN_DSTM_DESC
 	CS	Nezastavuj přehrávání hudby se postará o to, aby vám ticho nezničilo plynulost. Jakmile se dostanete na konec seznamu skladeb, automaticky přidá podobnou hudbu, jakou jste poslouchali doposud.
+	DA	Don't Stop The Music sikrer at stilhed ikke dræber dit flow. Ved afslutningen af ​​din afspilleliste, tilføjer modulet automatisk musik, der ligner det du har lyttet til.
 	DE	Don't Stop The Music bewahrt Sie davor, von der Stille überrascht zu werden. Wenn sich die Wiedergabeliste dem Ende neigt, wird automatisch passende Musik angehängt. Über das Menü Extras auf der Hauptseite können Sie für jeden Player separat die Auswahl der hinzuzufügenden Titel bestimmen oder abschalten.
 	EN	Don't Stop The Music will make sure you don't let the silence kill your flow. Once you reach the end of your playlist it will automatically add music similar to what you've been listening to.
 	FR	Ce plugin s'assurera de ne laisser aucune place au silence ! Une fois la fin de votre liste de lecture atteinte, de la musique similaire à celle que vous venez d'écouter est automatiquement ajoutée.
@@ -19,6 +21,7 @@ PLUGIN_DSTM_DESC
 
 PLUGIN_DSTM_HELP
 	CS	Vyberte, co chcete přehrát po skončení seznamu skladeb. Výběr se může lišit v závislosti na nainstalovaných a nakonfigurovaných Zásuvných modulech.
+	DA	Vælg, hvad du vil afspille, når en afspilleliste er slut. Valget kan variere afhængigt af de plugin moduler, du har installeret og konfigureret.
 	DE	Wählen Sie, was abgespielt werden soll, wenn eine Wiedergabe zu Ende geht. Die Auswahl variiert in Abhängigkeit der installierten Plugins.
 	EN	Select what you'd like to play once a playlist has come to an end. The choice can vary, depending on the plugins you've installed and configured.
 	FR	Sélectionnez ce que vous souhaitez jouer une fois la liste de lecture terminée. Le choix peut varier en fonction des plugins que vous avez installés et configurés.

--- a/Slim/Plugin/Favorites/strings.txt
+++ b/Slim/Plugin/Favorites/strings.txt
@@ -197,6 +197,7 @@ PLUGIN_FAVORITES_DESC
 
 PLUGIN_FAVORITES_USE_DSTM
 	CS	Nezastavuj přehrávání hudby
+	DA	Aldrig stop musikken
 	DE	Musikwiedergabe nie anhalten
 	EN	Don't Stop The Music
 	FR	N'arrêtez pas la musique
@@ -206,6 +207,7 @@ PLUGIN_FAVORITES_USE_DSTM
 
 PLUGIN_FAVORITES_USE_DSTM_DESC
 	CS	Zaregistrujte si oblíbené položky jako možnosti pro "Nezastavuj přehrávání hudby".
+	DA	Benyt favoritter som valg for "Don't Stop The Music".
 	DE	Favoriten als Option für "Musikwiedergabe nie anhalten" verwenden.
 	EN	Register favorites as options for "Don't Stop The Music".
 	EN_GB	Register favourites as options for "Don't Stop The Music".
@@ -281,7 +283,7 @@ PLUGIN_FAVORITES_ADD
 
 PLUGIN_FAVORITES_IMPORT
 	CS	Importovat
-	DA	Importer
+	DA	Importér
 	DE	Importieren
 	EN	Import
 	ES	Importar
@@ -297,7 +299,7 @@ PLUGIN_FAVORITES_IMPORT
 
 PLUGIN_FAVORITES_LOADFILE
 	CS	Adresa URL nebo název souboru
-	DA	Adresse eller filnavn
+	DA	URL adresse eller filnavn
 	DE	URL oder Dateiname
 	EN	URL or File Name
 	ES	URL o nombre de archivo
@@ -329,7 +331,7 @@ PLUGIN_FAVORITES_SAVEFILE
 
 PLUGIN_FAVORITES_IMPORTFILE
 	CS	Adresa URL nebo název souboru
-	DA	Adresse eller filnavn
+	DA	URL adresse eller filnavn
 	DE	URL oder Dateiname
 	EN	URL or File Name
 	ES	URL o nombre de archivo
@@ -361,7 +363,7 @@ PLUGIN_FAVORITES_NOFILE
 
 PLUGIN_FAVORITES_CANCEL
 	CS	Storno
-	DA	Annuller
+	DA	Annullér
 	DE	Abbrechen
 	EN	Cancel
 	ES	Cancelar
@@ -458,7 +460,7 @@ PLUGIN_FAVORITES_NEWFOLDER
 
 PLUGIN_FAVORITES_NEWENTRY
 	CS	Nová položka
-	DA	Ny
+	DA	Ny post
 	DE	Neuer Eintrag
 	EN	New Entry
 	ES	Entrada nueva
@@ -491,7 +493,7 @@ PLUGIN_FAVORITES_NEWFAVORITE
 
 PLUGIN_FAVORITES_NEWURL
 	CS	Nová adresa URL
-	DA	Ny adresse
+	DA	Ny URL adresse
 	DE	Neue URL
 	EN	New URL
 	ES	URL nueva
@@ -523,7 +525,7 @@ PLUGIN_FAVORITES_LOADERROR
 
 PLUGIN_FAVORITES_REMOTELOADERROR
 	CS	Chyba při načítání URL
-	DA	Fejl ved indlæsning af adresse
+	DA	Fejl ved indlæsning af URL adresse
 	DE	Fehler beim Lesen der URL
 	EN	Error Loading URL
 	ES	Error al cargar URL
@@ -571,7 +573,7 @@ PLUGIN_FAVORITES_IMPORTERROR
 
 PLUGIN_FAVORITES_NOTITLE
 	CS	Bez názvu
-	DA	Igen titel
+	DA	Ingen titel
 	DE	Kein Titel
 	EN	No Title
 	ES	Sin título
@@ -653,6 +655,7 @@ PLUGIN_FAVORITES_REMOVE
 
 PLUGIN_FAVORITES_DONT_BROWSEDB
 	CS	Chování místních hudebních položek
+	DA	Opførsel med lokal musikbibliotek
 	DE	Verhalten mit lokaler Musik
 	EN	Local music items behavior
 	HU	Helyi zenei tételek viselkedése
@@ -664,6 +667,7 @@ PLUGIN_FAVORITES_DONT_BROWSEDB
 
 PLUGIN_FAVORITES_DONT_BROWSEDB_ON
 	CS	Při výběru neprohlížet položky, ale pouze je přehrát (staré chování)
+	DA	Ikke bladre i numre når de er valgt, bare afspil dem (gammel adfærd)
 	DE	Beim Anwählen eines Eintrages Favoriten abspielen, nicht durchsuchen (altes Verhalten)
 	EN	Don't browse items when selected, just play them (old behavior)
 	EN_GB	Don't browse items when selected, just play them (old behaviour)
@@ -675,6 +679,7 @@ PLUGIN_FAVORITES_DONT_BROWSEDB_ON
 
 PLUGIN_FAVORITES_DONT_BROWSEDB_OFF
 	CS	Když vyberete oblíbeného přispěvatele, žánr nebo album, přejít k jeho obsahu.
+	DA	Når du vælger en favoritkunstner, -genre eller -album, vis detaljeret indhold.
 	DE	Beim Anwählen eines favorisierten Künstlers, Genres oder Album, dessen Details anzeigen
 	EN	When you select a favorite contributor, genre or album, drill down to its content
 	EN_GB	When you select a favourite contributor, genre or album, drill down to its content

--- a/Slim/Plugin/JazzRadio/strings.txt
+++ b/Slim/Plugin/JazzRadio/strings.txt
@@ -3,6 +3,7 @@ PLUGIN_JAZZRADIO_NAME
 
 PLUGIN_JAZZRADIO_DESC
 	CS	JAZZRADIO.com – Užijte si skvělý jazz
+	DA	JAZZRADIO.com - Nyd dejlig jazzmusik
 	EN	JAZZRADIO.com - Enjoy Great Jazz Music
 	FR	JAZZRADIO.com - Profitez du bon jazz
 	NL	JAZZRADIO.com - Geniet van geweldige jazzmuziek
@@ -10,6 +11,7 @@ PLUGIN_JAZZRADIO_DESC
 
 PLUGIN_JAZZRADIO_MISSING_CREDS
 	CS	Prosím, navštivte JAZZRADIO.com v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
+	DA	Besøg JAZZRADIO.com i Lyrion Music Server indstillingerne for at tilføje dine loginoplysninger.
 	EN	Please visit JAZZRADIO.com in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans JAZZRADIO.com dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar JAZZRADIO.com in de Lyrion Music Server Instellingen om je gegevens toe te voegen.
@@ -17,6 +19,7 @@ PLUGIN_JAZZRADIO_MISSING_CREDS
 
 PLUGIN_JAZZRADIO_LINK
 	CS	Chcete-li si vytvořit nebo spravovat svůj účet, navštivte <a href="https://www.jazzradio.com" target="_blank">JAZZRADIO.com</a>.
+	DA	Besøg <a href="https://www.jazzradio.com" target="_blank">JAZZRADIO.com</a> for at oprette eller administrere din konto.
 	EN	To create or manage your account please visit <a href="https://www.jazzradio.com" target="_blank">JAZZRADIO.com</a>.
 	FR	Pour créer ou gérer votre compte, veuillez accéder à <a href="https://www.jazzradio.com" target="_blank">JAZZRADIO.com</a>.
 	NL	Ga om een account aan te maken of te beheren naar <a href="https://www.jazzradio.com" target="_blank">JAZZRADIO.com</a>.

--- a/Slim/Plugin/JazzRadio/strings.txt
+++ b/Slim/Plugin/JazzRadio/strings.txt
@@ -11,7 +11,7 @@ PLUGIN_JAZZRADIO_DESC
 
 PLUGIN_JAZZRADIO_MISSING_CREDS
 	CS	Prosím, navštivte JAZZRADIO.com v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
-	DA	Besøg JAZZRADIO.com i Lyrion Music Server indstillingerne for at tilføje dine loginoplysninger.
+	DA	Besøg JAZZRADIO.com i Lyrion Music Server indstillinger for at tilføje dine loginoplysninger.
 	EN	Please visit JAZZRADIO.com in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans JAZZRADIO.com dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar JAZZRADIO.com in de Lyrion Music Server Instellingen om je gegevens toe te voegen.

--- a/Slim/Plugin/LibraryDemo/strings.txt
+++ b/Slim/Plugin/LibraryDemo/strings.txt
@@ -1,5 +1,6 @@
 PLUGIN_LIBRARY_DEMO
 	CS	Ukázka dílčí knihovny
+	DA	Underbibliotek demo
 	EN	Sub-Library demo
 	FR	Démo de sous-bibliothèque
 	HU	Alkönyvtár demo
@@ -16,6 +17,7 @@ PLUGIN_LIBRARY_DEMO_DESC
 
 PLUGIN_LIBRARY_DEMO_ARTISTS
 	CS	Interpreti milující dlouhé skladby
+	DA	Kunstnere med lange numre
 	EN	Artists loving long tracks
 	FR	Artistes aimant les longs morceaux
 	HU	Előadók, akik szeretik a hosszú számokat
@@ -24,6 +26,7 @@ PLUGIN_LIBRARY_DEMO_ARTISTS
 
 PLUGIN_LIBRARY_DEMO_ALBUMS
 	CS	Alba s přídavky a dalšími dlouhými skladbami
+	DA	Albums med finaler og andre lange numre
 	EN	Albums with outros and other longish tracks
 	FR	Albums avec outros et autres morceaux longs
 	HU	Albumok outrókkal és más hosszú dalokkal

--- a/Slim/Plugin/MyApps/strings.txt
+++ b/Slim/Plugin/MyApps/strings.txt
@@ -16,6 +16,7 @@ PLUGIN_MY_APPS_MODULE_NAME
 
 PLUGIN_MY_APPS_NO_APPS
 	CS	Žádná nainstalovaná aplikace
+	DA	Ingen programmer installeret
 	DE	Keine Anwendung installiert
 	EN	No App installed
 	FR	Aucune application n'est installée

--- a/Slim/Plugin/Podcast/strings.txt
+++ b/Slim/Plugin/Podcast/strings.txt
@@ -51,7 +51,7 @@ PLUGIN_PODCAST_DESC
 
 PODCAST_NOTHING_TO_PLAY
 	CS	Nic k přehrání
-	DA	Der er ikke noget at spille
+	DA	Der er ikke noget at afspille
 	DE	Kein Material vorhanden
 	EN	Nothing to play
 	ES	Nada para reproducir
@@ -102,7 +102,7 @@ PODCAST_RESET_BUTTON
 
 PODCAST_RESETTING
 	CS	Obnovuji výchozí podcasty
-	DA	Standardpodcasts bliver valgt igen
+	DA	Nulstilling til standardpodcasts
 	DE	Standard-Podcasts werden wiederhergestellt
 	EN	Resetting to default podcasts
 	ES	Restableciendo podcasts predeterminados
@@ -136,7 +136,7 @@ PODCAST_FEEDS_CHANGE
 
 SETUP_PLUGIN_PODCAST_RESET
 	CS	Obnovit výchozí podcasty
-	DA	Gendan standardpodcasts
+	DA	Nulstil standardpodcasts
 	DE	Standard-Podcasts zurücksetzen
 	EN	Reset default Podcasts
 	ES	Restablecer podcasts predeterminados
@@ -201,6 +201,7 @@ SETUP_PLUGIN_PODCAST_INVALID_FEED
 
 PLUGIN_PODCAST_PLAY_FROM_BEGINNING
 	CS	Přehrát od začátku
+	DA	Afspil fra begyndelsen
 	DE	Vom Anfang an wiedergeben
 	EN	Play from the beginning
 	FR	Lire depuis le début
@@ -211,6 +212,7 @@ PLUGIN_PODCAST_PLAY_FROM_BEGINNING
 
 PLUGIN_PODCAST_PLAY_FROM_POSITION_X
 	CS	Přehrát z poslední pozice (%s)
+	DA	Afspil videre fra seneste position (%s)
 	DE	Von der letzten Position wiedergeben (%s)
 	EN	Play from last position (%s)
 	FR	Lire depuis la dernière position (%s)
@@ -221,6 +223,7 @@ PLUGIN_PODCAST_PLAY_FROM_POSITION_X
 
 PLUGIN_PODCAST_SKIP_BACK_SECS
 	CS	Skok o několik sekund zpět
+	DA	Spring X sekunder tilbage
 	DE	Zurückspringen um X Sekunden
 	EN	Jump back seconds
 	FR	Revenir en arrière de X secondes
@@ -231,6 +234,7 @@ PLUGIN_PODCAST_SKIP_BACK_SECS
 
 PLUGIN_PODCAST_SKIP_BACK_DESC
 	CS	Kontextová nabídka podcastů nabízí možnost rychlého skoku zpět v rámci podcastu. Ve výchozím nastavení tato možnost přeskočí o 15 sekund zpět.
+	DA	Podcasts kontekstmenuen giver mulighed for at springe hurtigt tilbage i podcasten. Som standard springer denne indstilling 15 sekunder baglæns. Angiv her hvor langt dette spring skal være.
 	DE	Das Kontextmenü bietet in Podcasts die Möglichkeit, schnell zurückzuspringen. Standardmässig sind dies 15 Sekunden. Geben Sie hier an, wie weit Sie zurückspringen wollen.
 	EN	The podcasts context menu offers an option to jump back quickly within the podcast. By default this option skips back by 15 seconds.
 	FR	Le menu contextuel des podcasts offre une option pour revenir rapidement en arrière dans le podcast. Par défaut, cette option recule de 15 secondes.
@@ -241,6 +245,7 @@ PLUGIN_PODCAST_SKIP_BACK_DESC
 
 PLUGIN_PODCAST_SKIP_BACK
 	CS	Skok o %s sekund zpět
+	DA	Spring tilbage %s sekunder
 	DE	%s Sekunden zurück springen
 	EN	Jump back %s seconds
 	FR	Revenir en arrière de %s secondes
@@ -251,6 +256,7 @@ PLUGIN_PODCAST_SKIP_BACK
 
 PLUGIN_PODCAST_RECENTLY_PLAYED
 	CS	Nedávno přehrávané
+	DA	Nyligt afspillede
 	DE	Zuletzt wiedergegeben
 	EN	Recently played
 	FR	Pistes récentes
@@ -259,6 +265,7 @@ PLUGIN_PODCAST_RECENTLY_PLAYED
 
 PLUGIN_PODCAST_SEARCH
 	CS	Prohledat kanály
+	DA	Søg feeds
 	DE	Shows suchen
 	EN	Search feeds
 	FR	Rechercher des flux
@@ -267,6 +274,7 @@ PLUGIN_PODCAST_SEARCH
 
 PLUGIN_PODCAST_PROVIDER
 	CS	Poskytovatel podcastů
+	DA	Podcast udbydere
 	DE	Podcastverzeichnis
 	EN	Podcast provider
 	FR	Fournisseur de Podcast
@@ -275,6 +283,7 @@ PLUGIN_PODCAST_PROVIDER
 
 PLUGIN_PODCAST_PROVIDER_DESC
 	CS	Nastavit poskytovatele podcastových kanálů (agregátor).
+	DA	Vælg udbyder af ​​Podcast-feeds (aggregator).
 	DE	Wählen Sie das Podcastverzeichnis (Aggregator).
 	EN	Set the Podcast feeds provider (aggregator).
 	FR	Configurez le fournisseur (concentrateur) de Podcasts
@@ -283,6 +292,7 @@ PLUGIN_PODCAST_PROVIDER_DESC
 
 PLUGIN_PODCAST_SEARCH_FAILED
 	CS	Vyhledávání se nepodařilo
+	DA	Søgning fejlede
 	DE	Suche fehlgeschlagen
 	EN	Search failed
 	FR	Echec de recherche
@@ -290,6 +300,7 @@ PLUGIN_PODCAST_SEARCH_FAILED
 
 PLUGIN_PODCAST_WHATSNEW
 	CS	Nové epizody za posledních %s dní
+	DA	Nye afsnit fra de sidste %s dage
 	DE	Neue Episoden der letzten %s Tage
 	EN	New episodes of the last %s days
 	FR	Nouveaux épisodes des %s derniers jours
@@ -298,8 +309,8 @@ PLUGIN_PODCAST_WHATSNEW
 
 PLUGIN_PODCAST_AUTHOR
 	CS	Autor:
+	DA	Forfatter:
 	DE	Autor:
-	DE	Herausgeber:
 	EN	Author:
 	FR	Auteur :
 	HU	Szerző:
@@ -307,6 +318,7 @@ PLUGIN_PODCAST_AUTHOR
 
 PLUGIN_PODCAST_WHATSNEW_DESC
 	CS	Nastavte, kolik dní zpětně se mají hledat nové epizody, a maximální počet epizod na tok. Všimněte si, že ručně přidané kanály nemusí být poskytovatelem sledovány
+	DA	Definerer den maksimale alder for nye afsnit (i dage) og det maksimale antal pr. podcast. Bemærk, at manuelt tilføjede feeds muligvis ikke spores af udbyderen
 	DE	Definieren Sie, wieviele Tage und Anzahl Episoden pro Show zurück verfolgt werden soll. Beachten Sie, dass manuell erfasste Podcasts diese Einstellungen u.U. nicht berücksichtigen können.
 	EN	Set how many days to look back for new episodes and maximum number of episodes per flow. Note that manually added feeds might not be tracked by provider
 	FR	Définit l'ancienneté maximale des nouveaux épisodes (en jours) et le nombre maximum par flux. Notez que les flux ajoutés manuellement peuvent ne pas être suivis par le fournisseur.
@@ -315,6 +327,7 @@ PLUGIN_PODCAST_WHATSNEW_DESC
 
 PLUGIN_PODCAST_NEWSINCE
 	CS	Počet dnů historie
+	DA	Antal dages historik
 	DE	Anzahl Tage im Verlauf
 	EN	Number of history days
 	FR	Nombre de jours d'historique
@@ -323,6 +336,7 @@ PLUGIN_PODCAST_NEWSINCE
 
 PLUGIN_PODCAST_MAXNEW
 	CS	Počet nových epizod na kanál
+	DA	Antal nye afsnit per feed
 	DE	Anzahl neuer Episoden pro Show
 	EN	Number of new episodes per feed
 	FR	Nombre de nouveaux épisodes par flux
@@ -331,6 +345,7 @@ PLUGIN_PODCAST_MAXNEW
 
 PLUGIN_PODCAST_COUNTRY_DESC
 	CS	Omezit vyhledávání na zemi (volitelné)
+	DA	Begræns søgning til et land (valgfrit)
 	DE	Suche auf ein Land beschränken (optional)
 	EN	Limit search to a country (optional)
 	FR	Limite la recherche à un pays (optionnel)
@@ -339,6 +354,7 @@ PLUGIN_PODCAST_COUNTRY_DESC
 
 PLUGIN_PODCAST_COUNTRY
 	CS	Země
+	DA	Land
 	DE	Land
 	EN	Country
 	HU	Ország
@@ -347,6 +363,7 @@ PLUGIN_PODCAST_COUNTRY
 
 PLUGIN_PODCAST_SUBSCRIBE
 	CS	Přihlásit se k odběru "%s"
+	DA	Abonnér på '%s'
 	DE	Podcast '%s' abonnieren
 	EN	Subscribe to '%s'
 	FR	S'abonner à '%s'
@@ -355,6 +372,7 @@ PLUGIN_PODCAST_SUBSCRIBE
 
 PLUGIN_PODCAST_UNSUBSCRIBE
 	CS	Odhlásit se z odběru "%s"
+	DA	Afmeld '%s'
 	DE	Von Podcast '%s' abmelden
 	EN	Unsubscribe from '%s'
 	FR	Se désabonner de '%s'
@@ -363,6 +381,7 @@ PLUGIN_PODCAST_UNSUBSCRIBE
 
 PLUGIN_PODCAST_DONE
 	CS	Přihlášeno/odhlášeno z kanálu...
+	DA	Abonnementstatus justeret...
 	DE	Abonnement angepasst...
 	EN	Subscribed/Unsubscribed from show...
 	FR	Abonné/Désabonné ...

--- a/Slim/Plugin/PresetsEditor/strings.txt
+++ b/Slim/Plugin/PresetsEditor/strings.txt
@@ -1,5 +1,6 @@
 PLUGIN_PRESETS_EDITOR
 	CS	Editor předvoleb
+	DA	Presets editor
 	DE	Presets bearbeiten
 	EN	Presets Editor
 	FR	Editeur de présélections
@@ -8,6 +9,7 @@ PLUGIN_PRESETS_EDITOR
 
 PLUGIN_PRESETS_EDITOR_DESC
 	CS	Tento zásuvný modul umožňuje vizuálně upravovat konfiguraci tlačítek předvoleb Squeezeboxu.
+	DA	Dette plugin giver dig mulighed for at konfigurere de forudindstillede knapper på din Squeezebox.
 	DE	Dieses Plugin erlaubt es ihnen, die Preset-Tasten ihrer Squeezebox zu konfigurieren.
 	EN	This plugin allows you to visually edit the configuration of your Squeezebox preset keys.
 	FR	Ce plugin vous permet de modifier visuellement la configuration de vos touches de présélection Squeezebox.
@@ -16,6 +18,7 @@ PLUGIN_PRESETS_EDITOR_DESC
 
 PLUGIN_PRESETS_EDITOR_NEED_WEBUI
 	CS	Chcete-li používat Editor předvoleb, musíte povolit webové uživatelské rozhraní.
+	DA	For at bruge Presets Editor skal du aktivere webgrænsefladen.
 	DE	Um den Presets Editor verwenden zu können müssen Sie das Web-Interface aktivieren.
 	EN	You need to enable the web UI in order to use the Presets Editor.
 	FR	Vous devez activer l'interface utilisateur Web pour utiliser l'éditeur de présélections.

--- a/Slim/Plugin/RadioTunes/strings.txt
+++ b/Slim/Plugin/RadioTunes/strings.txt
@@ -3,6 +3,7 @@ PLUGIN_RADIOTUNES_NAME
 
 PLUGIN_RADIOTUNES_DESC
 	CS	RadioTunes.com – Vaše každodenní dávka hudby
+	DA	RadioTunes.com - Din daglige dosis musik
 	EN	RadioTunes.com - Your daily music fix
 	FR	RadioTunes.com - Votre dose de musique quotidienne
 	NL	RadioTunes.com - Uw dagelijkse muziekervaring
@@ -10,6 +11,7 @@ PLUGIN_RADIOTUNES_DESC
 
 PLUGIN_RADIOTUNES_MISSING_CREDS
 	CS	Prosím, navštivte RadioTunes.com v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
+	DA	Besøg RadioTunes.com i Lyrion Music Server indstillinger for at tilføje dine loginoplysninger.
 	EN	Please visit RadioTunes.com in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans RadioTunes.com dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar RadioTunes.com in de instellingen van de Lyrion Music Server om je gegevens toe te voegen.
@@ -17,6 +19,7 @@ PLUGIN_RADIOTUNES_MISSING_CREDS
 
 PLUGIN_RADIOTUNES_LINK
 	CS	Chcete-li si vytvořit nebo spravovat svůj účet, navštivte <a href="https://www.radiotunes.com" target="_blank">RadioTunes.com</a>.
+	DA	Besøg <a href="https://www.radiotunes.com" target="_blank">RadioTunes.com</a> for at oprette eller administrere din konto.
 	EN	To create or manage your account please visit <a href="https://www.radiotunes.com" target="_blank">RadioTunes.com</a>.
 	FR	Pour créer ou gérer votre compte, veuillez accéder à <a href="https://www.radiotunes.com" target="_blank">RadioTunes.com</a>.
 	NL	Ga om een account aan te maken of te beheren naar <a href="https://www.radiotunes.com" target="_blank">RadioTunes.com</a>.

--- a/Slim/Plugin/RockRadio/strings.txt
+++ b/Slim/Plugin/RockRadio/strings.txt
@@ -3,6 +3,7 @@ PLUGIN_ROCKRADIO_NAME
 
 PLUGIN_ROCKRADIO_DESC
 	CS	ROCKRADIO.COM | rocková hudba pro život
+	DA	ROCKRADIO.COM | rockmusik for livet
 	EN	ROCKRADIO.COM | rock music for life
 	FR	ROCKRADIO.COM | Musique rock pour la vie
 	NL	ROCKRADIO.COM | rockmuziek voor het leven
@@ -10,6 +11,7 @@ PLUGIN_ROCKRADIO_DESC
 
 PLUGIN_ROCKRADIO_MISSING_CREDS
 	CS	Prosím, navštivte ROCKRADIO.COM v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
+	DA	Besøg ROCKRADIO.COM i Lyrion Music Server indstillinger for at tilføje dine loginoplysninger.
 	EN	Please visit ROCKRADIO.COM in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans ROCKRADIO.COM dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar ROCKRADIO.COM in de Lyrion Music Server-instellingen om je gegevens toe te voegen.
@@ -17,6 +19,7 @@ PLUGIN_ROCKRADIO_MISSING_CREDS
 
 PLUGIN_ROCKRADIO_LINK
 	CS	Chcete-li si vytvořit nebo spravovat svůj účet, navštivte <a href="https://www.rockradio.com" target="_blank">ROCKRADIO.COM</a>.
+	DA	Besøg <a href="https://www.rockradio.com" target="_blank">ROCKRADIO.COM</a> for at oprette eller administrere din konto.
 	EN	To create or manage your account please visit <a href="https://www.rockradio.com" target="_blank">ROCKRADIO.COM</a>.
 	FR	Pour créer ou gérer votre compte, veuillez accéder à <a href="https://www.rockradio.com" target="_blank">ROCKRADIO.COM</a>.
 	NL	Ga om een account aan te maken of te beheren naar <a href="https://www.rockradio.com" target="_blank">ROCKRADIO.COM</a>.

--- a/Slim/Plugin/ViewTags/strings.txt
+++ b/Slim/Plugin/ViewTags/strings.txt
@@ -1,5 +1,6 @@
 PLUGIN_VIEW_TAGS
 	CS	Pokročilé zobrazení tagů
+	DA	Avanceret filmærke visning
 	DE	Erweiterte Tag Ansicht
 	EN	Advanced Tag View
 	FR	Vue avancée des tags
@@ -8,6 +9,7 @@ PLUGIN_VIEW_TAGS
 
 PLUGIN_VIEW_TAGS_WCOM
 	CS	Obchodní informace (WCOM)
+	DA	Kommerciel information (WCOM)
 	DE	Kommerzielle Informationen (WCOM)
 	EN	Commercial information (WCOM)
 	FR	Informations commerciales (WCOM)
@@ -16,6 +18,7 @@ PLUGIN_VIEW_TAGS_WCOM
 
 PLUGIN_VIEW_TAGS_WCOP
 	CS	Autorská práva/právní informace (WCOP, LICENSE)
+	DA	Ophavsret/Juridisk information (WCOP, LICENSE)
 	DE	Copyright/Rechtliche Informationen (WCOP, LICENSE)
 	EN	Copyright/Legal information (WCOP, LICENSE)
 	FR	Droits d'auteur / informations juridiques (WCOP, LICENSE)
@@ -24,6 +27,7 @@ PLUGIN_VIEW_TAGS_WCOP
 
 PLUGIN_VIEW_TAGS_WOAF
 	CS	Oficiální webová stránka zvukového souboru (WOAF)
+	DA	Officiel download webside (WOAF)
 	DE	Offizielle Download Website (WOAF)
 	EN	Official audio file webpage (WOAF)
 	FR	Site Web de téléchargement officiel (WOAF)
@@ -32,6 +36,7 @@ PLUGIN_VIEW_TAGS_WOAF
 
 PLUGIN_VIEW_TAGS_WOAR
 	CS	Oficiální webové stránky interpreta (WOAR, WEBSITE)
+	DA	Officiel kunstner webside (WOAR, WEBSITE)
 	DE	Offizielle Interpreten Website (WOAR, WEBSITE)
 	EN	Official artist webpage (WOAR, WEBSITE)
 	FR	Site Web officiel de l'artiste (WOAR, WEBSITE)
@@ -40,6 +45,7 @@ PLUGIN_VIEW_TAGS_WOAR
 
 PLUGIN_VIEW_TAGS_WOAS
 	CS	Oficiální webová stránka zdroje zvuku (WOAS)
+	DA	Officiel lydkilde webside (WOAS)
 	DE	Offizielle Quelle der Audiodaten (WOAS)
 	EN	Official audio source webpage (WOAS)
 	FR	Site Web officiel de la source audio (WOAS)
@@ -48,6 +54,7 @@ PLUGIN_VIEW_TAGS_WOAS
 
 PLUGIN_VIEW_TAGS_WORS
 	CS	Domovská stránka rozhlasové stanice (WORS)
+	DA	Webside for radiostation (WORS)
 	DE	Website der Radiostation (WORS)
 	EN	Radio station homepage (WORS)
 	FR	Site Web de la station de radio (WORS)
@@ -56,6 +63,7 @@ PLUGIN_VIEW_TAGS_WORS
 
 PLUGIN_VIEW_TAGS_WPUB
 	CS	Webové stránky vydavatele (WPUB)
+	DA	Udgiverens webside (WPUB)
 	DE	Website des Publishers (WPUB)
 	EN	Publishers webpage (WPUB)
 	FR	Site Web de l'éditeur (WPUB)
@@ -64,6 +72,7 @@ PLUGIN_VIEW_TAGS_WPUB
 
 PLUGIN_VIEW_TAGS_STD_URL
 	CS	Standardní tagy adres URL
+	DA	Standard URL mærker
 	DE	Standardtags mit URLs
 	EN	Standard URL tags
 	FR	Tags d'URL standards
@@ -72,6 +81,7 @@ PLUGIN_VIEW_TAGS_STD_URL
 
 PLUGIN_VIEW_TAGS_CUSTOM_TAGS
 	CS	Další tagy pro zobrazení
+	DA	Supplerende mærker at vise
 	DE	Zusätzliche anzuzeigende Tags
 	EN	Additional tags to show
 	FR	Tags supplémentaires à afficher
@@ -80,6 +90,7 @@ PLUGIN_VIEW_TAGS_CUSTOM_TAGS
 
 PLUGIN_VIEW_TAGS_CUSTOM_TAGS_DESC
 	CS	"Název tagu" se vztahuje na skutečný tag, jak je uložen v souboru, např. "WEBSITE". Zobrazí se v nabídce "Zobrazit tagy". "Zobrazovaný název" je uživatelsky přívětivější název, který se použije v uživatelském rozhraní. "Adresa URL" určuje, zda pole obsahuje adresu URL. V tomto případě mohou uživatelská rozhraní, která jsou schopná odkazovat na adresy URL, zobrazit obsah s odkazem.
+	DA	"Mærke navn" er det faktiske navn som er gemt i filen, f.eks. "WEBSITE". Dette vises også i "Vis mærker" menuen. "Mærkenavn at vise" er et mere brugervenligt navn, der vil blive vist i brugergrænsefladen. "URL" definerer, om den viste værdi skal vises som et link (hvis muligt).
 	DE	"Tag Name" ist der eigentliche Name, wie er in der Datei gespeichert ist, z.B. "WEBSITE". Dieser Name wird auch in "Tags anzeigen" eines Titels angezeigt. "Anzuzeigender Name" ist ein benutzerfreundlicherer Name, der in der Benutzeroberfläche angezeigt wird. "URL" definiert, ob der angezeigte Wert als Link dargestellt werden soll (wenn möglich).
 	EN	"Tag name" refers to the actual tag, as stored in the file, eg. "WEBSITE". The "View Tags" menu shows these. The "Name to be displayed" is a more user friendly name to be used in the UI. "URL" defines whether the field contains a URL. In this case UIs able to link to URLs can render the content with a link.
 	FR	Le "Nom du tag" fait référence à la balise réelle telle qu'elle est stockée dans le fichier (par exemple "WEBSITE"). Le menu "Afficher les tags" permet de consulter les tags. Le « Nom à afficher » est un nom plus parlant qui est utilisé dans l'interface utilisateur. "URL" précise si la balise contient un lien Web qu'il faut tenter de restituer sous cette forme.
@@ -88,6 +99,7 @@ PLUGIN_VIEW_TAGS_CUSTOM_TAGS_DESC
 
 PLUGIN_VIEW_TAGS_TAG_NAME
 	CS	Název tagu
+	DA	Mærke navn
 	DE	Tag Name
 	EN	Tag name
 	FR	Nom du tag
@@ -96,6 +108,7 @@ PLUGIN_VIEW_TAGS_TAG_NAME
 
 PLUGIN_VIEW_TAGS_TAG_HUMAN_READABLE
 	CS	Zobrazovaný název tagu
+	DA	Mærkenavn at vise
 	DE	Anzuzeigender Name
 	EN	Tag name to be displayed
 	FR	Nom à afficher
@@ -104,6 +117,7 @@ PLUGIN_VIEW_TAGS_TAG_HUMAN_READABLE
 
 PLUGIN_VIEW_TAGS_LEVEL
 	CS	Úroveň, na které se tyto tagy zobrazují
+	DA	Visningsniveaur for disse mærker
 	DE	Anzeigeebene für diese Tags
 	EN	Level at which to show these tags
 	FR	Niveau auquel afficher ces tags
@@ -112,6 +126,7 @@ PLUGIN_VIEW_TAGS_LEVEL
 
 PLUGIN_VIEW_TAGS_TOPLEVEL
 	CS	Zobrazit tagy na nejvyšší úrovni
+	DA	Vis mærker på øverste niveau
 	DE	Tags auf oberster Ebene anzeigen
 	EN	Show tags at the top level
 	FR	Afficher les tags au niveau supérieur
@@ -120,6 +135,7 @@ PLUGIN_VIEW_TAGS_TOPLEVEL
 
 PLUGIN_VIEW_TAGS_MOREINFO
 	CS	Zobrazit tagy v "Další informace"
+	DA	Vis mærker i "Mere info"
 	DE	Tags in "Weitere Infos" anzeigen
 	EN	Show tags in "More Info"
 	FR	Afficher les tags dans "Plus d'infos"
@@ -128,5 +144,6 @@ PLUGIN_VIEW_TAGS_MOREINFO
 
 PLUGIN_VIEW_TAGS_URL
 	CS	Adresa URL
+	DA	URL adresse
 	EN	URL
 	HU	URL

--- a/Slim/Plugin/ViewTags/strings.txt
+++ b/Slim/Plugin/ViewTags/strings.txt
@@ -90,7 +90,7 @@ PLUGIN_VIEW_TAGS_CUSTOM_TAGS
 
 PLUGIN_VIEW_TAGS_CUSTOM_TAGS_DESC
 	CS	"Název tagu" se vztahuje na skutečný tag, jak je uložen v souboru, např. "WEBSITE". Zobrazí se v nabídce "Zobrazit tagy". "Zobrazovaný název" je uživatelsky přívětivější název, který se použije v uživatelském rozhraní. "Adresa URL" určuje, zda pole obsahuje adresu URL. V tomto případě mohou uživatelská rozhraní, která jsou schopná odkazovat na adresy URL, zobrazit obsah s odkazem.
-	DA	"Mærke navn" er det faktiske navn som er gemt i filen, f.eks. "WEBSITE". Dette vises også i "Vis mærker" menuen. "Mærkenavn at vise" er et mere brugervenligt navn, der vil blive vist i brugergrænsefladen. "URL" definerer, om den viste værdi skal vises som et link (hvis muligt).
+	DA	"Mærkenavn" er det faktiske navn som er gemt i filen, f.eks. "WEBSITE". Dette vises også i "Vis mærker" menuen. "Mærkenavn at vise" er et mere brugervenligt navn, der vil blive vist i brugergrænsefladen. "URL" definerer, om den viste værdi skal vises som et link (hvis muligt).
 	DE	"Tag Name" ist der eigentliche Name, wie er in der Datei gespeichert ist, z.B. "WEBSITE". Dieser Name wird auch in "Tags anzeigen" eines Titels angezeigt. "Anzuzeigender Name" ist ein benutzerfreundlicherer Name, der in der Benutzeroberfläche angezeigt wird. "URL" definiert, ob der angezeigte Wert als Link dargestellt werden soll (wenn möglich).
 	EN	"Tag name" refers to the actual tag, as stored in the file, eg. "WEBSITE". The "View Tags" menu shows these. The "Name to be displayed" is a more user friendly name to be used in the UI. "URL" defines whether the field contains a URL. In this case UIs able to link to URLs can render the content with a link.
 	FR	Le "Nom du tag" fait référence à la balise réelle telle qu'elle est stockée dans le fichier (par exemple "WEBSITE"). Le menu "Afficher les tags" permet de consulter les tags. Le « Nom à afficher » est un nom plus parlant qui est utilisé dans l'interface utilisateur. "URL" précise si la balise contient un lien Web qu'il faut tenter de restituer sous cette forme.
@@ -99,7 +99,7 @@ PLUGIN_VIEW_TAGS_CUSTOM_TAGS_DESC
 
 PLUGIN_VIEW_TAGS_TAG_NAME
 	CS	Název tagu
-	DA	Mærke navn
+	DA	Mærkenavn
 	DE	Tag Name
 	EN	Tag name
 	FR	Nom du tag

--- a/Slim/Plugin/ZenRadio/strings.txt
+++ b/Slim/Plugin/ZenRadio/strings.txt
@@ -3,6 +3,7 @@ PLUGIN_ZENRADIO_NAME
 
 PLUGIN_ZENRADIO_DESC
 	CS	Zen Radio – Relaxační a meditační hudba
+	DA	Zen Radio - Musik til afslapning og meditation
 	EN	Zen Radio - Relaxation & Meditation Music
 	FR	Zen Radio - Musique de relaxation et de méditation
 	NL	Zen Radio - Ontspannings- en meditatiemuziek
@@ -10,6 +11,7 @@ PLUGIN_ZENRADIO_DESC
 
 PLUGIN_ZENRADIO_MISSING_CREDS
 	CS	Prosím, navštivte Zen Radio v nastavení Lyrion Music Serveru a přidejte své přihlašovací údaje.
+	DA	Besøg Zen Radio i Lyrion Music Server indstillinger for at tilføje dine loginoplysninger.
 	EN	Please visit Zen Radio in the Lyrion Music Server Settings to add your credentials.
 	FR	Veuillez vous rendre dans Zen Radio dans les paramètres de Lyrion Music Server pour ajouter vos informations d'identification.
 	NL	Ga naar Zen Radio in de Lyrion Music Server Instellingen om je gegevens toe te voegen.
@@ -17,6 +19,7 @@ PLUGIN_ZENRADIO_MISSING_CREDS
 
 PLUGIN_ZENRADIO_LINK
 	CS	Chcete-li si vytvořit nebo spravovat svůj účet, navštivte <a href="https://www.zenradio.com" target="_blank">Zen Radio</a>.
+	DA	Besøg <a href="https://www.zenradio.com" target="_blank">Zen Radio</a> for at oprette eller administrere din konto.
 	EN	To create or manage your account please visit <a href="https://www.zenradio.com" target="_blank">Zen Radio</a>.
 	FR	Pour créer ou gérer votre compte, veuillez accéder à <a href="https://www.zenradio.com" target="_blank">Zen Radio</a>.
 	NL	Ga om een account aan te maken of te beheren naar <a href="https://www.zenradio.com" target="_blank">Zen Radio</a>.


### PR DESCRIPTION
The plugins updated with Danish language elements are: ACLFiletest - Analytics - AudioAddict - AudioScrobbler - ClassicRadio - DIfm - DnDPlay - DontStopTheMusic - Favorites - JazzRadio - LibraryDemo - MyApps - Podcast (deleted one German double-entry) - PresetsEditor - RadioTunes - RockRadio - ViewTags - ZenRadio