### PR TITLE
Only allow audio tracks for RandomPlay

### DIFF
--- a/Slim/Plugin/RandomPlay/Mixer.pm
+++ b/Slim/Plugin/RandomPlay/Mixer.pm
@@ -114,7 +114,7 @@ sub getIdList {
 		# it's messy reaching that far in to Slim::Control::Queries, but it's >5x faster on a Raspberry Pi2 with 100k tracks than running the full "titles" query
 		my $results;
 		($results, $idList) = Slim::Control::Queries::_getTagDataForTracks( 'II', {
-			where     => '(tracks.content_type != "cpl" AND tracks.content_type != "src" AND tracks.content_type != "ssp" AND tracks.content_type != "dir")',
+			where     => '(tracks.audio = 1 AND tracks.content_type != "cpl" AND tracks.content_type != "src" AND tracks.content_type != "ssp" AND tracks.content_type != "dir")',
 			year      => $type eq 'year' && getRandomYear($client, $filteredGenres),
 			genreId   => $queryGenres,
 			libraryId => $queryLibrary,


### PR DESCRIPTION
I had noticed a discrepancy with the RandomPlay tracks functionality based on the genre selection:

## All genres selected
* Less than the expected number of tracks are added to the queue. When configured to show 10 upcoming songs, 4-6 tracks are typically queued, but it ranged from 2 to 9 tracks.
* The newly added first track queue almost always did not autoplay.
* The `playlist jump` request almost always completed with a status of 1 (Dispatchable).

## At least one genre deselected
* The expected number of tracks are added to the queue.
* The newly added first track queue is autoplayed.
* The `playlist jump` request completes with a status of 10 (Done).

I finally narrowed down the issue to embedded cuesheet FLACs. For reference, the library I am dealing with is as follows:
```
content_type|audio|COUNT(*)|
------------+-----+--------+
alc         |    1|     136|
dir         |     |     905|
fec         |    0|    2478|
flc         |    1|   35803|
mp3         |    1|    1280|
mp4         |    1|     300|
ogg         |    1|       5|
ops         |    1|     131|
ssp         |     |      21|
```

Embedded cuesheet FLACs (FEC) are inserted into the `tracks` table with `audio` set to 0. The individual tracks in a FEC are inserted into the `tracks` table as FLACs with `audio` set to 1. However, FEC files are not excluded as potential RandomPlay tracks, and will not correctly populate in the playlist if they are selected. This is typically seen as the RandomPlay-generated playlist having less than the expected number of tracks. The issue is mitigated by adding a genre conditional; FEC files are not associated from genres and therefore are eliminated as potential RandomPlay tracks.

To address this, I required that RandomPlay tracks must have `audio` set to 1. I opted to not extend the list of precluded content types for a couple of reasons:
* I wouldn't expect other, non-excluded playlists from being used in RandomPlay (cue, m3u, etc). **I did not test this!**
* Precedent in Slim::Web::Pages::Search::advancedSearch to append `audio = 1`.
* Precedent in other modules to limit the precluded content types to `cpl`, `src`, `ssp`, and `dir`.

I limited this PR specifically to RandomPlay, but there is at least one additional reference in [Slim::Control::Queries::titlesQuery](https://github.com/LMS-Community/slimserver/blob/b9fb246c69f4051ad1026f19a3e91577056c212a/Slim/Control/Queries.pm#L4538) that should also be further limited.