### PR TITLE
Include w tag from browse library so that albums.compilation is inclu…

### DIFF
--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -1440,7 +1440,7 @@ sub _albums {
 	my $search     = $pt->{'search'};
 	my $wantMeta   = $pt->{'wantMetadata'};
 	# aa & SS will get all contributors and IDs in addition to the main contributor (albums.contributor) - slower but more accurate
-	my $tags       = 'ljsaaSSKE';
+	my $tags       = 'ljsaaSSKEw';
 	my $library_id = $args->{'library_id'} || $pt->{'library_id'};
 	my $remote_library = $args->{'remote_library'} ||= $pt->{'remote_library'};
 


### PR DESCRIPTION
…ded in the SQL results

See https://forums.slimdevices.com/forum/user-forums/logitech-media-server/1736783-lms-9-0-shows-a-list-of-track-artists-for-compilations-when-browsing-in-default-skin

The code in albumsQuery is trying to look at albums.compilation but it's not there.