### PR TITLE
Need to utf8Decode album title for new&changed

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -945,6 +945,7 @@ sub _createOrUpdateAlbum {
 
 	if ( !$create && $track ) {
 		$albumHash = Slim::Schema::Album->findhash( $track->album->id );
+		utf8::decode($albumHash->{title});
 		my $differentTitle = Slim::Utils::Unicode::utf8toLatin1Transliterate($title) ne Slim::Utils::Unicode::utf8toLatin1Transliterate($albumHash->{title});
 
 		# Bug: 4140


### PR DESCRIPTION
A bit of a strange one:

When doing a new and changed scan, we're checking the album names to see if we need to create a new album, but it is failing because of different hex characters in the retrieved data:

eg
The title passed into createOrUpdateAlbum (from the newly-read tag) is:
`"Alb\xE9niz: Iberia, Granados: Goyescas, Alicia de Larrocha"`
but the title retrieved from the database is:
`"Alb\xC3\xA9niz: Iberia, Granados: Goyescas, Alicia de Larrocha"`

A quick `utf8::decode` seems to sort it out.