### PR TITLE
slimserver#1236: fix create table syntax for MySQL (MariaDB) in 23 up

### DIFF
--- a/SQL/mysql/schema_23_up.sql
+++ b/SQL/mysql/schema_23_up.sql
@@ -5,8 +5,8 @@ ALTER TABLE albums ADD subtitle blob;
 ALTER TABLE albums ADD label blob;
 CREATE INDEX tracksWorkIndex ON tracks (work);
 CREATE TABLE works (
-  id  integer PRIMARY KEY AUTOINCREMENT,
-  composer integer,
+  id  integer PRIMARY KEY AUTO_INCREMENT,
+  composer int(10) unsigned,
   title blob,
   titlesort text,
   titlesearch text,


### PR DESCRIPTION
These changes were required to upgrade the schema on MariaDB 10.11.

AUTOINCREMENT -> AUTO_INCREMENT, all the other .sql files for MySQL use that variation.
composer integer -> int(10) unsigned, the type must be the same as the column referenced in the foreign key.

Closes #1236.