### PR TITLE
Guard against tracks with multiple WORK tags

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1470,9 +1470,13 @@ sub _createComments {
 }
 
 sub _createWork {
-	my ($self, $work, $workSort, $composerID, $create) = @_;
+	my ($self, $work, $workSort, $composerID, $create, $track, $album) = @_;
 
 	if ( $work && $composerID ) {
+		if (ref $work eq 'ARRAY') {
+			$log->error("-- Found mutiple work tags for album=$album, track=$track. Setting Work=@$work[0]");
+			$work = @$work[0];
+		}
 		# Using native DBI here to improve performance during scanning
 		my $dbh = Slim::Schema->dbh;
 
@@ -1752,7 +1756,7 @@ sub _newTrack {
 	}
 
 	### Create Work rows
-	my $workID = $self->_createWork($deferredAttributes->{'WORK'}, $deferredAttributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1);
+	my $workID = $self->_createWork($deferredAttributes->{'WORK'}, $deferredAttributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1, $attributeHash->{'TITLE'}, $deferredAttributes->{'ALBUM'});
 
 	### Find artwork column values for the Track
 	if ( !$columnValueHash{cover} && $columnValueHash{audio} ) {
@@ -2954,8 +2958,8 @@ sub _postCheckAttributes {
 	# etc don't show up if you don't have any.
 	my %cols = $track->get_columns;
 
-	my ($trackId, $trackUrl, $trackType, $trackAudio, $trackRemote) =
-		(@cols{qw/id url content_type audio remote/});
+	my ($trackId, $trackUrl, $trackType, $trackAudio, $trackRemote, $trackTitle) =
+		(@cols{qw/id url content_type audio remote title/});
 
 	if (!defined $trackType || $trackType eq 'dir' || $trackType eq 'lnk') {
 		$track->update;
@@ -2993,7 +2997,7 @@ sub _postCheckAttributes {
 
 	#Work
 	if (defined $attributes->{'WORK'}) {
-		my $workID = $self->_createWork($attributes->{'WORK'}, $attributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1);
+		my $workID = $self->_createWork($attributes->{'WORK'}, $attributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1, $trackTitle, $attributes->{'ALBUM'});
 		if ($workID) {
 			$track->work($workID);
 		}


### PR DESCRIPTION
Prevents WORK being created as array ref when user has multiple WORK tags in a track.