### PR TITLE
Option to limit works scanning to classical

### DIFF
--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -110,12 +110,12 @@
 		[% END %]
 
 		[% WRAPPER settingGroup title="SETUP_WORKSSCAN" desc="" %]
-			<input type="radio" name="pref_worksScan" id="pref_worksScan0" value="0" [% IF NOT prefs.pref_worksScan %]checked="checked"[% END %] />
-			<label for="pref_worksScan0" class="stdlabel">[% 'SETUP_WORKSSCAN_0' | getstring %]</label><br/>
-			<input type="radio" name="pref_worksScan" id="pref_worksScan1" value="1" [% IF prefs.pref_worksScan == 1 %]checked="checked"[% END %] />
-			<label for="pref_worksScan1" class="stdlabel">[% 'SETUP_WORKSSCAN_1' | getstring %]</label><br/>
-			<input type="radio" name="pref_worksScan" id="pref_worksScan2" value="2" [% IF prefs.pref_worksScan == 2 %]checked="checked"[% END %] />
-			<label for="pref_worksScan2" class="stdlabel">[% 'SETUP_WORKSSCAN_2' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan1" value="1" [% IF prefs.pref_worksScan %]checked="checked"[% END %] />
+			<label for="pref_worksScan0" class="stdlabel">[% 'SETUP_WORKSSCAN_1' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan1" value="2" [% IF prefs.pref_worksScan == 2 %]checked="checked"[% END %] />
+			<label for="pref_worksScan1" class="stdlabel">[% 'SETUP_WORKSSCAN_2' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan2" value="0" [% IF prefs.pref_worksScan == 0 %]checked="checked"[% END %] />
+			<label for="pref_worksScan2" class="stdlabel">[% 'SETUP_WORKSSCAN_0' | getstring %]</label><br/>
 		[% END %]
 	[% END %]
 

--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -105,11 +105,17 @@
 			<label for="pref_useTPE2AsAlbumArtist1" class="stdlabel">[% 'SETUP_USETPE2ASALBUMARTIST_1' | getstring %]</label><br/>
 		[% END %]
 
-		[% WRAPPER settingGroup title="SETUP_WORKSSCANONLYCLASSICAL" desc="" %]
-			<input type="radio" name="pref_worksScanOnlyClassical" id="pref_worksScanOnlyClassical0" value="0" [% IF NOT prefs.pref_worksScanOnlyClassical %]checked="checked"[% END %] />
-			<label for="pref_worksScanOnlyClassical0" class="stdlabel">[% 'SETUP_WORKSSCANONLYCLASSICAL_0' | getstring %]</label><br/>
-			<input type="radio" name="pref_worksScanOnlyClassical" id="pref_worksScanOnlyClassical1" value="1" [% IF prefs.pref_worksScanOnlyClassical %]checked="checked"[% END %] />
-			<label for="pref_worksScanOnlyClassical1" class="stdlabel">[% 'SETUP_WORKSSCANONLYCLASSICAL_1' | getstring %]</label><br/>
+		[% WRAPPER settingGroup title="SETUP_MYCLASSICALGENRES" desc="SETUP_MYCLASSICALGENRES_DESC" %]
+			<input type="text" class="stdedit" name="pref_myClassicalGenres" id="myClassicalGenres" value="[% prefs.pref_myClassicalGenres | html %]" size="40" placeholder="[% "GENRES" | string | html %]"><br/>
+		[% END %]
+
+		[% WRAPPER settingGroup title="SETUP_WORKSSCAN" desc="" %]
+			<input type="radio" name="pref_worksScan" id="pref_worksScan0" value="0" [% IF NOT prefs.pref_worksScan %]checked="checked"[% END %] />
+			<label for="pref_worksScan0" class="stdlabel">[% 'SETUP_WORKSSCAN_0' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan1" value="1" [% IF prefs.pref_worksScan == 1 %]checked="checked"[% END %] />
+			<label for="pref_worksScan1" class="stdlabel">[% 'SETUP_WORKSSCAN_1' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan2" value="2" [% IF prefs.pref_worksScan == 2 %]checked="checked"[% END %] />
+			<label for="pref_worksScan2" class="stdlabel">[% 'SETUP_WORKSSCAN_2' | getstring %]</label><br/>
 		[% END %]
 	[% END %]
 
@@ -159,10 +165,8 @@
 			<label for="pref_showComposerReleasesbyAlbum1" class="stdlabel">[% 'SETUP_RELEASE_TYPES_COMPOSER_ROLE_GROUPING_1' | getstring %]</label><br/>
 			<input type="radio" name="pref_showComposerReleasesbyAlbum" id="pref_showComposerReleasesbyAlbum2" value="2" [% IF prefs.pref_showComposerReleasesbyAlbum == 2 %]checked="checked"[% END %] />
 			<label for="pref_showComposerReleasesbyAlbum2" class="stdlabel">[% 'SETUP_RELEASE_TYPES_COMPOSER_ROLE_GROUPING_2' | getstring %]</label>
-			<input type="text" class="stdedit" name="pref_showComposerReleasesbyAlbumGenres" id="showComposerReleasesbyAlbumGenres" value="[% prefs.pref_showComposerReleasesbyAlbumGenres | html %]" size="40" placeholder="[% "GENRES" | string | html %]"><br/>
 		[% END; ELSE %]
 			<input type="hidden" name="pref_showComposerReleasesbyAlbum" value="[% prefs.pref_showComposerReleasesbyAlbum %]" />
-			<input type="hidden" name="pref_showComposerReleasesbyAlbumGenres" value="[% prefs.pref_showComposerReleasesbyAlbumGenres %]" />
 		[% END %]
 	[% END %]
 

--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -110,12 +110,12 @@
 		[% END %]
 
 		[% WRAPPER settingGroup title="SETUP_WORKSSCAN" desc="" %]
-			<input type="radio" name="pref_worksScan" id="pref_worksScan1" value="1" [% IF prefs.pref_worksScan %]checked="checked"[% END %] />
-			<label for="pref_worksScan0" class="stdlabel">[% 'SETUP_WORKSSCAN_1' | getstring %]</label><br/>
-			<input type="radio" name="pref_worksScan" id="pref_worksScan1" value="2" [% IF prefs.pref_worksScan == 2 %]checked="checked"[% END %] />
-			<label for="pref_worksScan1" class="stdlabel">[% 'SETUP_WORKSSCAN_2' | getstring %]</label><br/>
-			<input type="radio" name="pref_worksScan" id="pref_worksScan2" value="0" [% IF prefs.pref_worksScan == 0 %]checked="checked"[% END %] />
-			<label for="pref_worksScan2" class="stdlabel">[% 'SETUP_WORKSSCAN_0' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan0" value="0" [% IF prefs.pref_worksScan == 0 %]checked="checked"[% END %] />
+			<label for="pref_worksScan0" class="stdlabel">[% 'SETUP_WORKSSCAN_0' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan1" value="1" [% IF prefs.pref_worksScan == 1 %]checked="checked"[% END %] />
+			<label for="pref_worksScan1" class="stdlabel">[% 'SETUP_WORKSSCAN_1' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScan" id="pref_worksScan2" value="2" [% IF prefs.pref_worksScan == 2 %]checked="checked"[% END %] />
+			<label for="pref_worksScan2" class="stdlabel">[% 'SETUP_WORKSSCAN_2' | getstring %]</label><br/>
 		[% END %]
 	[% END %]
 

--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -104,6 +104,13 @@
 			<input type="radio" name="pref_useTPE2AsAlbumArtist" id="pref_useTPE2AsAlbumArtist1" value="1" [% IF prefs.pref_useTPE2AsAlbumArtist %]checked="checked"[% END %] />
 			<label for="pref_useTPE2AsAlbumArtist1" class="stdlabel">[% 'SETUP_USETPE2ASALBUMARTIST_1' | getstring %]</label><br/>
 		[% END %]
+
+		[% WRAPPER settingGroup title="SETUP_WORKSSCANONLYCLASSICAL" desc="" %]
+			<input type="radio" name="pref_worksScanOnlyClassical" id="pref_worksScanOnlyClassical0" value="0" [% IF NOT prefs.pref_worksScanOnlyClassical %]checked="checked"[% END %] />
+			<label for="pref_worksScanOnlyClassical0" class="stdlabel">[% 'SETUP_WORKSSCANONLYCLASSICAL_0' | getstring %]</label><br/>
+			<input type="radio" name="pref_worksScanOnlyClassical" id="pref_worksScanOnlyClassical1" value="1" [% IF prefs.pref_worksScanOnlyClassical %]checked="checked"[% END %] />
+			<label for="pref_worksScanOnlyClassical1" class="stdlabel">[% 'SETUP_WORKSSCANONLYCLASSICAL_1' | getstring %]</label><br/>
+		[% END %]
 	[% END %]
 
 	[% WRAPPER settingSection %]

--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -82,7 +82,7 @@ sub _releases {
 			}
 			else {
 				foreach my $genre (@{$request->getResult('genres_loop')}) {
-					last if $genreMatch = Slim::Schema::Genre->isMyClassicalGenre(uc($genre->{genre}));
+					last if $genreMatch = Slim::Schema::Genre->isMyClassicalGenre($genre->{genre});
 				}
 			}
 		}

--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -65,7 +65,7 @@ sub _releases {
 
 	my %composerGenres = map {
 		$_ => 1
-	} split(/,\s*/, uc($prefs->get('showComposerReleasesbyAlbumGenres')));
+	} split(/,\s*/, uc($prefs->get('myClassicalGenres')));
 
 	my $checkComposerGenres = !( $menuMode && $menuMode ne 'artists' && $menuRoles ) && $prefs->get('showComposerReleasesbyAlbum') == 2;
 	my $allComposers = ( $menuMode && $menuMode ne 'artists' && $menuRoles ) || $prefs->get('showComposerReleasesbyAlbum') == 1;

--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -63,10 +63,6 @@ sub _releases {
 	my %isPrimaryArtist;
 	my %albumList;
 
-	my %composerGenres = map {
-		$_ => 1
-	} split(/,\s*/, uc($prefs->get('myClassicalGenres')));
-
 	my $checkComposerGenres = !( $menuMode && $menuMode ne 'artists' && $menuRoles ) && $prefs->get('showComposerReleasesbyAlbum') == 2;
 	my $allComposers = ( $menuMode && $menuMode ne 'artists' && $menuRoles ) || $prefs->get('showComposerReleasesbyAlbum') == 1;
 
@@ -86,7 +82,7 @@ sub _releases {
 			}
 			else {
 				foreach my $genre (@{$request->getResult('genres_loop')}) {
-					last if $genreMatch = $composerGenres{uc($genre->{genre})};
+					last if $genreMatch = Slim::Schema::Genre->isMyClassicalGenre(uc($genre->{genre}));
 				}
 			}
 		}
@@ -207,6 +203,7 @@ sub _releases {
 
 	# Add item for Classical Works if the artist has any.
 	push @searchTags, "role_id:$menuRoles" if $menuRoles && $menuMode && $menuMode ne 'artists';
+	push @searchTags, "genre_id:" . Slim::Schema::Genre->myClassicalGenreIds() if $checkComposerGenres;
 	main::INFOLOG && $log->is_info && $log->info("works ($index, $quantity): tags ->", join(', ', @searchTags));
 	my $requestRef = [ 'works', 0, MAX_ALBUMS, @searchTags ];
 	my $request = Slim::Control::Request->new( $client ? $client->id() : undef, $requestRef );

--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -1004,6 +1004,7 @@ $prefs->setChange(
 
 sub splitTag {
 	my $tag = shift;
+	my $customSeparator = shift;
 
 	# Handle Vorbis comments where the tag can be an array.
 	if (ref($tag) eq 'ARRAY') {
@@ -1018,15 +1019,17 @@ sub splitTag {
 
 	my @splitTags = ();
 
-	if (!$_gotSplitList) {
+	if (!$_gotSplitList && !$customSeparator) {
 		$_splitList = $prefs->get('splitList');
 		$_gotSplitList = 1;
 	}
 
-	# only bother if there are some characters in the pref
-	if ($_splitList) {
+	my $separator = $customSeparator || $_splitList;
 
-		for my $splitOn (split(/\s+/, $_splitList),'\x00') {
+	# only bother if there are some characters in the pref
+	if ($separator) {
+
+		for my $splitOn (split(/\s+/, $separator),'\x00') {
 
 			my @temp = ();
 

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1757,7 +1757,10 @@ sub _newTrack {
 	}
 
 	### Create Work rows
-	my $workID = $self->_createWork($deferredAttributes->{'WORK'}, $deferredAttributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1);
+	my $workID;
+	if ( lc($deferredAttributes->{'GENRE'}) =~ /classical/ || !$prefs->get('worksScanOnlyClassical') ) {
+		$workID = $self->_createWork($deferredAttributes->{'WORK'}, $deferredAttributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1);
+	}
 
 	### Find artwork column values for the Track
 	if ( !$columnValueHash{cover} && $columnValueHash{audio} ) {
@@ -2998,9 +3001,11 @@ sub _postCheckAttributes {
 
 	#Work
 	if (defined $attributes->{'WORK'}) {
-		my $workID = $self->_createWork($attributes->{'WORK'}, $attributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1);
-		if ($workID) {
-			$track->work($workID);
+		if ( lc($attributes->{'GENRE'}) =~ /classical/ || !$prefs->get('worksScanOnlyClassical') ) {
+			my $workID = $self->_createWork($attributes->{'WORK'}, $attributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1);
+			if ($workID) {
+				$track->work($workID);
+			}
 		}
 	}
 

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1764,6 +1764,8 @@ sub _newTrack {
 	if ( _workRequired($deferredAttributes->{'GENRE'}) ) {
 		$workID = $self->_createWork($deferredAttributes->{'WORK'}, $deferredAttributes->{'WORKSORT'}, $contributors->{'COMPOSER'}->[0], 1);
 	}
+	else {
+	}
 
 	### Find artwork column values for the Track
 	if ( !$columnValueHash{cover} && $columnValueHash{audio} ) {
@@ -3306,8 +3308,6 @@ sub canFulltextSearch {
 sub _workRequired {
 	if ( (defined $scanWorks ? $scanWorks : $prefs->get('worksScan')) == SCAN_WORKS_FOR_MY_CLASSICAL_GENRES ) {
 		my $genres = shift;
-		# input will be an array if multiple genre tags
-		$genres = join(';', @$genres) if ref $genres eq 'ARRAY';
 		return Slim::Schema::Genre->isMyClassicalGenre($genres);
 	} else {
 		return defined $scanWorks ? $scanWorks : $prefs->get('worksScan');

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -59,7 +59,7 @@ use constant SCAN_WORKS_FOR_MY_CLASSICAL_GENRES => 2;
 my $log = logger('database.info');
 
 my $prefs = preferences('server');
-my $scanWorks = $prefs->get('worksScan');
+my $scanWorks = $prefs->get('worksScan') if main::SCANNER;
 
 # Singleton objects for Unknowns
 our ($_unknownArtist, $_unknownGenre, $_unknownAlbumId) = ('', '', undef);
@@ -3304,13 +3304,13 @@ sub canFulltextSearch {
 }
 
 sub _workRequired {
-	if ( $scanWorks == SCAN_WORKS_FOR_MY_CLASSICAL_GENRES ) {
+	if ( (defined $scanWorks ? $scanWorks : $prefs->get('worksScan')) == SCAN_WORKS_FOR_MY_CLASSICAL_GENRES ) {
 		my $genres = shift;
 		# input will be an array if multiple genre tags
 		$genres = join(';', @$genres) if ref $genres eq 'ARRAY';
 		return Slim::Schema::Genre->isMyClassicalGenre($genres);
 	} else {
-		return $scanWorks;
+		return defined $scanWorks ? $scanWorks : $prefs->get('worksScan');
 	}
 }
 

--- a/Slim/Schema/Genre.pm
+++ b/Slim/Schema/Genre.pm
@@ -13,6 +13,8 @@ use Slim::Utils::Prefs;
 
 my $myClassicalGenreMap;
 my $myClassicalGenreIds;
+my $tagSeparator;
+my $tagSeparatorLoaded;
 
 {
 	my $class = __PACKAGE__;
@@ -41,7 +43,7 @@ my $myClassicalGenreIds;
 
 sub loadMyClassicalGenreMap {
 	my $prefs = preferences('server');
-	%$myClassicalGenreMap = map {$_ => 1} split(/,\s*/, uc($prefs->get('myClassicalGenres')));
+	%$myClassicalGenreMap = map {$_ => 1} split(/\s*,\s*/, uc($prefs->get('myClassicalGenres')));
 	if ( !%$myClassicalGenreMap ) {
 		$myClassicalGenreIds = undef;
 		return;
@@ -61,8 +63,9 @@ sub isMyClassicalGenre {
 	loadMyClassicalGenreMap() if !$myClassicalGenreMap;
 	my $class = shift;
 	my $genres = shift;
-	foreach (Slim::Music::Info::splitTag(uc($genres))) {
-		return 1 if %$myClassicalGenreMap{$_}
+	my $sep = shift;
+	foreach ( Slim::Music::Info::splitTag($genres, $sep) ) {
+		return 1 if %$myClassicalGenreMap{uc($_)}
 	}
 	return 0;
 }

--- a/Slim/Schema/Genre.pm
+++ b/Slim/Schema/Genre.pm
@@ -9,6 +9,11 @@ use Slim::Schema::ResultSet::Genre;
 
 use Slim::Utils::Misc;
 use Slim::Utils::Log;
+use Slim::Utils::Prefs;
+
+my %myClassicalGenreMap;
+my $myClassicalGenreIds;
+loadMyClassicalGenreMap();
 
 {
 	my $class = __PACKAGE__;
@@ -33,6 +38,35 @@ use Slim::Utils::Log;
 	}
 
 	$class->resultset_class('Slim::Schema::ResultSet::Genre');
+}
+
+sub loadMyClassicalGenreMap {
+	my $prefs = preferences('server');
+	%myClassicalGenreMap = map {$_ => 1} split(/,\s*/, uc($prefs->get('myClassicalGenres')));
+	$myClassicalGenreIds = undef;
+}
+
+sub isMyClassicalGenre {
+	my $class = shift;
+	my $genres = shift;
+	foreach (Slim::Music::Info::splitTag(uc($genres))) {
+		return 1 if $myClassicalGenreMap{$_}
+	}
+	return 0;
+}
+
+sub myClassicalGenreIds {
+	if ( !$myClassicalGenreIds ) {
+		my @genreNames = keys %myClassicalGenreMap;
+		my $dbh = Slim::Schema->dbh;
+		my $sql = 'SELECT GROUP_CONCAT(id) FROM genres WHERE UPPER(name) IN (' . join(', ', map {'?'} @genreNames) . ')';
+		my $sth = $dbh->prepare_cached($sql);
+		$sth->execute(@genreNames);
+		($myClassicalGenreIds) = $sth->fetchrow_array;
+		$sth->finish;
+	Slim::Utils::Log::logError("DK \$myClassicalGenreIds=" . Data::Dump::dump($myClassicalGenreIds));
+	}
+	return $myClassicalGenreIds;
 }
 
 sub url {

--- a/Slim/Schema/Genre.pm
+++ b/Slim/Schema/Genre.pm
@@ -64,7 +64,6 @@ sub myClassicalGenreIds {
 		$sth->execute(@genreNames);
 		($myClassicalGenreIds) = $sth->fetchrow_array;
 		$sth->finish;
-	Slim::Utils::Log::logError("DK \$myClassicalGenreIds=" . Data::Dump::dump($myClassicalGenreIds));
 	}
 	return $myClassicalGenreIds;
 }

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -194,7 +194,7 @@ sub init {
 		'ignoreReleaseTypes'    => 0,
 		'groupArtistAlbumsByReleaseType' => 0,
 		'showComposerReleasesbyAlbum' => 2,
-		'showComposerReleasesbyAlbumGenres' => "Classical, Klassik, Classique, Klassiek",
+		'myClassicalGenres' => "Classical, Klassik, Classique, Klassiek",
 		'ratingImplementation'  => 'LOCAL_RATING_STORAGE',
 		# Server Settings - FileTypes
 		'disabledextensionsaudio'    => '',
@@ -275,7 +275,7 @@ sub init {
 		'composerAlbumLink'     => $prefs->get('useUnifiedArtistsList') && $prefs->get('composerInArtists'),
 		'conductorAlbumLink'    => $prefs->get('useUnifiedArtistsList') && $prefs->get('conductorInArtists'),
 		'bandAlbumLink'         => $prefs->get('useUnifiedArtistsList') && $prefs->get('bandInArtists'),
-		'worksScanOnlyClassical'=> 0,
+		'worksScan'=> 0,
 	);
 
 	# we can have different defaults depending on the OS
@@ -403,8 +403,14 @@ sub init {
 
 	$prefs->setChange(
 		sub { Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]) },
-		qw(splitList groupdiscs useTPE2AsAlbumArtist cleanupReleaseTypes worksScanOnlyClassical)
+		qw(splitList groupdiscs useTPE2AsAlbumArtist cleanupReleaseTypes worksScan)
 	);
+
+	$prefs->setChange( sub {
+		if ( $prefs->get('worksScan') == 1 ) {
+			Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]);
+		}
+	}, 'myClassicalGenres' );
 
 	$prefs->setChange( sub {
 		my $newRoles = $_[1];

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -194,7 +194,7 @@ sub init {
 		'ignoreReleaseTypes'    => 0,
 		'groupArtistAlbumsByReleaseType' => 0,
 		'showComposerReleasesbyAlbum' => 2,
-		'myClassicalGenres' => "Classical, Klassik, Classique, Klassiek",
+		'myClassicalGenres' => $prefs->get("showComposerReleasesbyAlbumGenres") || "Classical, Klassik, Classique, Klassiek",
 		'ratingImplementation'  => 'LOCAL_RATING_STORAGE',
 		# Server Settings - FileTypes
 		'disabledextensionsaudio'    => '',
@@ -275,7 +275,7 @@ sub init {
 		'composerAlbumLink'     => $prefs->get('useUnifiedArtistsList') && $prefs->get('composerInArtists'),
 		'conductorAlbumLink'    => $prefs->get('useUnifiedArtistsList') && $prefs->get('conductorInArtists'),
 		'bandAlbumLink'         => $prefs->get('useUnifiedArtistsList') && $prefs->get('bandInArtists'),
-		'worksScan'=> 0,
+		'worksScan'=> $prefs->get("showComposerReleasesbyAlbum") || 2,
 	);
 
 	# we can have different defaults depending on the OS

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -275,6 +275,7 @@ sub init {
 		'composerAlbumLink'     => $prefs->get('useUnifiedArtistsList') && $prefs->get('composerInArtists'),
 		'conductorAlbumLink'    => $prefs->get('useUnifiedArtistsList') && $prefs->get('conductorInArtists'),
 		'bandAlbumLink'         => $prefs->get('useUnifiedArtistsList') && $prefs->get('bandInArtists'),
+		'worksScanOnlyClassical'=> 0,
 	);
 
 	# we can have different defaults depending on the OS
@@ -402,7 +403,7 @@ sub init {
 
 	$prefs->setChange(
 		sub { Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]) },
-		qw(splitList groupdiscs useTPE2AsAlbumArtist cleanupReleaseTypes)
+		qw(splitList groupdiscs useTPE2AsAlbumArtist cleanupReleaseTypes worksScanOnlyClassical)
 	);
 
 	$prefs->setChange( sub {

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -407,7 +407,8 @@ sub init {
 	);
 
 	$prefs->setChange( sub {
-		if ( $prefs->get('worksScan') == 1 ) {
+		Slim::Schema::Genre->loadMyClassicalGenreMap();
+		if ( $prefs->get('worksScan') == 2 ) {
 			Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]);
 		}
 	}, 'myClassicalGenres' );

--- a/Slim/Web/Settings/Server/Behavior.pm
+++ b/Slim/Web/Settings/Server/Behavior.pm
@@ -30,8 +30,8 @@ sub prefs {
 				variousArtistAutoIdentification
 				ignoreReleaseTypes cleanupReleaseTypes groupArtistAlbumsByReleaseType
 				useTPE2AsAlbumArtist variousArtistsString ratingImplementation useUnifiedArtistsList
-				skipsentinel showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears
-				worksScanOnlyClassical)
+				skipsentinel showComposerReleasesbyAlbum myClassicalGenres onlyAlbumYears
+				worksScan)
 		   );
 }
 

--- a/Slim/Web/Settings/Server/Behavior.pm
+++ b/Slim/Web/Settings/Server/Behavior.pm
@@ -30,7 +30,8 @@ sub prefs {
 				variousArtistAutoIdentification
 				ignoreReleaseTypes cleanupReleaseTypes groupArtistAlbumsByReleaseType
 				useTPE2AsAlbumArtist variousArtistsString ratingImplementation useUnifiedArtistsList
-				skipsentinel showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears)
+				skipsentinel showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears
+				worksScanOnlyClassical)
 		   );
 }
 

--- a/Slim/Web/XMLBrowser.pm
+++ b/Slim/Web/XMLBrowser.pm
@@ -42,7 +42,7 @@ if ( !main::SCANNER ) {
 
 	$prefs->setChange( \&wipeCaches, qw(itemsPerPage thumbSize showArtist showYear additionalPlaylistButtons noGenreFilter noRoleFilter searchSubString browseagelimit
 		composerInArtists conductorInArtists bandInArtists trackartistInArtists variousArtistAutoIdentification titleFormat titleFormatWeb language useUnifiedArtistsList
-		groupArtistAlbumsByReleaseType ignoreReleaseTypes releaseTypesToIgnore showComposerReleasesbyAlbum showComposerReleasesbyAlbumGenres onlyAlbumYears userDefinedRoles
+		groupArtistAlbumsByReleaseType ignoreReleaseTypes releaseTypesToIgnore showComposerReleasesbyAlbum myClassicalGenres onlyAlbumYears userDefinedRoles
 		artistAlbumLink albumartistAlbumLink trackartistAlbumLink composerAlbumLink conductorAlbumLink bandAlbumLink) );
 }
 

--- a/strings.txt
+++ b/strings.txt
@@ -10422,14 +10422,14 @@ SETUP_RELEASE_TYPES_COMPOSER_ROLE_GROUPING_1
 	ES	Crear siempre un grupo de Álbum de compositor
 
 SETUP_RELEASE_TYPES_COMPOSER_ROLE_GROUPING_2
-	CS	fix! Vytvořit pro tyto žánry skupinu Alba skladatele:
-	DA	fix! Opret en Composer Album gruppe for følgende genrer:
+	CS	Vytvoření skupiny Skladatelské album pro "Moje klasické žánry" (výše)
+	DA	Opret en komponistalbumgruppe for "Mine klassiske genrer" (ovenfor)
+	DE	Erstellen einer Komponistenalbengruppe für "Meine klassischen Genres" (oben)
 	EN	Create a Composer Album group for "My classical genres" (above)
-	FR	fix! Créer un groupe "Albums du compositeur" pour ces genres :
-	DE	fix! Komponistenalbengruppe für diese Stilrichtungen erstellen:
-	HU	fix! Hozzon létre egy zeneszerzői albumcsoportot a következő műfajokhoz:
-	NL	fix! Maak een groep van componistenalbums voor deze genres:
-	ES	fix! Crea un grupo de Álbum de compositor para estos géneros:
+	ES	Crear un grupo de álbumes de compositor para "Mis géneros clásicos" (arriba)
+	FR	Créer un groupe d'albums de compositeur pour « Mes genres classiques » (ci-dessus)
+	HU	Zeneszerzői albumcsoport létrehozása a "Klasszikus műfajaim" számára (fent)
+	NL	Maak een componistenalbumgroep voor 'Mijn klassieke genres' (hierboven)
 
 SETUP_IGNORE_RELEASE_TYPES_0
 	CS	Povolit podporu typu vydání pro alba
@@ -26863,21 +26863,21 @@ SETUP_WORKSSCAN
 	FR	Numérisation d'œuvres classiques
 	NL	Scannen van klassieke werken
 
-SETUP_WORKSSCAN_0
+SETUP_WORKSSCAN_1
 	DE	Durchsuchen Sie die gesamte Bibliothek nach klassischen Werken
 	EN	Scan whole library for classical works
 	ES	Escanea toda la biblioteca en busca de obras clásicas
 	FR	Parcourez toute la bibliothèque à la recherche d'œuvres classiques
 	NL	Scan de hele bibliotheek op klassieke werken
 
-SETUP_WORKSSCAN_1
+SETUP_WORKSSCAN_2
 	DE	Klassik-Scan auf "Meine klassischen Genres" beschränken (oben)
 	EN	Limit classical works scan to "My classical genres" (above)
 	ES	Limitar el escaneo de obras clásicas a "Mis géneros clásicos" (arriba)
 	FR	Limiter le balayage des œuvres classiques à « Mes genres classiques » (ci-dessus)
 	NL	Beperk de scan van klassieke werken tot "Mijn klassieke genres" (hierboven)
 
-SETUP_WORKSSCAN_2
+SETUP_WORKSSCAN_0
 	DE	Nicht nach Werken suchen
 	EN	Do not scan for Works
 	ES	No buscar obras

--- a/strings.txt
+++ b/strings.txt
@@ -26856,3 +26856,21 @@ SETUP_USERDEFINEDROLES_TEXT_PLURAL
 	HU	Szöveg megjelenítése (többes számú)
 	NL	Tekst weergeven (meervoud)
 
+SETUP_WORKSSCANONLYCLASSICAL
+	DE	Scannen klassischer Werke
+	EN	Classical Works Scanning
+	ES	Escaneo de Obras Clásicas
+	FR	Numérisation d'œuvres classiques
+
+SETUP_WORKSSCANONLYCLASSICAL_0
+	DE	Durchsuchen Sie die gesamte Bibliothek nach klassischen Werken
+	EN	Scan whole library for classical works
+	ES	Escanea toda la biblioteca en busca de obras clásicas
+	FR	Parcourez toute la bibliothèque à la recherche d'œuvres classiques
+
+SETUP_WORKSSCANONLYCLASSICAL_1
+	DE	Beschränken Sie den Scan klassischer Werke auf das "klassische" Genre
+	EN	Limit classical works scan to "classical" genre
+	ES	Limitar el escaneo de obras clásicas al género "clásico"
+	FR	Limiter la numérisation des œuvres classiques au genre « classique »
+

--- a/strings.txt
+++ b/strings.txt
@@ -10422,14 +10422,14 @@ SETUP_RELEASE_TYPES_COMPOSER_ROLE_GROUPING_1
 	ES	Crear siempre un grupo de Álbum de compositor
 
 SETUP_RELEASE_TYPES_COMPOSER_ROLE_GROUPING_2
-	CS	Vytvořit pro tyto žánry skupinu Alba skladatele:
-	DA	Opret en Composer Album gruppe for følgende genrer:
-	EN	Create a Composer Album group for these genres:
-	FR	Créer un groupe "Albums du compositeur" pour ces genres :
-	DE	Komponistenalbengruppe für diese Stilrichtungen erstellen:
-	HU	Hozzon létre egy zeneszerzői albumcsoportot a következő műfajokhoz:
-	NL	Maak een groep van componistenalbums voor deze genres:
-	ES	Crea un grupo de Álbum de compositor para estos géneros:
+	CS	fix! Vytvořit pro tyto žánry skupinu Alba skladatele:
+	DA	fix! Opret en Composer Album gruppe for følgende genrer:
+	EN	Create a Composer Album group for "My classical genres" (above)
+	FR	fix! Créer un groupe "Albums du compositeur" pour ces genres :
+	DE	fix! Komponistenalbengruppe für diese Stilrichtungen erstellen:
+	HU	fix! Hozzon létre egy zeneszerzői albumcsoportot a következő műfajokhoz:
+	NL	fix! Maak een groep van componistenalbums voor deze genres:
+	ES	fix! Crea un grupo de Álbum de compositor para estos géneros:
 
 SETUP_IGNORE_RELEASE_TYPES_0
 	CS	Povolit podporu typu vydání pro alba
@@ -26856,21 +26856,45 @@ SETUP_USERDEFINEDROLES_TEXT_PLURAL
 	HU	Szöveg megjelenítése (többes számú)
 	NL	Tekst weergeven (meervoud)
 
-SETUP_WORKSSCANONLYCLASSICAL
+SETUP_WORKSSCAN
 	DE	Scannen klassischer Werke
-	EN	Classical Works Scanning
-	ES	Escaneo de Obras Clásicas
+	EN	Classical works scanning
+	ES	Escaneo de obras clásicas
 	FR	Numérisation d'œuvres classiques
+	NL	Scannen van klassieke werken
 
-SETUP_WORKSSCANONLYCLASSICAL_0
+SETUP_WORKSSCAN_0
 	DE	Durchsuchen Sie die gesamte Bibliothek nach klassischen Werken
 	EN	Scan whole library for classical works
 	ES	Escanea toda la biblioteca en busca de obras clásicas
 	FR	Parcourez toute la bibliothèque à la recherche d'œuvres classiques
+	NL	Scan de hele bibliotheek op klassieke werken
 
-SETUP_WORKSSCANONLYCLASSICAL_1
-	DE	Beschränken Sie den Scan klassischer Werke auf das "klassische" Genre
-	EN	Limit classical works scan to "classical" genre
-	ES	Limitar el escaneo de obras clásicas al género "clásico"
-	FR	Limiter la numérisation des œuvres classiques au genre « classique »
+SETUP_WORKSSCAN_1
+	DE	Klassik-Scan auf "Meine klassischen Genres" beschränken (oben)
+	EN	Limit classical works scan to "My classical genres" (above)
+	ES	Limitar el escaneo de obras clásicas a "Mis géneros clásicos" (arriba)
+	FR	Limiter le balayage des œuvres classiques à « Mes genres classiques » (ci-dessus)
+	NL	Beperk de scan van klassieke werken tot "Mijn klassieke genres" (hierboven)
+
+SETUP_WORKSSCAN_2
+	DE	Nicht nach Werken suchen
+	EN	Do not scan for Works
+	ES	No buscar obras
+	FR	Ne pas rechercher d'œuvres
+	NL	Niet scannen op werken
+
+SETUP_MYCLASSICALGENRES
+	DE	Meine klassischen Genres
+	EN	My classical genres
+	ES	Mis géneros clásicos
+	FR	Mes genres classiques
+	NL	Mijn klassieke genres
+
+SETUP_MYCLASSICALGENRES_DESC
+	DE	Verwenden Sie diese Genres, um klassische Musik zu identifizieren
+	EN	Use these genres to identify classical music
+	ES	Utiliza estos géneros para identificar la música clásica
+	FR	Utilisez ces genres pour identifier la musique classique
+	NL	Gebruik deze genres om klassieke muziek te identificeren
 


### PR DESCRIPTION
To make things better for those using MusicBrainz, where they might get Work tags for non-classical tracks, which have a completely different meaning (eg Sometimes Work is the base track, Title is the specific mix/cover version). See https://forums.slimdevices.com/forum/user-forums/3rd-party-software/106269-announce-material-skin?p=1738324#post1738324

Obviously, classical stuff will need to be tagged "Classical" as well as more specific sub-genres, but I think that is generally the case.