### PR TITLE
Squeezebox.pm: fix method name for spdr protocol handler

### DIFF
--- a/Slim/Player/Squeezebox.pm
+++ b/Slim/Player/Squeezebox.pm
@@ -792,7 +792,7 @@ sub stream_s {
 		main::INFOLOG && logger('player.streaming.direct')->info("SqueezePlay direct stream: $url");
 
 		my $methodHandler = $currentTrackHandler->can('requestString') ? $currentTrackHandler : $handler;
-		$request_string = $methodHandler->getRequestString($client, $url, undef, $params->{'seekdata'} || $controller->song->seekdata);
+		$request_string = $methodHandler->requestString($client, $url, undef, $params->{'seekdata'} || $controller->song->seekdata);
 		$autostart += 2; # will be 2 for direct streaming with no autostart, or 3 for direct with autostart
 
 	} elsif (my $proxy = $params->{'proxyStream'}) {


### PR DESCRIPTION
This reverts a change from https://github.com/LMS-Community/slimserver/commit/828675e93bfbb6cc59068d926402d2a2d372a2f1 which I believe was done by mistake and broke spdr:// protocol handling.

Closes https://github.com/LMS-Community/slimserver/issues/1164