### PR TITLE
 More releases rework

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -932,7 +932,7 @@ sub albumsQuery {
 				my $rolesRef;
 				my $contributorRoleSql = "SELECT role FROM contributor_album WHERE album = ?";
 				if ( $contributorID ) {
-					$contributorRoleSql .= " AND contributor = ?" if $contributorID;
+					$contributorRoleSql .= " AND contributor = ?";
 					$contributorRoleSth ||= $dbh->prepare_cached($contributorRoleSql);
 					$rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'}, $contributorID);
 				} else {

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -929,9 +929,16 @@ sub albumsQuery {
 			}
 
 			if ( $tags =~ /R/ ) {
-				$contributorRoleSth ||= $dbh->prepare_cached("SELECT role FROM contributor_album WHERE album = ? AND contributor = ?");
-				my $rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'}, $contributorID || $c->{'albums.contributor'});
-
+				my $rolesRef;
+				my $contributorRoleSql = "SELECT role FROM contributor_album WHERE album = ?";
+				if ( $contributorID ) {
+					$contributorRoleSql .= " AND contributor = ?" if $contributorID;
+					$contributorRoleSth ||= $dbh->prepare_cached($contributorRoleSql);
+					$rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'}, $contributorID);
+				} else {
+					$contributorRoleSth ||= $dbh->prepare_cached($contributorRoleSql);
+					$rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'});
+				}
 				if ($rolesRef) {
 					my $roles = join(',', map { $_->[0] } @$rolesRef);
 					$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'role_ids', $roles);

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -931,12 +931,11 @@ sub albumsQuery {
 			if ( $tags =~ /R/ ) {
 				my $rolesRef;
 				my $contributorRoleSql = "SELECT role FROM contributor_album WHERE album = ?";
+				$contributorRoleSql .= " AND contributor = ?" if $contributorID;
+				$contributorRoleSth ||= $dbh->prepare_cached($contributorRoleSql);
 				if ( $contributorID ) {
-					$contributorRoleSql .= " AND contributor = ?";
-					$contributorRoleSth ||= $dbh->prepare_cached($contributorRoleSql);
 					$rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'}, $contributorID);
 				} else {
-					$contributorRoleSth ||= $dbh->prepare_cached($contributorRoleSql);
 					$rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'});
 				}
 				if ($rolesRef) {

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -934,9 +934,9 @@ sub albumsQuery {
 				$contributorRoleSql .= " AND contributor = ?" if $contributorID;
 				$contributorRoleSth ||= $dbh->prepare_cached($contributorRoleSql);
 				if ( $contributorID ) {
-					$rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'}, $contributorID);
+					$rolesRef = $dbh->selectall_arrayref( $contributorRoleSth, undef, ($c->{'albums.id'}, $contributorID) );
 				} else {
-					$rolesRef = $dbh->selectall_arrayref($contributorRoleSth, , undef, $c->{'albums.id'});
+					$rolesRef = $dbh->selectall_arrayref( $contributorRoleSth, undef, ($c->{'albums.id'}) );
 				}
 				if ($rolesRef) {
 					my $roles = join(',', map { $_->[0] } @$rolesRef);

--- a/Slim/Menu/BrowseLibrary/Releases.pm
+++ b/Slim/Menu/BrowseLibrary/Releases.pm
@@ -8,6 +8,7 @@ use Slim::Utils::Strings qw(cstring);
 
 # Should we page through results instead of doing one huge bulk request?
 use constant MAX_ALBUMS => 1500;
+use constant LIST_LIMIT => 980; # SQL parameter limit is 999. This is used to limit the number of album_ids passed in. Leave some room for other searchTags.
 
 my $log = logger('database.info');
 my $prefs = preferences('server');
@@ -27,7 +28,7 @@ sub _releases {
 	my @originalSearchTags = @searchTags;
 
 	# map menuRoles to name for readability
-	$menuRoles = join(',', map { Slim::Schema::Contributor->roleToType($_) } split(',', $menuRoles || ''));
+	$menuRoles = join(',', map { Slim::Schema::Contributor->roleToType($_) || $_ } split(',', $menuRoles || ''));
 
 	Slim::Schema::Album->addReleaseTypeStrings();
 
@@ -37,7 +38,7 @@ sub _releases {
 		# library_id:-1 is supposed to clear/override the global library_id
 		$_ && $_ !~ /(?:library_id\s*:\s*-1|remote_library)/
 	} @searchTags;
-	push @searchTags, "role_id:$menuRoles" if $menuRoles;
+	push @searchTags, "role_id:$menuRoles" if $menuRoles && $menuMode ne 'artists';
 
 	my @artistIds = grep /artist_id:/, @searchTags;
 	my $artistId;
@@ -55,10 +56,10 @@ sub _releases {
 	main::INFOLOG && $log->is_info && $log->info("$query ($index, $quantity): tags ->", join(', ', @searchTags));
 
 	# get the artist's albums list to create releases sub-items etc.
-	my $request = Slim::Control::Request->new( undef, [ $query, 0, MAX_ALBUMS, @searchTags ] );
-	$request->execute();
+	my $releasesRequest = Slim::Control::Request->new( undef, [ $query, 0, MAX_ALBUMS, @searchTags ] );
+	$releasesRequest->execute();
 
-	$log->error($request->getStatusText()) if $request->isStatusError();
+	$log->error($releasesRequest->getStatusText()) if $releasesRequest->isStatusError();
 
 	# compile list of release types and contributions
 	my %releaseTypes;
@@ -69,43 +70,43 @@ sub _releases {
 	my $checkComposerGenres = !( $menuMode && $menuMode ne 'artists' && $menuRoles ) && $prefs->get('showComposerReleasesbyAlbum') == 2;
 	my $allComposers = ( $menuMode && $menuMode ne 'artists' && $menuRoles ) || $prefs->get('showComposerReleasesbyAlbum') == 1;
 
-	foreach (@{ $request->getResult('albums_loop') || [] }) {
+	foreach my $release (@{ $releasesRequest->getResult('albums_loop') || [] }) {
 
 		# map to role's name for readability
-		$_->{role_ids} = join(',', map { Slim::Schema::Contributor->roleToType($_) } split(',', $_->{role_ids} || ''));
-		my ($defaultRoles, $userDefinedRoles) = Slim::Schema::Contributor->splitDefaultAndCustomRoles($_->{role_ids});
+		$release->{role_ids} = join(',', map { Slim::Schema::Contributor->roleToType($_) } split(',', $release->{role_ids} || ''));
+		my ($defaultRoles, $userDefinedRoles) = Slim::Schema::Contributor->splitDefaultAndCustomRoles($release->{role_ids});
 
 		my $genreMatch = undef;
 		if ( $checkComposerGenres ) {
-			my $request = Slim::Control::Request->new( undef, [ 'genres', 0, MAX_ALBUMS, 'album_id:' . $_->{id} ] );
-			$request->execute();
+			my $genresRequest = Slim::Control::Request->new( undef, [ 'genres', 0, MAX_ALBUMS, 'album_id:' . $release->{id} ] );
+			$genresRequest->execute();
 
-			if ($request->isStatusError()) {
-				$log->error($request->getStatusText());
+			if ($genresRequest->isStatusError()) {
+				$log->error($genresRequest->getStatusText());
 			}
 			else {
-				foreach my $genre (@{$request->getResult('genres_loop')}) {
+				foreach my $genre (@{$genresRequest->getResult('genres_loop')}) {
 					last if $genreMatch = Slim::Schema::Genre->isMyClassicalGenre($genre->{genre});
 				}
 			}
 		}
 
 		my $addToMainReleases = sub {
-			$isPrimaryArtist{$_->{id}}++;
-			$releaseTypes{$_->{release_type}}++;
-			$albumList{$_->{release_type}} ||= [];
-			push @{$albumList{$_->{release_type}}}, $_->{id};
+			$isPrimaryArtist{$release->{id}}++;
+			$releaseTypes{$release->{release_type}}++;
+			$albumList{$release->{release_type}} ||= [];
+			push @{$albumList{$release->{release_type}}}, $release->{id};
 		};
 
 		my $addUserDefinedRoles = sub {
 			foreach my $role ( split(',', $userDefinedRoles || '') ) {
 				$contributions{$role} ||= [];
-				push @{$contributions{$role}}, $_->{id};
+				push @{$contributions{$role}}, $release->{id};
 			}
 		};
 
-		if ($_->{compilation}) {
-			$_->{release_type} = 'COMPILATION';
+		if ($release->{compilation}) {
+			$release->{release_type} = 'COMPILATION';
 			$addToMainReleases->();
 			# only list default roles outside the compilations if Composer/Conductor
 			if ( $defaultRoles !~ /COMPOSER|CONDUCTOR/ || $defaultRoles =~ /ARTIST|BAND/ ) {
@@ -122,7 +123,7 @@ sub _releases {
 		# Consider this artist the main (album) artist if there's no other, defined album artist
 		elsif ( $defaultRoles =~ /ARTIST/ ) {
 			my $albumArtist = Slim::Schema->first('ContributorAlbum', {
-				album => $_->{id},
+				album => $release->{id},
 				role  => Slim::Schema::Contributor->typeToRole('ALBUMARTIST'),
 				contributor => { '!=' => $artistId }
 			});
@@ -137,14 +138,14 @@ sub _releases {
 		# Default roles on other releases
 		foreach my $role ( grep { $_ ne 'ALBUMARTIST' } split(',', $defaultRoles || '') ) {
 			# don't list as trackartist, if the artist is albumartist, too
-			next if $role eq 'TRACKARTIST' && $isPrimaryArtist{$_->{id}};
+			next if $role eq 'TRACKARTIST' && $isPrimaryArtist{$release->{id}};
 
 			if ( $role eq 'COMPOSER' && ( $genreMatch || $allComposers ) ) {
 				$role = 'COMPOSERALBUM';
 			}
 
 			$contributions{$role} ||= [];
-			push @{$contributions{$role}}, $_->{id};
+			push @{$contributions{$role}}, $release->{id};
 		}
 
 		# User-defined roles
@@ -165,53 +166,71 @@ sub _releases {
 		!$primaryReleaseTypes{$_};
 	} keys %releaseTypes);
 
+	my $limitList = sub {
+		my $list = shift;
+		my $name = shift;
+		my $albumCount = scalar @$list;
+		if ( $albumCount > LIST_LIMIT ) {
+			splice @$list, LIST_LIMIT;
+			$name .= ' (' . cstring($client, 'FIRST') . ' ' . LIST_LIMIT . ' ' . cstring($client, 'ALBUMS') .')';
+		}
+		return $list, $name;
+	};
+
 	foreach my $releaseType (@sortedReleaseTypes) {
-		my $name = Slim::Schema::Album->releaseTypeName($releaseType, $client);
 
 		if ($releaseTypes{uc($releaseType)}) {
+			my $name = Slim::Schema::Album->releaseTypeName($releaseType, $client);
+			($albumList{$releaseType}, $name) = $limitList->($albumList{$releaseType}, $name);
 			$pt->{'searchTags'} = $releaseType eq 'COMPILATION'
-				? [@searchTags, 'compilation:1']
-				: [@searchTags, "compilation:0", "release_type:$releaseType"];
+				? [@searchTags, 'compilation:1', "album_id:" . join(',', @{$albumList{$releaseType}})]
+				: [@searchTags, "compilation:0", "release_type:$releaseType", "album_id:" . join(',', @{$albumList{$releaseType}})];
 			push @items, _createItem($name, [{%$pt}]);
 		}
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSERALBUM}) {
-		$pt->{'searchTags'} = [@searchTags, "role_id:COMPOSER"];
-		push @items, _createItem(cstring($client, 'COMPOSERALBUMS'), [{%$pt}]);
+		my $name = cstring($client, 'COMPOSERALBUMS');
+		($albumIds, $name) = $limitList->($albumIds, $name);
+		$pt->{'searchTags'} = [@searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)];
+		push @items, _createItem($name, [{%$pt}]);
 	}
 
 	if (my $albumIds = delete $contributions{COMPOSER}) {
+		my $name = cstring($client, 'COMPOSITIONS');
+		($albumIds, $name) = $limitList->($albumIds, $name);
 		push @items, {
-			name        => cstring($client, 'COMPOSITIONS'),
+			name        => $name,
 			image       => 'html/images/playlists.png',
 			type        => 'playlist',
 			playlist    => \&_tracks,
 			# for compositions we want to have the compositions only, not the albums
 			url         => \&_tracks,
-			passthrough => [ { searchTags => [@searchTags, "role_id:COMPOSER"] } ],
+			passthrough => [ { searchTags => [@searchTags, "role_id:COMPOSER", "album_id:" . join(',', @$albumIds)] } ],
 		};
 	}
 
 	if (my $albumIds = delete $contributions{TRACKARTIST}) {
-		$pt->{'searchTags'} = [@searchTags, "role_id:TRACKARTIST"];
-		push @items, _createItem(cstring($client, 'APPEARANCES'), [{%$pt}]);
+		my $name = cstring($client, 'APPEARANCES');
+		($albumIds, $name) = $limitList->($albumIds, $name);
+		$pt->{'searchTags'} = [@searchTags, "role_id:TRACKARTIST", "album_id:" . join(',', @$albumIds)];
+		push @items, _createItem($name, [{%$pt}]);
 	}
 
 	foreach my $role (sort keys %contributions) {
 		my $name = cstring($client, $role) if Slim::Utils::Strings::stringExists($role);
-		$pt->{'searchTags'} = [@searchTags, "role_id:$role"];
-		push @items, _createItem($name || ucfirst($role), [{%$pt}]);
+		($contributions{$role}, $name) = $limitList->($contributions{$role}, $name || ucfirst($role));
+		$pt->{'searchTags'} = [@searchTags, "role_id:$role", "album_id:" . join(',', @{$contributions{$role}})];
+		push @items, _createItem($name, [{%$pt}]);
 	}
 
 	# Add item for Classical Works if the artist has any.
 	push @searchTags, "role_id:$menuRoles" if $menuRoles && $menuMode && $menuMode ne 'artists';
 	push @searchTags, "genre_id:" . Slim::Schema::Genre->myClassicalGenreIds() if $checkComposerGenres;
 	main::INFOLOG && $log->is_info && $log->info("works ($index, $quantity): tags ->", join(', ', @searchTags));
-	my $requestRef = [ 'works', 0, MAX_ALBUMS, @searchTags ];
-	my $request = Slim::Control::Request->new( $client ? $client->id() : undef, $requestRef );
-	$request->execute();
-	$log->error($request->getStatusText()) if $request->isStatusError();
+	my $worksRequest = Slim::Control::Request->new( undef, [ 'works', 0, MAX_ALBUMS, @searchTags ] );
+	$worksRequest->execute();
+	$log->error($worksRequest->getStatusText()) if $worksRequest->isStatusError();
 
 	push @items, {
 		name        => cstring($client, 'WORKS_CLASSICAL'),
@@ -220,7 +239,7 @@ sub _releases {
 		playlist    => \&_tracks,
 		url         => \&_works,
 		passthrough => [ { searchTags => [@searchTags, "work_id:-1", "wantMetadata:1", "wantIndex:1"] } ],
-	} if ( $request->getResult('count') > 1 || ( scalar @items && $request->getResult('count') ) );
+	} if ( $worksRequest->getResult('count') > 1 || ( scalar @items && $worksRequest->getResult('count') ) );
 
 	# restore original search tags
 	$pt->{'searchTags'} = [@originalSearchTags];

--- a/strings.txt
+++ b/strings.txt
@@ -26924,3 +26924,10 @@ SETUP_MYCLASSICALGENRES_DESC
 	FR	Précisez les genres concernés par les œuvres et les compositeurs. Séparez-les par des virgules.
 	NL	Gebruik deze genres voor werken en albums van componisten. Scheid met komma's.
 
+FIRST_N_ALBUMS
+	DE	(erste %s Alben)
+	EN	(first %s albums)
+	ES	(primeros %s álbumes)
+	FR	(premiers %s albums)
+	NL	(eerste %s albums)
+


### PR DESCRIPTION
Looking into https://forums.lyrion.org/forum/user-forums/logitech-media-server/1746593-9-0-2-albums-search-query-fails I found that at some point in the many versions of `Releases.pm` the `album_id` array (introduced by me!) became redundant.

At least, I can't find any differences in the results from `albumsQuery`.

This also fixes the bug where the search parameter was being ignored. And another one I found when testing: the `/R/` tag wasn't working properly when no `artist_id` was passed, it was using only `albums.contributor` to find the required roles, which meant that other roles for the album were not being passed back.

I also simplified the main `$request` which drives `_releases`: `$menuRoles` is already added to `@searchTags` and the alternative of adding all roles to the request is unnecessary (and might be causing an explosion in the number of contributors added to `artists` and `artist_ids` returned by `albumsQuery`).

Once this gets past pre-merge testing, we should ask users of 9.0.2 to give release types in Default Skin a good going over.