### PR TITLE
Return contiguous/non-contiguous flag in statusQuery

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4319,7 +4319,7 @@ sub statusQuery {
 						my $groupSeen = {};
 						# determine whether album group contains contiguous or non-contiguous groups of tracks
 						foreach my $track ( sort { $a <=> $b } keys %{$groups{$albumGroup}} ) {
-							my $thisTrackGroup = $groups{$albumGroup}{$track};
+							my $thisTrackGroup = $groups{$albumGroup}->{$track};
 							if ( $previousGroup ne $thisTrackGroup ) {
 								if ( $nonContiguous = $groupSeen->{$thisTrackGroup} && $thisTrackGroup ne '####' ) {
 									last;


### PR DESCRIPTION
To allow proper handling of albums with non-contiguous track groups in the "album style" play queue (Material only for now, but there's always hope...)

It's all conditioned by the /2/ tag.

I've coded the corresponding Material changes and will submit a PR for that when we've ironed out the wrinkles in this one.