### PR TITLE
Don't add contributor role to album links when browsing a contributor

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -778,7 +778,7 @@ sub albumsQuery {
 			} else {
 				my @linkRoles = Slim::Schema::Contributor->allAlbumLinkRoles();
 				# when filtering by role and not by contributor, put that role at the head of the list if it wasn't in there yet
-				if ($roleID & !$contributorID) {
+				if ($roleID && !$contributorID) {
 					unshift @linkRoles, map { Slim::Schema::Contributor->roleToType($_) || $_ } split(/,/, $roleID);
 					@linkRoles = Slim::Utils::Misc::uniq(@linkRoles);
 				}

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -777,8 +777,8 @@ sub albumsQuery {
 				join(',', @linkRoleIds));
 			} else {
 				my @linkRoles = Slim::Schema::Contributor->allAlbumLinkRoles();
-				# when filtering by role, put that role at the head of the list if it wasn't in there yet
-				if ($roleID) {
+				# when filtering by role and not by contributor, put that role at the head of the list if it wasn't in there yet
+				if ($roleID & !$contributorID) {
 					unshift @linkRoles, map { Slim::Schema::Contributor->roleToType($_) || $_ } split(/,/, $roleID);
 					@linkRoles = Slim::Utils::Misc::uniq(@linkRoles);
 				}


### PR DESCRIPTION
As raised by Frank here: https://forums.lyrion.org/forum/developer-forums/developers/1753452-artists-named-on-appearances-and-composer-tabs

Makes sense to me.