### PR TITLE
Fixes for Musicbrainz ID processing

### DIFF
--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -315,7 +315,7 @@ sub readTags {
 				foreach my $mbID ( Slim::Music::Info::splitTag($value) ) {
 					if ( $tag eq 'MUSICBRAINZ_DISCID' && $mbID =~ /^[0-9a-z_\.-]{28}$/i ) {
 						push @mbIDs, lc($1);
-					} elsif ( $mbID =~ /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i ) {
+					} elsif ( $mbID =~ /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i ) {
 						push @mbIDs, lc($1);
 					}
 					else {
@@ -327,9 +327,10 @@ sub readTags {
 					}
 				}
 				$tags->{$tag} = \@mbIDs;
+				$tagCache{$original} = \@mbIDs;
+			} else {
+				$tagCache{$original} = $value;
 			}
-
-			$tagCache{$original} = $value;
 		}
 
 		main::DEBUGLOG && $isDebug && $value && $log->debug(". $tag : $value");

--- a/Slim/Formats.pm
+++ b/Slim/Formats.pm
@@ -326,11 +326,10 @@ sub readTags {
 						next TAG;
 					}
 				}
-				$tags->{$tag} = \@mbIDs;
-				$tagCache{$original} = \@mbIDs;
-			} else {
-				$tagCache{$original} = $value;
+				$value = $tags->{$tag} = \@mbIDs;
 			}
+
+			$tagCache{$original} = $value;
 		}
 
 		main::DEBUGLOG && $isDebug && $value && $log->debug(". $tag : $value");

--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -1008,7 +1008,7 @@ sub splitTag {
 
 	# Handle Vorbis comments where the tag can be an array.
 	if (ref($tag) eq 'ARRAY') {
-
+		map { $_ =~ s/^\s+|\s+$//g; } @$tag;
 		return @$tag;
 	}
 
@@ -1061,6 +1061,7 @@ sub splitTag {
 		return @splitTags;
 	}
 
+	$tag =~ s/^\s+|\s+$//g;
 	return $tag;
 }
 

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -912,7 +912,7 @@ sub _createOrUpdateAlbum {
 	my $disc      = $attributes->{DISC};
 	my $discc     = $attributes->{DISCC};
 	# Bug 10583 - Also check for MusicBrainz Album Id
-	my $brainzId  = $attributes->{MUSICBRAINZ_ALBUM_ID};
+	my $brainzId  = $attributes->{MUSICBRAINZ_ALBUM_ID}[0]; # Surely there is only one MB album id!
 	my $extId     = $attributes->{EXTID} || $attributes->{ALBUM_EXTID};
 
 	# if we have a disc number from an online service, default disc count to 1


### PR DESCRIPTION
See https://forums.lyrion.org/forum/user-forums/logitech-media-server/1754498-lms-splitting-up-mutidisc-albums-in-9-0-2-1739477540

`Slim::Formats::readTags`
Write validated/cleaned up MB tags to `$tagCache`, not the original input tag value.

`Slim::Music::Info::splitTag`
Remove leading/trailing space even when input is an array or a single tag.

`Slim::Schema::_createOrUpdateAlbum`
With the change to `Slim::Formats::readTags`, `$attributes->{MUSICBRAINZ_ALBUM_ID}` will always be an array, but we need a string.