### PR TITLE
Prevent attempt to close invalid socket

### DIFF
--- a/Slim/Player/Client.pm
+++ b/Slim/Player/Client.pm
@@ -562,7 +562,9 @@ sub forgetClient {
 		delete $Slim::Networking::Slimproto::heartbeat{ $client->id };
 
 		# Bug 15860: Force the connection shut if it is not already
-		Slim::Networking::Slimproto::slimproto_close($client->tcpsock()) if defined $client->tcpsock();
+		if (defined $client->tcpsock && ref $client->tcpsock eq "IO::Socket::INET") {
+			Slim::Networking::Slimproto::slimproto_close($client->tcpsock);
+		}
 	}
 }
 


### PR DESCRIPTION
Prevent forgetClient() from passing an invalid socket reference to slimproto_close().

Signed-off-by: SamY <syahres@gmail.com>