### PR TITLE
Try to sort out compound Artist tags from Musicbrainz

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2658,6 +2658,35 @@ sub _preCheckAttributes {
 		}
 	}
 
+	# If we've got an ARTISTS tag, treat it as a reference list of all individual artists associated with the track.
+	# Use it to fix ARTIST, ALBUMARTIST, ARTISTSORT and ALBUMARTISTSORT that may have been tagged by Musicbrainz
+	# with compound values.
+	# eg:
+	#	ALBUMARTIST="Panda Bear & Sonic Boom"
+	#	ARTIST="Panda Bear & Sonic Boom"
+	#	ARTISTS=["Panda Bear", "Sonic Boom"]
+	if ( $attributes->{'ARTISTS'} && ($attributes->{'MUSICBRAINZ_ARTIST_ID'} || $attributes->{'MUSICBRAINZ_ALBUMARTIST_ID'}) ) {
+		my (@newAA, @newA, @newAAS, @newAS);
+		foreach ( Slim::Music::Info::splitTag($attributes->{'ARTISTS'}) ) {
+			if ( $attributes->{'ALBUMARTIST'} && $attributes->{'ALBUMARTIST'} =~ $_ ) {
+				push @newAA, $_;
+			}
+			if ( $attributes->{'ARTIST'} && $attributes->{'ARTIST'} =~ $_ ) {
+				push @newA, $_;
+			}
+			if ( $attributes->{'ALBUMARTISTSORT'} && $attributes->{'ALBUMARTISTSORT'} =~ $_ ) {
+				push @newAAS, $_;
+			}
+			if ( $attributes->{'ARTISTSORT'} && $attributes->{'ARTISTSORT'} =~ $_ ) {
+				push @newAS, $_;
+			}
+		}
+		$attributes->{'ALBUMARTIST'} = \@newAA if scalar @newAA;
+		$attributes->{'ARTIST'} = \@newA if scalar @newA;
+		$attributes->{'ALBUMARTISTSORT'} = \@newAAS if scalar @newAAS;
+		$attributes->{'ARTISTSORT'} = \@newAS if scalar @newAS;
+	}
+
 	# Bug 9359, don't allow tags named 'ID'
 	if ( exists $attributes->{'ID'} ) {
 		delete $attributes->{'ID'};


### PR DESCRIPTION
See https://forums.lyrion.org/forum/user-forums/logitech-media-server/1755770-possible-bug-with-recent-musicbrainz_album_id-changes?p=1757960#post1757960

Creating this a draft for now, as I think it needs some discussion, especially on the *SORT tags where it would fall down if MB came back with sort tags that were different (as they should often be, otherwise what's the point?)

I don't use MB tags in my own library, so I might put this out for testing in the community before we commit.

But any comments/ideas welcome at this point.