### PR TITLE
Simplify player volume control for JSON clients

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4039,9 +4039,14 @@ sub statusQuery {
 		$request->addResult('digital_volume_control', $digitalVolumeControl + 0);
 	}
 
+	# indicate whether the player's volume control is active
 	my $hasDigitalOut = $client->hasDigitalOut();
-	if ( defined ($hasDigitalOut) ) {
-		$request->addResult('has_digital_out', $hasDigitalOut + 0);		
+	if ( defined($digitalVolumeControl) && defined($hasDigitalOut) ) {
+		my $useVolumeControl = 0;
+		if ($digitalVolumeControl || !$hasDigitalOut) {
+			$useVolumeControl = 1;
+		}
+		$request->addResult('use_volume_control', $useVolumeControl);
 	}
 
 	if ($menuMode || $request->getParam('alarmData')) {

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4042,10 +4042,7 @@ sub statusQuery {
 	# indicate whether the player's volume control is active
 	my $hasDigitalOut = $client->hasDigitalOut();
 	if ( defined($digitalVolumeControl) && defined($hasDigitalOut) ) {
-		my $useVolumeControl = 0;
-		if ($digitalVolumeControl || !$hasDigitalOut) {
-			$useVolumeControl = 1;
-		}
+		my $useVolumeControl = ($digitalVolumeControl || !$hasDigitalOut) ? 1 : 0;
 		$request->addResult('use_volume_control', $useVolumeControl);
 	}
 


### PR DESCRIPTION
After further thought, the determination of whether the player's volume control is active should be made by LMS and not the JSON client.