### PR TITLE
Parse CUE file dates down to just the year

### DIFF
--- a/Slim/Formats/Playlists/CUE.pm
+++ b/Slim/Formats/Playlists/CUE.pm
@@ -399,6 +399,7 @@ sub parse {
 
 	# EAC CUE sheet has REM DATE not REM YEAR, and no quotes
 	_mergeCommand('DATE', 'YEAR', $cuesheet, $cuesheet);
+	$cuesheet->{YEAR} = Slim::Formats->sanitizeYearTag($cuesheet->{YEAR}) if defined $cuesheet->{YEAR};
 
 	for my $key (sort {$a <=> $b} keys %$tracks) {
 
@@ -425,6 +426,7 @@ sub parse {
 
 		# EAC CUE sheet has REM DATE not REM YEAR, and no quotes
 		_mergeCommand('DATE', 'YEAR', $track, $track);
+		$track->{YEAR} = Slim::Formats->sanitizeYearTag($track->{YEAR}) if defined $track->{YEAR};
 
 		_mergeCommand('DISCNUMBER', 'DISC', $track, $track);
 	}


### PR DESCRIPTION
Adds four-digit YEAR parsing into CUE files, which is inline with other formats (FLAC, OGG, MPG, etc.). Works with track and non-track (global) `REM` date fields.

Tested with:
* CUE and a WAV file
* FLAC with embedded cuesheets (dates in the `CUESHEET` comment are processed second and win during conflicts)

Inspired by changes from #1338 and subsequent [forum discussions](https://forums.lyrion.org/forum/user-forums/logitech-media-server/1755770-possible-bug-with-recent-musicbrainz_album_id-changes).