### PR TITLE
Update Source.pm to address alarm bug

### DIFF
--- a/Slim/Player/Source.pm
+++ b/Slim/Player/Source.pm
@@ -56,7 +56,8 @@ sub _returnPlayMode {
 	my $controller = $_[0];
 
 	# Should reall find out if the player is active in the sync-group but too expensive
-	return 'stop' if !$_[1]->power();
+	# 13 March, 2025 -- propose removing following line -- player can be isPaused.  Accuracy needed for alarm code
+#	return 'stop' if !$_[1]->power();
 
 	my $returnedmode = $controller->isStopped ? 'stop'
 						: $controller->isPaused ? 'pause' : 'play';


### PR DESCRIPTION
Comment out line in _returnPlayMode that returns 'stop' without confirming that player is stopped.
If player actually paused, then alarm process will resume player, not start streaming.  Start is required for server to notify the remote device.  Without notification the backup alarm.mp3 will start playing after 60 seconds.