### PR TITLE
Use ORIGINALDATE tag with Flac

### DIFF
--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -57,6 +57,7 @@ my %tagMapping = (
 	'MUSICBRAINZ_TRMID'         => 'MUSICBRAINZ_TRM_ID',
 	'DESCRIPTION'               => 'COMMENT',
 	'ORIGINALYEAR'              => 'YEAR',
+	'ORIGINALDATE'              => 'DATE',
 	'UNSYNCEDLYRICS'            => "LYRICS",
 
 	# J.River once again.. can't these people use existing standards?


### PR DESCRIPTION
The MusicBrainz-supported ORIGINALDATE was added to Ogg with 3beabe26.

A simple followup to #1347. Local testing with Picard-tagged Flacs looked fine and works with the recent year parsing.

ORIGINALYEAR was already in place for FLAC's `tagMapping`, so I followed the precedent. ORIGINALDATE is listed on MusicBrainz's [Basic Tags](https://picard-docs.musicbrainz.org/en/variables/tags_basic.html).