### PR TITLE
Update ConnectionManager.pm to add checks for Wav and Opus

### DIFF
--- a/Slim/Plugin/UPnP/MediaRenderer/ConnectionManager.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ConnectionManager.pm
@@ -153,6 +153,8 @@ sub _sinkProtocols {
 		my $hasWMAP = grep { /wmap/ } @cf;
 		my $hasOgg = grep { /ogg/ } @cf;
 		my $hasFLAC = grep { /flc/ } @cf;
+  		my $hasWav = grep { /wav/ } @cf;
+		my $hasOpus = grep { /ops/ } @cf;
 
 		# Transcoder-supported formats
 		my $canTranscode = sub {
@@ -228,10 +230,22 @@ sub _sinkProtocols {
 		if ( $hasFLAC || $canTranscode->('flc') ) {
 			# Seeking not supported for remote FLAC content (OP=00)
 			push @formats, (
-				"http-get:*:audio/x-flac:DLNA.ORG_OP=00;DLNA.ORG_FLAGS=$flags",
+				"http-get:*:audio/flac:DLNA.ORG_OP=00;DLNA.ORG_FLAGS=$flags",
 			);
 		}
 
+		if ( $hasWav || $canTranscode->('wav') ) {
+			push @formats, (
+				"http-get:*:audio/wav:DLNA.ORG_PN=WAV;DLNA.ORG_OP=01;DLNA.ORG_FLAGS=$flags",
+			);
+		}
+		if ( $hasOpus || $canTranscode->('ops') ) {
+  			# Seeking not supported for remote Opus content (OP=00)
+			push @formats, (
+				"http-get:*:audio/opus:DLNA.ORG_OP=00;DLNA.ORG_FLAGS=$flags",
+			);
+		}
+  
 		# XXX Disable DLNA stuff for now
 		for ( @formats ) {
 			s/:DLNA.+/:\*/;


### PR DESCRIPTION
Take 2 on the pull request....

Squeezeplay and some of the Squeezeboxes support Wav and Opus but that is not advertised over UPnP. This change fixes that

Currently for Squeezeplay the @cf array is filled with the following formats - alc,aac,ogg,ogf,flc,aif,pcm,mp3,test. This is incorrect as it doesn't actually support pcm and is missing Wav and Opus formats. I can't figure out how to change that. So the $hasWav and $hasOpus are returning false but because canTranscode is returning true they are getting added to the advertised list of formats. This solves an issue I'm having when attempting to play these formats on Squeezebox devices over UPnP.

audio/flac is now the official mimetype for flac instead of audio/x-flac.

https://www.iana.org/assignments/media-types/media-types.xhtml#audio