### PR TITLE
Update AVTransport.pm to move LMS event registration

### DIFF
--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -45,6 +45,11 @@ sub newClient {
 
 	# Initialize all state variables
 	$client->pluginData( AVT => _initialState() );
+
+	# Subscribe to LMS events for this client
+	Slim::Control::Request::subscribe(
+		\&clientEvent, [['playlist']], $client,
+	);
 }
 
 sub disconnectClient { }
@@ -125,11 +130,6 @@ sub clientEvent {
 
 sub subscribe {
 	my ( $class, $client, $uuid ) = @_;
-
-	# Subscribe to events for this client
-	Slim::Control::Request::subscribe(
-		\&clientEvent, [['playlist']], $client,
-	);
 
 	# Bump the number of subscribers for this client
 	my $pd = $client->pluginData();


### PR DESCRIPTION
Previously the plugin only registered for LMS events when the Control Point subscribed to UPnP events. This meant the play state was not updated for Control Points that did not support UPnP eventing. This change fixes that.