### PR TITLE
Fix: BUG 17980 - Allow item removal even if playlist has only 1 item

### DIFF
--- a/Slim/Menu/TrackInfo.pm
+++ b/Slim/Menu/TrackInfo.pm
@@ -547,7 +547,9 @@ sub addTrack {
 	if ( $cmd eq 'delete' ) {
 
 		# Do not add this item if only one item in playlist
-		return $emptyItemList if Slim::Player::Playlist::count($client) < 2;
+		# BUG: 17980 (2012-06-14) - Allow item removal even if playlist has only 1 item
+		# Just comment out for now in case impact on UI should turn out to be sub-optimal
+		#return $emptyItemList if Slim::Player::Playlist::count($client) < 2;
 
 		$actions = {
 			go => {


### PR DESCRIPTION
At present there is no way to clear a playlist on a Squeezebox Controller if the playlist only contains one item.

The issue has been raised recently in this forum post: [Controller Anomaly](https://forums.lyrion.org/forum/user-forums/squeezebox-duet/1760969-controller-anomaly#post1761026).

It was also raised in 2012, but a proposed solution was rejected because it did not fit the UI vision that existed at that time. [Bug 17980 - Can't remove song from playlist which has just 1 song](https://bugs-archive.lyrion.org/bug-17980.html).

This proposed change deals with the point by restoring the ability to remove a (single) item from a "single item playlist" by adding the "Remove from playlist" context menu item, even when the playlist only that one item.

This option had historically been present, but was removed in commit [Unnecessary items in context menu for current-playlist tracks, 2012-02-22](71e36d4).

I have tested this change on a Squeezebox Controller and a Squeezebox Radio. It works as expected, and I am not aware of any adverse consequences.
