### PR TITLE
Add pcp os Files

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -46,7 +46,7 @@ runs:
       with:
         repository: picoreplayer/lms-update-script
         path: platforms/pcp
-
+        ref: prebuilt_tcz
 
     - name: Set up Docker environment
       if: ${{ startsWith(inputs.build-params, 'docker') }}

--- a/HTML/EN/html/docs/pcp-update.html
+++ b/HTML/EN/html/docs/pcp-update.html
@@ -1,0 +1,34 @@
+[%# Helper web page for piCore and piCorePlayer with instructions as to how to 
+	update slimserver.
+	
+	Revision 1.2
+%]
+
+[% pagetitle = 'How to update your Lyrion Music Server on your pCP system' %]
+[% PROCESS helpheader.html %]
+[% extension = installerFile.match('\.(tcz)$');
+IF extension;
+	distro = extension.0;
+END;
+%]
+<p>On piCore distributions we provide script to download and Update Lyrion Music Server. 
+These will update your local copy of LMS to the latest source code.<p>
+
+<p>The download URL for your Lyrion Music Server has set to the latest installer:</p>
+
+<pre>[% installerFile %]</pre>
+
+<p>Please execute the following steps to bring your Lyrion Music Server installation up to date:</p> 
+
+<ul style="direction: ltr;">
+	<li>Log in to your server machine using your username and password.</li>
+	<li>Run the following command to execute the installer</li>
+	<li><code>sudo [% distro == 'tcz' ? 'lms-update.sh -r ' : 'Error' %] </code></li>
+</ul>
+<br>
+<p>For users of piCorePlayer please use 
+<script language="JavaScript">
+document.write('<a href="' + window.location.protocol + '//' + window.location.hostname + ':80' + '/cgi-bin/lms-update.cgi?ACTION=Nightly' + '" >this Link</a> ' );
+</script></p>
+
+[% PROCESS helpfooter.html %]

--- a/Slim/Utils/OS/Linux.pm
+++ b/Slim/Utils/OS/Linux.pm
@@ -104,6 +104,11 @@ sub getFlavor {
 	} elsif (-f '/etc/synoinfo.conf' || -f '/etc.defaults/synoinfo.conf') {
 
 		return 'Synology DiskStation';
+
+	} elsif ($osName =~ /picoreplayer/ ) {
+
+		return 'piCorePlayer';
+
 	}
 
 	return 'Linux';

--- a/Slim/Utils/OS/Linux.pm
+++ b/Slim/Utils/OS/Linux.pm
@@ -76,7 +76,7 @@ sub getFlavor {
 	# parse new-school operating system identification file if available
 	if (-f '/etc/os-release' && open(OS_RELEASE, '/etc/os-release')) {
 		while (<OS_RELEASE>) {
-			if (/^NAME="(.*?)"/i) {
+			if (/^NAME="?(.*)"?/i) {
 				$osName = lc($1);
 				last;
 			}

--- a/Slim/Utils/OS/pCP.pm
+++ b/Slim/Utils/OS/pCP.pm
@@ -1,0 +1,125 @@
+package Slim::Utils::OS::pCP;
+
+# OS file for pCP https://www.picoreplayer.org
+#
+# Revision 1.1
+# 2017-04-16	Removed /proc from a music path
+#
+# Revision 1.2
+# 2017-08-14    Added Manual Plugin directory at Cache/Plugins
+#
+# Revision 2.0
+# 2025-03-23   Packages now being built by Lyrion.org.  Use default Cache/updates folder
+
+use strict;
+use warnings;
+
+use base qw(Slim::Utils::OS::Linux);
+use File::Spec::Functions qw(catdir);
+
+use constant MAX_LOGSIZE => 1024*1024*1; # maximum log size: 1 MB
+
+sub initDetails {
+	my $class = shift;
+
+	$class->{osDetails} = $class->SUPER::initDetails();
+	$class->{osDetails}->{osName} = 'piCore';
+	return $class->{osDetails};
+}
+
+sub getSystemLanguage { 'EN' }
+
+sub localeDetails {
+	my $lc_ctype = 'utf8';
+	my $lc_time = 'C';
+
+	return ($lc_ctype, $lc_time);
+}
+
+=head2 dirsFor( $dir )
+
+Return OS Specific directories.
+
+Argument $dir is a string to indicate which of the server directories we
+need information for.
+
+pCP Uses a update directory in /tmp and a custom manual plugin folder
+
+=cut
+
+sub dirsFor {
+	my ($class, $dir) = @_;
+
+	my @dirs;
+
+	if ($dir eq 'updates') {
+
+		mkdir UPDATE_DIR unless -d UPDATE_DIR;
+		@dirs = (UPDATE_DIR);
+	}
+	else {
+		@dirs = $class->SUPER::dirsFor($dir);
+
+		if ($dir eq "Plugins") {
+			push @dirs, catdir( Slim::Utils::Prefs::preferences('server')->get('cachedir'), 'Plugins' );
+			unshift @INC, catdir( Slim::Utils::Prefs::preferences('server')->get('cachedir') );
+		}
+	}
+
+	return wantarray() ? @dirs : $dirs[0];
+}
+
+sub canAutoUpdate { 1 }
+sub installerExtension { 'tcz' }
+sub installerOS { 'pcp' }
+
+sub getUpdateParams {
+	my ($class, $url) = @_;
+
+	if ($url) {
+		require File::Slurp;
+
+		my $updateFile = UPDATE_DIR . '/update_url';
+		File::Slurp::write_file($updateFile, $url);
+	}
+
+	return {
+		cb => sub {
+			my ($file) = @_;
+
+			if ($file) {
+				my ($version, $revision) = $file =~ /(\d+\.\d+\.\d+)(?:.*?(\d{5,}))?/;
+				$revision ||= 0;
+				$::newVersion = Slim::Utils::Strings::string('PCP_UPDATE_AVAILABLE', "$version - $revision", $file);
+			}		
+		}
+	};
+}
+
+sub logRotate {
+	# only keep small log files (1MB) because they are in RAM
+	Slim::Utils::OS->logRotate($_[1], MAX_LOGSIZE);
+}
+
+sub ignoredItems {
+	return (
+		'bin'	=> '/',
+		'dev'	=> '/',
+		'etc'	=> '/',
+		'opt'	=> '/',
+		'init'	=> '/',
+		'root'	=> '/',
+		'sbin'	=> '/',
+		'tmp'	=> '/',
+		'var'	=> '/',
+		'lib'	=> '/',
+		'run'	=> '/',
+		'sys'	=> '/',
+		'usr'	=> '/',
+		'proc'  => '/',
+		'lost+found'=> 1,
+	);
+}
+
+1;
+

--- a/Slim/Utils/OS/pCP.pm
+++ b/Slim/Utils/OS/pCP.pm
@@ -18,6 +18,7 @@ use base qw(Slim::Utils::OS::Linux);
 use File::Spec::Functions qw(catdir);
 
 use constant MAX_LOGSIZE => 1024*1024*1; # maximum log size: 1 MB
+use constant UPDATE_DIR => '/tmp/slimupdate';
 
 sub initDetails {
 	my $class = shift;

--- a/Slim/Utils/OSDetect.pm
+++ b/Slim/Utils/OSDetect.pm
@@ -105,6 +105,11 @@ sub init {
 				require Slim::Utils::OS::Synology;
 				$os = Slim::Utils::OS::Synology->new();
 
+			} elsif ($os =~ /piCorePlayer/i) {
+
+				require Slim::Utils::OS::pCP;
+				$os = Slim::Utils::OS::pCP->new();
+
 			} else {
 
 				$os = Slim::Utils::OS::Linux->new();

--- a/strings.txt
+++ b/strings.txt
@@ -26165,6 +26165,14 @@ SERVER_LINUX_UPDATE_AVAILABLE
 	PT	Está disponível uma nova versão do Lyrion Music Server. <a href="updateinfo.html?installerFile=%s" target="update">Clique aqui para mais infromações</a>.
 	SV	En ny version av Lyrion Music Server är tillgänglig (%s). <a href="updateinfo.html?installerFile=%s" target="update">Klicka här för mer information</a>.
 
+PCP_UPDATE_AVAILABLE
+	DE	Eine neue Version von Lyrion Music Server ist verfügbar (%s). <a href="/html/docs/pcp-update.html?installerFile=%s" target="update">Klicken Sie hier für weitere Instruktionen</a>.
+	EN	A new version of Lyrion Music Server is available (%s). <a href="/html/docs/pcp-update.html?installerFile=%s" target="update">Click here for further information</a>.         
+	FR	Une nouvelle version de Lyrion Music Server est disponible (%s). <a href="/html/docs/pcp-update.html?installerFile=%s" target="update">Cliquez ici pour plus d'info</a>.
+	NL	Er is een nieuwe versie van Lyrion Music Server beschikbaar (%s). <a href="/html/docs/pcp-update.html?installerFile=%s" target="update">Klik op hier</a>.
+	NO	En ny versjon av Lyrion Music Server er tilgjengelig (%s). <a href="/html/docs/pcp-update.html?installerFile=%s" target="update">Klikk her for å få mer informasjon</a>.
+	PL	Nowa wersja Lyrion Music Server jest dostępna (%s). <a href="/html/docs/pcp-update.html?installerFile=%s" target="update">Kliknij tutaj w celu uzyskania dodatkowej wiadomości</a>.
+
 SERVER_WINDOWS_UPDATE_AVAILABLE
 	CS	<ul><li>Verze %s – %s je k dispozici pro instalaci.</li><li>Přihlaste se do počítače se spuštěným Lyrion Music Serverem (%s).</li><li>Spusťe <code>%s</code> a postupujte podle pokynů.</li></ul>
 	DA	<ul><li>Version %s - %s er tilgængelig for installation.</li><li>Log ind på computeren som kører Lyrion Music Server (%s).</li><li>Eksekver <code>%s</code> og følg instruktionerne.</li></ul>


### PR DESCRIPTION
These are the updated files for direct support of pCP in the LMS source.   I have changed the name of some of the support files, so they do not conflict with current installations using the current Custom.pm and lms-updates through the NOCPAN tar file.

You can also change the build process as you will no longer need files from https://github.com/piCorePlayer/lms-update-script.

