### PR TITLE
Fix gapless playback (setNextAVTransport)

### DIFF
--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -1430,9 +1430,7 @@ sub typeFromSuffix {
 	my $defaultType = shift || 'unk';
 
 	if (defined $path && $path =~ m%\.([^./]+)$%) {
-		if (exists($suffixes{lc($1)})) {
-			return $suffixes{lc($1)};
-		}
+		return $suffixes{lc($1)} || $defaultType;		
 	}
 
 	return $defaultType;

--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -1430,7 +1430,7 @@ sub typeFromSuffix {
 	my $defaultType = shift || 'unk';
 
 	if (defined $path && $path =~ m%\.([^./]+)$%) {
-		if(exists($suffixes{lc($1)})) {
+		if (exists($suffixes{lc($1)})) {
 			return $suffixes{lc($1)};
 		}
 	}

--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -1430,7 +1430,9 @@ sub typeFromSuffix {
 	my $defaultType = shift || 'unk';
 
 	if (defined $path && $path =~ m%\.([^./]+)$%) {
-		return $suffixes{lc($1)};
+		if(exists($suffixes{lc($1)})) {
+			return $suffixes{lc($1)};
+		}
 	}
 
 	return $defaultType;

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -124,7 +124,7 @@ sub clientEvent {
 					# Remove track that just finished playing. The protocol handler
 					# can only return metadata for currentURI and NextURI, so keep
 					# the playlist limited to those 2 tracks
-					Slim::Player::Playlist::removeTrack($client, 0);
+					$client->execute(["playlist", "delete", 0);
 
 					# change state variables
 					$class->changeState( $client, {
@@ -377,7 +377,7 @@ sub SetNextAVTransportURI {
 		# Next track queued on the control point has changed while
 		# currentURI is still playing. Remove it from the playlist
 		# ready for the updated NextURI.
-		Slim::Player::Playlist::removeTrack($client, 1);
+		$client->execute(["playlist", "delete", 1);
 	}
 
 	if ( exists $args->{NextURI} && $args->{NextURI} eq '' ) {

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -124,7 +124,7 @@ sub clientEvent {
 					# Remove track that just finished playing. The protocol handler
 					# can only return metadata for currentURI and NextURI, so keep
 					# the playlist limited to those 2 tracks
-					$client->execute(["playlist", "delete", 0);
+					$client->execute( [ 'playlist', 'delete', 0 ] );
 
 					# change state variables
 					$class->changeState( $client, {
@@ -377,7 +377,7 @@ sub SetNextAVTransportURI {
 		# Next track queued on the control point has changed while
 		# currentURI is still playing. Remove it from the playlist
 		# ready for the updated NextURI.
-		$client->execute(["playlist", "delete", 1);
+		$client->execute( [ 'playlist', 'delete', 1 ] );
 	}
 
 	if ( exists $args->{NextURI} && $args->{NextURI} eq '' ) {

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -103,7 +103,7 @@ sub clientEvent {
 	# for gapless playback support.
 	if ( $cmd eq 'newsong' ) {
 		my $playlist = Slim::Player::Playlist::playList($client);
-		if( scalar @{$playlist} > 1){
+		if ( scalar @{$playlist} > 1 ){
 			if ( my $song = ($client->playingSong() || $client->streamingSong()) ) {
 
 				my $pd = $client->pluginData();
@@ -114,7 +114,7 @@ sub clientEvent {
 				# Convert URI to protocol handler
 				$currentURI =~ s/^http/upnp/; 
 
-				if( $track->url ne $currentURI){
+				if ( $track->url ne $currentURI ){
 
 					# player has moved on to next track, copy NextURI to CurrentURI
 					$pd->{avt_AVTransportURIMetaData_hash} = $pd->{avt_NextAVTransportURIMetaData_hash};
@@ -247,7 +247,7 @@ sub changeState {
 		}
 	}
 
-	if ($count) {
+	if ( $count ) {
 		main::INFOLOG && $log->is_info && $log->info( $client->id . ' state change: ' . Data::Dump::dump($changed) );
 		$class->sendEvent( $client, $client->id, $changed );
 	}
@@ -400,7 +400,7 @@ sub SetNextAVTransportURI {
 		$upnp_uri =~ s/^http/upnp/;
   
 		# only update if NextURI has changed or it's not queued yet
-		if ($pd->{avt_NextAVTransportURIMetaData_hash} ne $meta || scalar @{$playlist} < 2){
+		if ( $pd->{avt_NextAVTransportURIMetaData_hash} ne $meta || scalar @{$playlist} < 2 ){
 
 			Slim::Music::Info::setBitrate( $upnp_uri, $meta->{res}->{bitrate} );
 			Slim::Music::Info::setDuration( $upnp_uri, $meta->{res}->{secs} );		

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -99,6 +99,45 @@ sub clientEvent {
 		return;
 	}
 
+	# Player jumped to new song, check if NextURI needs to be moved to CurrentURI
+	# for gapless playback support.
+	if ( $cmd eq 'newsong' ) {
+		my $playlist = Slim::Player::Playlist::playList($client);
+		if( scalar @{$playlist} > 1){
+			if ( my $song = ($client->playingSong() || $client->streamingSong()) ) {
+
+				my $pd = $client->pluginData();
+				my $currentURI = $pd->{AVT}->{CurrentTrackURI};
+				my $currentURIMetadata = $pd->{AVT}->{CurrentTrackMetaData};
+				my $track = $song->currentTrack;
+
+				# Convert URI to protocol handler
+				$currentURI =~ s/^http/upnp/; 
+
+				if( $track->url ne $currentURI){
+
+					# player has moved on to next track, copy NextURI to CurrentURI
+					$pd->{avt_AVTransportURIMetaData_hash} = $pd->{avt_NextAVTransportURIMetaData_hash};
+					$currentURI = $pd->{AVT}->{NextAVTransportURI};
+					$currentURIMetadata = $pd->{AVT}->{NextAVTransportURIMetaData};
+
+					# Remove track that just finished playing. The protocol handler
+					# can only return metadata for currentURI and NextURI, so keep
+					# the playlist limited to those 2 tracks
+					Slim::Player::Playlist::removeTrack($client, 0);
+
+					# change state variables
+					$class->changeState( $client, {
+						CurrentTrackURI				=> $currentURI,
+						CurrentTrackMetaData		=> $currentURIMetadata,
+						AVTransportURI				=> $currentURI,
+						AVTransportURIMetaData		=> $currentURIMetadata,
+					} );
+				}
+			}
+		}
+	}
+
 	# Use playmode to handle TransportState changes on any kind of event
 	my $mode = Slim::Player::Source::playmode($client);
 
@@ -330,17 +369,50 @@ sub SetNextAVTransportURI {
 		return [ 718 => 'Invalid InstanceID' ];
 	}
 
-	my $meta = $class->_DIDLLiteToHash( $args->{NextURIMetaData} );
+	my $playlist = Slim::Player::Playlist::playList($client);
+	my $pd = $client->pluginData();
 
-	# XXX parse playlist?
+	if (scalar @{$playlist} > 1 ){
 
-	if ( !$meta->{res} ) {
-		return [ 714 => 'Illegal MIME-type' ];
+		# Next track queued on the control point has changed while
+		# currentURI is still playing. Remove it from the playlist
+		# ready for the updated NextURI.
+		Slim::Player::Playlist::removeTrack($client, 1);
 	}
 
-	# Save hash version of metadata
-	$client->pluginData( avt_NextAVTransportURIMetaData_hash => $meta );
+	if ( exists $args->{NextURI} && $args->{NextURI} eq '' ) {
+	
+		# NextURI is blank, clear metadata
+		$pd->{avt_NextAVTransportURIMetaData_hash} = '';
+		main::DEBUGLOG && $log->is_debug && $log->debug("NextURI cleared");
+	} else {
 
+ 		my $meta = $class->_DIDLLiteToHash( $args->{NextURIMetaData} );
+
+		# XXX parse playlist?
+
+		if ( !$meta->{res} ) {
+			return [ 714 => 'Illegal MIME-type' ];
+		}
+
+		# Convert URI to protocol handler
+		my $upnp_uri = $meta->{res}->{uri};
+		$upnp_uri =~ s/^http/upnp/;
+  
+		# only update if NextURI has changed or it's not queued yet
+		if ($pd->{avt_NextAVTransportURIMetaData_hash} ne $meta || scalar @{$playlist} < 2){
+
+			Slim::Music::Info::setBitrate( $upnp_uri, $meta->{res}->{bitrate} );
+			Slim::Music::Info::setDuration( $upnp_uri, $meta->{res}->{secs} );		
+
+			# Save hash version of metadata
+			$pd->{avt_NextAVTransportURIMetaData_hash} = $meta;
+
+			# use insert to make sure it is queued next.
+			$client->execute( [ 'playlist', 'insert', $upnp_uri, $meta->{title} ] );	
+			main::DEBUGLOG && $log->is_debug && $log->debug("NextURI set " . $upnp_uri . ":" . $meta->{title});
+		}
+	}
 	# Change state variables
 	$class->changeState( $client, {
 		NextAVTransportURI         => $args->{NextURI},

--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -11,7 +11,59 @@ my $log = logger('plugin.upnp');
 
 sub isRemote { 1 }
 
-sub getFormatForURL { 'mp3' } # XXX
+sub getFormatForURL {
+	my $class = shift;
+	my $url = shift;
+
+	# Previously this just returned 'mp3', this caused some streams to have
+	# an incorrect type set. It doesn't seem to have any effect on playback,
+	# it just changes the format listed in the SqueezePlay UI when the user
+	# selects more info. 
+
+	# attempted to use the built in method below but this caused Lyrion
+	# to lock up and consume a lot of memory. It's probably not meant to
+	# be used for streams.
+	# my $type = Slim::Music::Info::typeFromPath($url, 'mp3');
+
+	my $i = rindex($url, ".");
+	if($i ne -1){
+
+		my $ext = substr $url, $i + 1;
+		$ext = lc($ext);
+		my $return;
+
+		my %code_ref = (
+
+			# Added other formats, it can't hurt right?
+			mp3 => sub { $return = 'mp3'; },
+			mpeg => sub { $return = 'mp3'; },
+			ogg => sub { $return = 'ogg'; },
+			flac => sub { $return = 'flc'; },
+			flc => sub { $return = 'flc'; },
+			wav => sub { $return = 'wav'; },
+			aif => sub { $return = 'aif'; },
+			aiff => sub { $return = 'aif'; },
+			wma => sub { $return = 'wma'; },
+			aac => sub { $return = 'aac'; },
+			ape => sub { $return = 'ape'; },
+			wvpk => sub { $return = 'wvp'; },
+			l16 => sub { $return = 'pcm'; },
+			l24 => sub { $return = 'pcm'; },
+			opus => sub { $return = 'ops'; },
+			m4a => sub { $return = 'alc'; },
+		);
+
+		if ( exists $code_ref{$ext} ) {
+
+			$code_ref{$ext}->();
+			main::DEBUGLOG && $log->is_debug && $log->debug( 'Extension ' . $ext . ' , returned ' . $return . ' : ' . $url );
+			return $return;
+		}
+	}
+	# if all else fails, default to mp3 to maintain previous behaviour.
+	main::DEBUGLOG && $log->is_debug && $log->debug( 'Extension Default returned mp3 ' . $url);
+	return 'mp3';
+}
 
 # XXX use DLNA.ORG_OP value, and/or MIME type
 sub canSeek { 1 } # We'll assume Range requests are supported by all servers,
@@ -66,11 +118,37 @@ sub isRepeatingStream {
 
 sub getMetadataFor {
 	my ( $class, $client, $url ) = @_;
-	
+
+	# This returns metadata for any tracks added to the playlist via the plugin.
+	# It can only return metadata for CurrentURI and NextURI so the playlist
+	# needs to be managed to only show those tracks. Any extra tracks will have
+	# the metadata for CurrentURI returned.
+
+	# $url =~ s/^http/upnp/; is returning an empty string for some reason so 
+	# stripping upnp/http from url so it can be compared.
+	my $strippedUrl = substr $url, 4;
 	my $pd   = $client->pluginData();
 	my $meta = $pd->{avt_AVTransportURIMetaData_hash};
 	my $res  = $meta->{res};
-	
+	my $currentUri = substr $res->{uri}, 4;
+
+	# if $url doesn't match CurrentURI check against NextUri
+	if( $strippedUrl ne $currentUri){
+		my $nextMeta = $pd->{avt_NextAVTransportURIMetaData_hash};
+
+		# check for cleared NextUri
+		if( ref($nextMeta) eq 'HASH'){
+			my $nextRes = $nextMeta->{res};
+			$currentUri = substr $nextRes->{uri}, 4;
+
+			if( $strippedUrl eq $currentUri){
+				$meta = $nextMeta;
+				$res = $nextRes;
+			}
+		}
+	}
+	main::DEBUGLOG && $log->is_debug && $log->debug( 'Metadata returned for  ' . $meta->{title} );
+
 	return {
 		artist   => $meta->{artist},
 		album    => $meta->{album},

--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -15,54 +15,9 @@ sub getFormatForURL {
 	my $class = shift;
 	my $url = shift;
 
-	# Previously this just returned 'mp3', this caused some streams to have
-	# an incorrect type set. It doesn't seem to have any effect on playback,
-	# it just changes the format listed in the SqueezePlay UI when the user
-	# selects more info. 
-
-	# attempted to use the built in method below but this caused Lyrion
-	# to lock up and consume a lot of memory. It's probably not meant to
-	# be used for streams.
-	# my $type = Slim::Music::Info::typeFromPath($url, 'mp3');
-
-	my $i = rindex($url, ".");
-	if($i ne -1){
-
-		my $ext = substr $url, $i + 1;
-		$ext = lc($ext);
-		my $return;
-
-		my %code_ref = (
-
-			# Added other formats, it can't hurt right?
-			mp3 => sub { $return = 'mp3'; },
-			mpeg => sub { $return = 'mp3'; },
-			ogg => sub { $return = 'ogg'; },
-			flac => sub { $return = 'flc'; },
-			flc => sub { $return = 'flc'; },
-			wav => sub { $return = 'wav'; },
-			aif => sub { $return = 'aif'; },
-			aiff => sub { $return = 'aif'; },
-			wma => sub { $return = 'wma'; },
-			aac => sub { $return = 'aac'; },
-			ape => sub { $return = 'ape'; },
-			wvpk => sub { $return = 'wvp'; },
-			l16 => sub { $return = 'pcm'; },
-			l24 => sub { $return = 'pcm'; },
-			opus => sub { $return = 'ops'; },
-			m4a => sub { $return = 'alc'; },
-		);
-
-		if ( exists $code_ref{$ext} ) {
-
-			$code_ref{$ext}->();
-			main::DEBUGLOG && $log->is_debug && $log->debug( 'Extension ' . $ext . ' , returned ' . $return . ' : ' . $url );
-			return $return;
-		}
-	}
-	# if all else fails, default to mp3 to maintain previous behaviour.
-	main::DEBUGLOG && $log->is_debug && $log->debug( 'Extension Default returned mp3 ' . $url);
-	return 'mp3';
+	# if typeFromSuffix can't find a result it returns the mp3 default.
+	my $type = Slim::Music::Info::typeFromSuffix($url, 'mp3');
+	return $type;
 }
 
 # XXX use DLNA.ORG_OP value, and/or MIME type
@@ -124,24 +79,23 @@ sub getMetadataFor {
 	# needs to be managed to only show those tracks. Any extra tracks will have
 	# the metadata for CurrentURI returned.
 
-	# $url =~ s/^http/upnp/; is returning an empty string for some reason so 
-	# stripping upnp/http from url so it can be compared.
-	my $strippedUrl = substr $url, 4;
-	my $pd   = $client->pluginData();
+ 	# convert prefix to match AVTransport format
+	$url =~ s/^upnp/http/;
+	
+	my $pd = $client->pluginData();
 	my $meta = $pd->{avt_AVTransportURIMetaData_hash};
-	my $res  = $meta->{res};
-	my $currentUri = substr $res->{uri}, 4;
+	my $res = $meta->{res};
+	my $currentUri = $res->{uri};
 
-	# if $url doesn't match CurrentURI check against NextUri
-	if( $strippedUrl ne $currentUri){
+	if( $url ne $currentUri){
 		my $nextMeta = $pd->{avt_NextAVTransportURIMetaData_hash};
 
 		# check for cleared NextUri
 		if( ref($nextMeta) eq 'HASH'){
 			my $nextRes = $nextMeta->{res};
-			$currentUri = substr $nextRes->{uri}, 4;
+			$currentUri = $nextRes->{uri};
 
-			if( $strippedUrl eq $currentUri){
+			if( $url eq $currentUri){
 				$meta = $nextMeta;
 				$res = $nextRes;
 			}

--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -87,15 +87,15 @@ sub getMetadataFor {
 	my $res = $meta->{res};
 	my $currentUri = $res->{uri};
 
-	if( $url ne $currentUri){
+	if ( $url ne $currentUri ){
 		my $nextMeta = $pd->{avt_NextAVTransportURIMetaData_hash};
 
 		# check for cleared NextUri
-		if( ref($nextMeta) eq 'HASH'){
+		if ( ref($nextMeta) eq 'HASH' ){
 			my $nextRes = $nextMeta->{res};
 			$currentUri = $nextRes->{uri};
 
-			if( $url eq $currentUri){
+			if ( $url eq $currentUri ){
 				$meta = $nextMeta;
 				$res = $nextRes;
 			}

--- a/types.conf
+++ b/types.conf
@@ -42,7 +42,7 @@ mpc     mpc,mp+         audio/x-musepack                audio
 ogg     ogg,oga         audio/x-ogg,application/ogg,audio/ogg,application/x-ogg       audio
 ogf     ogf             audio/ogg;codecs=flac           audio
 ops     opus            audio/opus,audio/ogg;codecs=opus audio
-pcm     pcm             audio/L16,audio/x-pcm           audio
+pcm     pcm,l16,l24     audio/L16,audio/L24,audio/x-pcm audio
 pdf     pdf             application/pdf                 -
 pls     pls             audio/scpls,audio/x-scpls       playlist
 pod     -               application/rss+xml             -


### PR DESCRIPTION
The plugin currently advertises to Control Points that it supports Gapless Playback (setNextAVTransport). It accepts the command and returns a success result but doesn't actually do anything with the supplied information. This breaks functionality.

In normal playback, the Control Point sends one track to the Renderer with SetAVTransport. When the Renderer reports that it's stopped (the track is finished) the Control Point sends the next track with another SetAVTransport command. The Renderer clears the playlist and the new track is added. This causes a delay between tracks.

SetNextAVTransport allows the Control Point to queue up the next track so the Renderer can switch to the next track immediately. Gapless Playback.

When operating in this mode, the Control Point sends the first track with SetAVTransport and then sends the next track with SetNextAVTransport. Once the renderer has finished playing the first track it copies the NextURI information to the CurrentURI state variable, this allows the Control Point to determine the Renderer has switched to the next track and it sends another SetNextAVTransport command with the next track in the Control Points queue. This is repeated until the Control Point queue is finished.

These changes fix setNextAVTransport so Gapless Playback works correctly. The CurrentURI and NextURI tracks are displayed in the playlist. Once a track has finished playing, it's removed from the playlist and the NextURI is queued up. The Protocol Handler was modified so the Playlist could display the correct metadata for the CurrentURI and NextURI tracks. Previously it would only return the metadata for the CurrentURI track

These changes only effect users that are using LMS as a Renderer for a Control Point. I've tested it with my Musicbee Plugin, BubbleUPnP and Foobar. Gapless playback now works with all 3 Control Points whereas it previously didn't. 

Sorry for the long spiel, but I thought it was important to explain how it all works to understand the changes I made. I've been neck deep in UPnP documentation over the last few months and I expect it's not something a lot of people have kept up to speed on.

