### PR TITLE
Revert part of c28f3c3 (PR #1364)

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5682,8 +5682,8 @@ sub _songDataFromHash {
 		}
 
 		# Special case for 2: at track level, triggers addition of the play queue context $addedFromWork
-		elsif ( $tag eq '2' && $addedFromWork ) {
-			$returnHash{added_from_work} = $addedFromWork;
+		elsif ( $tag eq '2' ) {
+			$returnHash{added_from_work} = $addedFromWork if $addedFromWork;
 		}
 
 		# eg. the web UI is requesting some tags which are only available for remote tracks,
@@ -5827,8 +5827,8 @@ sub _songData {
 		}
 
 		# Special case for 2: at track level, triggers addition of the play queue context $addedFromWork
-		elsif ( $tag eq '2' && $addedFromWork ) {
-			$returnHash{added_from_work} = $addedFromWork;
+		elsif ( $tag eq '2' ) {
+			$returnHash{added_from_work} = $addedFromWork if $addedFromWork;
 		}
 
 		# special case artists (tag A and S)


### PR DESCRIPTION
Revert part of https://github.com/LMS-Community/slimserver/commit/c28f3c32f52eb3b2691927ea7b98d659aaef12da

This ensures tag `2` bypasses further `elsif` tests regardless of the value of `$addedFromWork`.