### PR TITLE
Old MD5's

### DIFF
--- a/Slim/Utils/Update.pm
+++ b/Slim/Utils/Update.pm
@@ -384,7 +384,7 @@ sub cleanup {
 
 	my $ext = $os->installerExtension() . ($additionalExt ? "\.$additionalExt" : '');
 
-	Slim::Utils::Misc::deleteFiles($path, qr/^LyrionMusicServer.*\.$ext$/i);
+	Slim::Utils::Misc::deleteFiles($path, qr/^LyrionMusicServer.*\.$ext(\.md5\.txt)?$/i);
 }
 
 1;


### PR DESCRIPTION
When new installers are downloaded, it removes previous versions, however now that we are storing a hash file too, cleanup those old versions too.
