### PR TITLE
Provide a default TimeZone to SqueezeOS based players

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -52,7 +52,7 @@ use Slim::Web::Pages;
 use Slim::Web::Graphics;
 use Slim::Web::JSONRPC;
 use Slim::Web::Cometd;
-use Slim::Web::SqueezeosTimezone;
+use Slim::Web::Time;
 use Slim::Utils::Prefs;
 
 use constant HALFYEAR	 => 60 * 60 * 24 * 180;
@@ -135,8 +135,8 @@ sub init {
 	# Initialize Cometd
 	Slim::Web::Cometd::init();
 
-	# Initialize SqueezeOS TimeZone request
-	Slim::Web::SqueezeosTimezone::init();
+	# Initialize '/time' endpoint - /time/tz serves SqueezeOS
+	Slim::Web::Time::init();
 }
 
 sub init2 {

--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -52,6 +52,7 @@ use Slim::Web::Pages;
 use Slim::Web::Graphics;
 use Slim::Web::JSONRPC;
 use Slim::Web::Cometd;
+use Slim::Web::SqueezeosTimezone;
 use Slim::Utils::Prefs;
 
 use constant HALFYEAR	 => 60 * 60 * 24 * 180;
@@ -133,6 +134,9 @@ sub init {
 
 	# Initialize Cometd
 	Slim::Web::Cometd::init();
+
+	# Initialize SqueezeOS TimeZone request
+	Slim::Web::SqueezeosTimezone::init();
 }
 
 sub init2 {

--- a/Slim/Web/SqueezeosTimezone.pm
+++ b/Slim/Web/SqueezeosTimezone.pm
@@ -1,0 +1,161 @@
+package Slim::Web::SqueezeosTimezone;
+
+# Implements a simple HTTP endpoint '/tz' that provides a SqueezeOS based
+# player with a default, Olson formatted, TimeZone string. The player will
+# make the request whenever its own TimeZone has not been initialized. This
+# typically follows a factory reset, or during first set up.
+
+# LMS is expected to respond by returning an Olson formatted TimeZone string,
+# with a '200' (RC_OK) response code. If LMS fails to obtain a valid TimeZone
+# it will simply return a '404' (RC_NOT_FOUND) response.
+
+# LMS obtains the TimeZone by an API call to 'https://stats.lms-community.org'
+
+use strict;
+
+use HTTP::Status qw(RC_OK RC_NOT_FOUND);
+use Slim::Web::HTTP;
+use Slim::Networking::SimpleAsyncHTTP;
+use JSON::XS::VersionOneAndTwo;
+use Slim::Utils::Log;
+
+# The server/url that provides us with date/time data, including an Olson
+# formatted TimeZone. The response is JSON formatted.
+use constant TZGUESS_URL => 'https://stats.lms-community.org/api/time';
+
+my $log = logger('network.http');
+
+
+# 'init' is called by 'Slim::Web::HTTP:init'
+sub init {
+	Slim::Web::Pages->addRawFunction(qr{^/tz$}, \&tzAPIrequest);
+}
+
+
+sub tzAPIrequest {
+	my ($httpClient, $response) = @_;
+
+	# API call to retrieve date/time data
+	Slim::Networking::SimpleAsyncHTTP->new(
+		\&tzAPIsuccess,
+		\&tzAPIerror,
+		{
+			timeout    => 10,
+			httpClient => $httpClient,
+			response   => $response,
+		}
+	)->get(TZGUESS_URL);
+}
+
+
+# Parses out the Olson TimeZone identifier, validates the result, and returns
+# it to SqueezeOS. But a 404 error if validation fails.
+
+sub tzAPIsuccess {
+
+	my $http       = shift;
+	my $httpClient = $http->params('httpClient');
+	my $response   = $http->params('response');
+
+	# Server response should look like:
+	# {"datetime":"2025-04-03T11:39:10.351+01:00","timezone":"Europe/London","offset":"GMT+1","offsetHours":1,"offsetMinutes":60,"isInDST":true}
+
+	my $res = eval { from_json($http->content) };
+	if ($@ || ref $res ne 'HASH') {
+		$log->error($@ || 'Invalid JSON response: ' . $http->content);
+		$res = {}; # guarantee that $res will be a hash ref
+	}
+
+	# '$tz' will hold the Olson formatted TimeZone to be returned.
+	# Setting '$tz' to '' signals a validation failure, and triggers a
+	# 404 error response.
+
+	my $tz = $res->{'timezone'};
+	if (!defined $tz || ref $tz) {
+		$log->error('Unexpected JSON response, expected a timezone string: ' . $http->content);
+		$tz = ''; # guarantee that $tz will be a string scalar
+	}
+
+	$tz = "$tz"; # ensure $tz is a string scalar
+	# Trim any leading/trailing white space, should it be there.
+	$tz =~ s/\A\s+|\s+\z//g;
+
+	$log->info("TimeZone query: Retrieved TimeZone \"$tz\"");
+	my $savedTz = $tz;
+
+	# Sanity check on TimeZone string.
+
+	# A TimeZone identifier is, essentially, a POSIX path with some
+	# additional (more and less voluntary) restrictions. These are
+	# indicated in the "theory" section of the tz distribution:
+	#   https://github.com/eggert/tz/blob/main/theory.html
+
+	# Path components should contain only A-Z, a-z, '.', '-', and '_'.
+	# And we need '/' (directory) to join the path components together.
+	# Note:
+	#  Some "legacy" and "etc" TimeZones may also contain 0-9 and '+', but
+	#  we do not expect or support such oddities.
+
+	$tz = '' if $tz =~ m{[^A-Za-z._\-/]} ; # reject if any characters outside that range
+
+	# Additional restrictions
+	$tz = '' if $tz =~ m{^/}; # leading '/' not allowed
+	$tz = '' if $tz =~ m{/$}; # trailing '/' not allowed
+	$tz = '' if $tz =~ m{//}; # no path component to be empty
+	$tz = '' if $tz =~ m{ ^- | /- }x; # no path component to start with a hyphen
+
+	# Path components that consist of singleton '.' or doubleton '..' are
+	# not allowed for obvious reasons.
+	# Other than that, the "theory" section of the tz distribution does
+	# allow "dots" elsewhere in TimeZone identifiers, but discourages
+	# them. That said, there are none defined at present, and almost
+	# certainly won't be. So just exclude any TimeZone containing a dot.
+	$tz = '' if $tz =~ m{\.}; # no path component to contain a '.'
+
+	# The 'Factory' TimeZone should never be encountered. SqueezeOS uses
+	# it to signal that the device's TimeZone has not been set.
+	# The 'Etc/Unknown' TimeZone signals an 'Unknown or Invalid' TimeZone,
+	# and is not defined in the tz database. SqueezeOS doesn't want it.
+	$tz = '' if $tz eq 'Factory';
+	$tz = '' if $tz eq 'Etc/Unknown';
+
+	# Note:
+	#  We do not guarantee to purge all invalid TimeZones with the above
+	#  sanity checks.
+
+	# All done, return result to SqueezeOS.
+	# But a 404 error if TimeZone failed validation.
+	unless ($tz eq '') {
+		$response->code(RC_OK);
+		$log->info("TimeZone query: Returning \"$tz\" to SqueezeOS device");
+	} else {
+		$response->code(RC_NOT_FOUND);
+		$log->error("TimeZone query: Retrieved TimeZone \"$savedTz\" did not pass validation checks");
+	}
+	$response->content_type('text/plain;charset=UTF-8');
+	$response->header('Connection' => 'close');
+	Slim::Web::HTTP::addHTTPResponse(
+		$httpClient, $response, \$tz,
+	);
+}
+
+
+# Returns a 404 error to SqueezeOS.
+
+sub tzAPIerror {
+	my $http       = shift;
+	my $httpClient = $http->params('httpClient');
+	my $response   = $http->params('response');
+
+	$log->error("TimeZone query: Failed to get TimeZone from ", join("\n", $http->url, $http->error));
+
+	$response->code(RC_NOT_FOUND);
+	$response->content_type('text/plain;charset=UTF-8');
+	$response->header('Connection' => 'close');
+	my $body = "";
+	Slim::Web::HTTP::addHTTPResponse(
+		$httpClient, $response, \$body,
+	);
+}
+
+1;

--- a/Slim/Web/Time.pm
+++ b/Slim/Web/Time.pm
@@ -1,19 +1,22 @@
-package Slim::Web::SqueezeosTimezone;
+package Slim::Web::Time;
 
-# Implements a simple HTTP endpoint '/tz' that provides a SqueezeOS based
+# Implements a simple HTTP endpoint '/time/tz' that provides a SqueezeOS based
 # player with a default, Olson formatted, TimeZone string. The player will
 # make the request whenever its own TimeZone has not been initialized. This
 # typically follows a factory reset, or during first set up.
 
 # LMS is expected to respond by returning an Olson formatted TimeZone string,
-# with a '200' (RC_OK) response code. If LMS fails to obtain a valid TimeZone
-# it will simply return a '404' (RC_NOT_FOUND) response.
+# with a '200' (OK) response code. If LMS fails to obtain a valid TimeZone
+# it will return one of a '204' (No content) or '500' (Internal server error)
+# response.
+# The SqueezeOS callback will not see an empty body even if it is a '200'
+# response. So we don't do that.
 
 # LMS obtains the TimeZone by an API call to 'https://stats.lms-community.org'
 
 use strict;
 
-use HTTP::Status qw(RC_OK RC_NOT_FOUND);
+use HTTP::Status qw(RC_OK RC_NO_CONTENT RC_INTERNAL_SERVER_ERROR);
 use Slim::Web::HTTP;
 use Slim::Networking::SimpleAsyncHTTP;
 use JSON::XS::VersionOneAndTwo;
@@ -28,12 +31,28 @@ my $log = logger('network.http');
 
 # 'init' is called by 'Slim::Web::HTTP:init'
 sub init {
-	Slim::Web::Pages->addRawFunction(qr{^/tz$}, \&tzAPIrequest);
+	Slim::Web::Pages->addRawFunction(qr{^/time/tz$}, \&tzAPIrequest);
 }
 
+# Holds the Timezone string retrieved from a successful API call.
+# Although it may be '' if the string failed validation.
+my $cachedAPIresult;
 
 sub tzAPIrequest {
 	my ($httpClient, $response) = @_;
+
+	if (defined $cachedAPIresult) {
+		# Did it pass validation ? Or do we have '' ?
+		if ($cachedAPIresult) {
+			$log->info("TimeZone query: Returning \"$cachedAPIresult\" to SqueezeOS device (from cache)");
+			_sendHTTPresponse($httpClient, $response, RC_OK, $cachedAPIresult);
+		}
+		else {
+			$log->error("TimeZone query: Cached timezone was invalid. Returning 204 response to SqueezeOS device");
+			_sendHTTPresponse($httpClient, $response, RC_NO_CONTENT, '');
+		}
+		return;
+	}
 
 	# API call to retrieve date/time data
 	Slim::Networking::SimpleAsyncHTTP->new(
@@ -49,7 +68,9 @@ sub tzAPIrequest {
 
 
 # Parses out the Olson TimeZone identifier, validates the result, and returns
-# it to SqueezeOS. But a 404 error if validation fails.
+# it to SqueezeOS. But returns a 500 (Internal server error) code if the API
+# response is malformed, or a 204 (No content) code if validation of the tz
+# string fails.
 
 sub tzAPIsuccess {
 
@@ -63,17 +84,19 @@ sub tzAPIsuccess {
 	my $res = eval { from_json($http->content) };
 	if ($@ || ref $res ne 'HASH') {
 		$log->error($@ || 'Invalid JSON response: ' . $http->content);
-		$res = {}; # guarantee that $res will be a hash ref
+		_sendHTTPresponse($httpClient, $response, RC_INTERNAL_SERVER_ERROR, '');
+		return;
 	}
 
 	# '$tz' will hold the Olson formatted TimeZone to be returned.
 	# Setting '$tz' to '' signals a validation failure, and triggers a
-	# 404 error response.
+	# 204 (No content) response.
 
 	my $tz = $res->{'timezone'};
 	if (!defined $tz || ref $tz) {
 		$log->error('Unexpected JSON response, expected a timezone string: ' . $http->content);
-		$tz = ''; # guarantee that $tz will be a string scalar
+		_sendHTTPresponse($httpClient, $response, RC_INTERNAL_SERVER_ERROR, '');
+		return;
 	}
 
 	$tz = "$tz"; # ensure $tz is a string scalar
@@ -90,69 +113,62 @@ sub tzAPIsuccess {
 	# indicated in the "theory" section of the tz distribution:
 	#   https://github.com/eggert/tz/blob/main/theory.html
 
-	# Path components should contain only A-Z, a-z, '.', '-', and '_'.
-	# And we need '/' (directory) to join the path components together.
+	# Identifier components should contain only A-Z, a-z, '-', and '_'.
+	# And we need '/' to join the components together.
+	# Examples: 'America/Argentina/Buenos_Aires', 'Europe/Zurich'.
 	# Note:
 	#  Some "legacy" and "etc" TimeZones may also contain 0-9 and '+', but
 	#  we do not expect or support such oddities.
 
-	$tz = '' if $tz =~ m{[^A-Za-z._\-/]} ; # reject if any characters outside that range
-
-	# Additional restrictions
-	$tz = '' if $tz =~ m{^/}; # leading '/' not allowed
-	$tz = '' if $tz =~ m{/$}; # trailing '/' not allowed
-	$tz = '' if $tz =~ m{//}; # no path component to be empty
-	$tz = '' if $tz =~ m{ ^- | /- }x; # no path component to start with a hyphen
-
-	# Path components that consist of singleton '.' or doubleton '..' are
-	# not allowed for obvious reasons.
-	# Other than that, the "theory" section of the tz distribution does
-	# allow "dots" elsewhere in TimeZone identifiers, but discourages
-	# them. That said, there are none defined at present, and almost
-	# certainly won't be. So just exclude any TimeZone containing a dot.
-	$tz = '' if $tz =~ m{\.}; # no path component to contain a '.'
-
-	# The 'Factory' TimeZone should never be encountered. SqueezeOS uses
-	# it to signal that the device's TimeZone has not been set.
-	# The 'Etc/Unknown' TimeZone signals an 'Unknown or Invalid' TimeZone,
-	# and is not defined in the tz database. SqueezeOS doesn't want it.
-	$tz = '' if $tz eq 'Factory';
-	$tz = '' if $tz eq 'Etc/Unknown';
+	if (
+		$tz =~ m{[^A-Za-z_\-/]}  # reject if any characters outside that range
+		|| $tz =~ m{^/}          # leading '/' not allowed
+		|| $tz =~ m{/$}          # trailing '/' not allowed
+		|| $tz =~ m{//}          # no component to be empty
+		|| $tz =~ m{ ^- | /- }x  # no component to start with a hyphen
+		|| $tz eq 'Factory'      # reserved for SqueezeOS use
+		|| $tz eq 'Etc/Unknown'  # reserved - never a valid TimeZone
+	) {
+		$tz = ''
+	}
 
 	# Note:
 	#  We do not guarantee to purge all invalid TimeZones with the above
 	#  sanity checks.
 
-	# All done, return result to SqueezeOS.
-	# But a 404 error if TimeZone failed validation.
-	unless ($tz eq '') {
-		$response->code(RC_OK);
+	# All done, cache the result for re-use next time, and return result
+	# to SqueezeOS.
+	# But a 204 (No content) response if TimeZone failed validation.
+	$cachedAPIresult = $tz;
+
+	if ($tz) {
 		$log->info("TimeZone query: Returning \"$tz\" to SqueezeOS device");
+		_sendHTTPresponse($httpClient, $response, RC_OK, $tz);
 	} else {
-		$response->code(RC_NOT_FOUND);
 		$log->error("TimeZone query: Retrieved TimeZone \"$savedTz\" did not pass validation checks");
+		_sendHTTPresponse($httpClient, $response, RC_NO_CONTENT, '');
 	}
-	$response->content_type('text/plain;charset=UTF-8');
-	$response->header('Connection' => 'close');
-	Slim::Web::HTTP::addHTTPResponse(
-		$httpClient, $response, \$tz,
-	);
 }
 
 
-# Returns a 404 error to SqueezeOS.
+# Log the error and return a 500 code to SqueezeOS.
 
 sub tzAPIerror {
 	my $http       = shift;
 	my $httpClient = $http->params('httpClient');
 	my $response   = $http->params('response');
-
 	$log->error("TimeZone query: Failed to get TimeZone from ", join("\n", $http->url, $http->error));
+	_sendHTTPresponse($httpClient, $response, RC_INTERNAL_SERVER_ERROR, '');
+}
 
-	$response->code(RC_NOT_FOUND);
+# Helper function to dispatch the HTTP response
+
+sub _sendHTTPresponse {
+	my ($httpClient, $response, $code, $body) = @_;
+
+	$response->code($code);
 	$response->content_type('text/plain;charset=UTF-8');
 	$response->header('Connection' => 'close');
-	my $body = "";
 	Slim::Web::HTTP::addHTTPResponse(
 		$httpClient, $response, \$body,
 	);

--- a/Slim/Web/Time.pm
+++ b/Slim/Web/Time.pm
@@ -35,22 +35,14 @@ sub init {
 }
 
 # Holds the Timezone string retrieved from a successful API call.
-# Although it may be '' if the string failed validation.
-my $cachedAPIresult;
+my $cachedTimeZone;
 
 sub tzAPIrequest {
 	my ($httpClient, $response) = @_;
 
-	if (defined $cachedAPIresult) {
-		# Did it pass validation ? Or do we have '' ?
-		if ($cachedAPIresult) {
-			$log->info("TimeZone query: Returning \"$cachedAPIresult\" to SqueezeOS device (from cache)");
-			_sendHTTPresponse($httpClient, $response, RC_OK, $cachedAPIresult);
-		}
-		else {
-			$log->error("TimeZone query: Cached timezone was invalid. Returning 204 response to SqueezeOS device");
-			_sendHTTPresponse($httpClient, $response, RC_NO_CONTENT, '');
-		}
+	if ($cachedTimeZone) {
+		$log->info("TimeZone query: Returning \"$cachedTimeZone\" to SqueezeOS device (from cache)");
+		_sendHTTPresponse($httpClient, $response, RC_OK, $cachedTimeZone);
 		return;
 	}
 
@@ -93,7 +85,7 @@ sub tzAPIsuccess {
 	# 204 (No content) response.
 
 	my $tz = $res->{'timezone'};
-	if (!defined $tz || ref $tz) {
+	if (!$tz || ref $tz) {
 		$log->error('Unexpected JSON response, expected a timezone string: ' . $http->content);
 		_sendHTTPresponse($httpClient, $response, RC_INTERNAL_SERVER_ERROR, '');
 		return;
@@ -139,10 +131,10 @@ sub tzAPIsuccess {
 	# All done, cache the result for re-use next time, and return result
 	# to SqueezeOS.
 	# But a 204 (No content) response if TimeZone failed validation.
-	$cachedAPIresult = $tz;
 
 	if ($tz) {
 		$log->info("TimeZone query: Returning \"$tz\" to SqueezeOS device");
+		$cachedTimeZone = $tz;
 		_sendHTTPresponse($httpClient, $response, RC_OK, $tz);
 	} else {
 		$log->error("TimeZone query: Retrieved TimeZone \"$savedTz\" did not pass validation checks");


### PR DESCRIPTION
This proposed change implements an `http` endpoint `/tz` that provides the TimeZone in which the local LMS server operates.

It replaces a previous change proposal that had been made against the Community Firmware plugin. That can be seen [here]( https://github.com/ralph-irving/plugin-CommunityFirmware/pull/8). The substantive change to that proposal is that a simple web endpoint is now used, rather than using the Slim Request/Query mechanism.

The endpoint returns an Olson formatted TimeZone string with a 200, 'ok', response code. If the server fails to obtain a valid TimeZone it will simply return a 404, 'not found',  response.

A companion change to SqueezeOS/Squeezeplay has been prepared to enable it to make use of this service. [This PR](https://github.com/ralph-irving/squeezeos-squeezeplay/pull/15) refers.

The purpose of this endpoint is to allow SqueezeOS based devices to obtain a default TimeZone if their own TimeZone has not been initialized. This would arise following a “factory reset” of the device, or on first set up. It replaces the service that used to be provided by MySqueezebox.com.

The request handler obtains a best guess of its local TimeZone by making an API call to `https://stats.lms-community.org/api/time`, which has been recently implemented. This has the advantage of being platform neutral, and removes the need to “sniff out” a TimeZone from the OS on which LMS runs.

After retrieving the result of the API call, the handler carries out a number of validation checks to verify that the result is properly formatted, and that the TimeZone string basically complies with the naming conventions used within the IANA Time Zone Database. If verification fails, the query will return ~~the empty string~~ a 404 error.

The naming conventions may be found in the Timezone identifiers section of the document Theory and pragmatics of the tz code and data. Refer [here](https://ftp.iana.org/tz/tzdb-2022b/theory.html#naming) for details.

The proposed change has been tested locally on a MacOS based system, and appears to operate as expected.
