### PR TITLE
Update StreamingController.pm

### DIFF
--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -1301,8 +1301,6 @@ sub _Stream {				# play -> Buffering, Streaming
 		if ($song->currentTrackHandler()->can('onStream')) {
 			$song->currentTrackHandler()->onStream($player, $song);
 		}
-		
-		$player->replayGain($replayGain);  # store this for status queries
 
 		my %params = (
 			'paused'      => $paused,
@@ -1317,6 +1315,8 @@ sub _Stream {				# play -> Buffering, Streaming
 		);
 
 		$startedPlayers += $player->play( \%params );
+
+		$player->replayGain($replayGain);  # store this for status queries
 
 		$reportsTrackStart ||= $player->reportsTrackStart();
 	}


### PR DESCRIPTION
Slight change to PR#1383. Delay caching the replay gain value until after the play() command has been issued in order to close a small timing window where the new value could potentially be retrieved before the previous song has finished.