### PR TITLE
Use artwork appropriate to the Work if multiple album covers

### DIFF
--- a/Changelog9.html
+++ b/Changelog9.html
@@ -23,6 +23,7 @@
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1363">#1363</a> - Allow item removal even if playlist has only 1 item (@mw9)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1364">#1364</a> - store/return playqueue entry context flag ("addedFromWork")</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1377">#1377</a> - Provide new /time/tz endpoint for Squeezeplay to fetch the local timezone (@mw9)</li>
+		<li><a href="https://github.com/LMS-Community/slimserver/pull/1399">#1399</a> - Use artwork appropriate for a Work if multiple album covers</li>
 	</ul>
 	<br />
 

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -589,7 +589,8 @@ sub albumsQuery {
 	}
 
 	if ( $tags =~ /j/ ) {
-		$c->{'albums.artwork'} = 1;
+		$c->{'albums.artwork'} = 1 if !$work;
+		$c->{'tracks.coverid'} = 1 if $work;
 	}
 
 	if ( $tags =~ /t/ ) {
@@ -832,7 +833,10 @@ sub albumsQuery {
 
 			$tags =~ /l/ && $request->addResultLoop($loopname, $chunkCount, 'album', $construct_title->());
 			$tags =~ /y/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'year', $c->{'albums.year'});
-			$tags =~ /j/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artwork_track_id', $c->{'albums.artwork'}) if ($c->{'albums.artwork'} || '') !~ /^https?:/;;
+			if ($tags =~ /j/) {
+				$c->{'albums.artwork'} = $c->{'tracks.coverid'} if $c->{'tracks.coverid'};
+				$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artwork_track_id', $c->{'albums.artwork'}) if ($c->{'albums.artwork'} || '') !~ /^https?:/;
+			}
 			$tags =~ /K/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artwork_url', $c->{'albums.artwork'}) if ($c->{'albums.artwork'} || '') =~ /^https?:/;
 			$tags =~ /t/ && $request->addResultLoop($loopname, $chunkCount, 'title', $c->{'albums.title'});
 			$tags =~ /i/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'disc', $c->{'albums.disc'});
@@ -4921,7 +4925,7 @@ sub worksQuery {
 	my $w   = [];
 	my $p   = [];
 
-	my $columns = "works.title, works.id, composer.name, composer.id, composer.namesort, works.titlesort, GROUP_CONCAT(DISTINCT albums.artwork), GROUP_CONCAT(DISTINCT albums.id)";
+	my $columns = "works.title, works.id, composer.name, composer.id, composer.namesort, works.titlesort, GROUP_CONCAT(DISTINCT tracks.coverid), GROUP_CONCAT(DISTINCT albums.id)";
 
 	my $sql = 'SELECT %s FROM tracks
 		JOIN contributor_track composer_track ON composer_track.track = tracks.id AND composer_track.role = 2

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -834,8 +834,8 @@ sub albumsQuery {
 			$tags =~ /l/ && $request->addResultLoop($loopname, $chunkCount, 'album', $construct_title->());
 			$tags =~ /y/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'year', $c->{'albums.year'});
 			if ($tags =~ /j/) {
-				$c->{'albums.artwork'} = $c->{'tracks.coverid'} if $c->{'tracks.coverid'};
-				$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artwork_track_id', $c->{'albums.artwork'}) if ($c->{'albums.artwork'} || '') !~ /^https?:/;
+				my $albumCover = $c->{'tracks.coverid'} ? $c->{'tracks.coverid'} : $c->{'albums.artwork'};
+				$request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artwork_track_id', $albumCover) if ($albumCover || '') !~ /^https?:/;
 			}
 			$tags =~ /K/ && $request->addResultLoopIfValueDefined($loopname, $chunkCount, 'artwork_url', $c->{'albums.artwork'}) if ($c->{'albums.artwork'} || '') =~ /^https?:/;
 			$tags =~ /t/ && $request->addResultLoop($loopname, $chunkCount, 'title', $c->{'albums.title'});


### PR DESCRIPTION
Hopefully a quick one:

If an album has multiple cover images (either embedded in the file or via different images in disc subfolders for a multi-disc album), use the image appropriate to the Work (ie `tracks.coverid` for the first track of the work, rather than `albums.artwork`) when listing album-works or works.