### PR TITLE
Enhance metadata returned to clients for music services

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -796,7 +796,10 @@ sub objectForUrl {
 
 	# Confirm that the URL itself isn't an object (see bug 1811)
 	# XXX - exception should go here. Coming soon.
-	if (blessed($url) || ref($url)) {
+	if (ref($url) eq 'Slim::Schema::RemoteTrack' && $url->url) {
+		$url = $url->url;
+	}
+	elsif (blessed($url) || ref($url)) {
 
 		# returning already blessed url
 		return $url;
@@ -818,12 +821,16 @@ sub objectForUrl {
 	}
 
 	# Pull the track object for the DB
-	my $track = $self->_retrieveTrack($url, $playlist);
-	my $isRemote = Slim::Music::Info::isRemoteURL($url);
+	my $track;
 
 	# Check to see if we have a remote track stored in our database
-	if (!$track && $isRemote && !$create && !$readTag) {
+	my $isRemote = Slim::Music::Info::isRemoteURL($url);
+	if ($isRemote && !$create && !$readTag) {
 		$track = $self->_retrieveTrack($url, $playlist, 'integrateRemote');
+	}
+
+	if (!$track) {
+		$track = $self->_retrieveTrack($url, $playlist);
 	}
 
 	# Bug 14648: Check to see if we have a playlist with remote tracks


### PR DESCRIPTION
For music service tracks, prioritise metadata from the LMS database (if the track has been imported), even if the track was added to the play queue via the music service plugin.

Should also cut down on network traffic with Qobuz, etc.

Seems to work for Qobuz, needs testing with other services and brainstorming for unintended consequences!

Created as a draft PR, I'm also looking at ways to enhance the metadata as much as possible (e.g. artist id if we've got the artist in LMS) for remote tracks that haven't been imported to LMS.