### PR TITLE
Slim browse metadata: add title/version/titleFlags elements to response

### DIFF
--- a/Slim/Control/XMLBrowser.pm
+++ b/Slim/Control/XMLBrowser.pm
@@ -50,9 +50,9 @@ my %colMap = (
 	G => 'genres',
 	i => 'discnum',
 	k => 'description',
-	l => 'album',
+	l => ['album','version'],
 	q => 'disccount',
-	t => 'tracknum',
+	t => ['tracknum','title','titleFlags'],
 	# "date" is being used in Podcast episodes
 	y => ['year','date'],
 );


### PR DESCRIPTION
Just noticed that we were not returning `title` in the tracks response!

Also added `version` (for albums) and `titleFlags` (for tracks) to keep album and title elements clean, as discussed for the Qobuz changes.