### PR TITLE
Treat imported remote tracks the same as local tracks in statusQuery

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4212,7 +4212,7 @@ sub statusQuery {
 		if (!$totalOnly) {
 			$track = Slim::Player::Playlist::track($client, $playlist_cur_index, $refreshTrack);
 
-			if (ref($track) ne 'Slim::Schema::Track') {
+			if ( ref($track) ne 'Slim::Schema::Track' && $track->remote ) {
 				$tags .= "B" unless $totalOnly; # include button remapping
 				my $metadata = _songData($request, $track, $tags);
 				$request->addResult('remoteMeta', $metadata);

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4212,7 +4212,7 @@ sub statusQuery {
 		if (!$totalOnly) {
 			$track = Slim::Player::Playlist::track($client, $playlist_cur_index, $refreshTrack);
 
-			if ($track->remote) {
+			if (ref($track) ne 'Slim::Schema::Track') {
 				$tags .= "B" unless $totalOnly; # include button remapping
 				my $metadata = _songData($request, $track, $tags);
 				$request->addResult('remoteMeta', $metadata);
@@ -4265,7 +4265,7 @@ sub statusQuery {
 
 					push @addedFromWork, $track->added_from_work;
 
-					if ( $track->remote ) {
+					if ( ref($track) ne 'Slim::Schema::Track' && $track->remote ) {
 						push @tracks, $track;
 					}
 					else {
@@ -5737,7 +5737,7 @@ sub _songData {
 
 	# If we have a remote track, check if a plugin can provide metadata
 	my $remoteMeta = {};
-	my $isRemote = $track->remote;
+	my $isRemote = $track->remote && ref($track) ne 'Slim::Schema::Track';
 	my $url = $track->url;
 
 	my $song;

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -88,8 +88,8 @@ sub track {
 
 		$objOrUrl = Slim::Schema->objectForUrl({
 			'url'      => $objOrUrl,
-			'create'   => 0,
-			'readTags' => 0,
+			'create'   => 1,
+			'readTags' => 1,
 		});
 
 		if ($refresh) {
@@ -124,8 +124,8 @@ sub songs {
 
 			my $track = Slim::Schema->objectForUrl({
 					'url'      => $_,
-					'create'   => 0,
-					'readTags' => 0,
+					'create'   => 1,
+					'readTags' => 1,
 				});
 
 			if (defined $track) {
@@ -147,8 +147,8 @@ sub refreshTrack {
 
 	my $track = Slim::Schema->objectForUrl( {
 		url      => $url,
-		create   => 0,
-		readTags => 0,
+		create   => 1,
+		readTags => 1,
 	} );
 
 	my $i = 0;

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -84,12 +84,12 @@ sub track {
 		$objOrUrl = ${playList($client)}[$index];
 	}
 
-	if ( $objOrUrl && ($refresh || !blessed($objOrUrl)) ) {
+	if ( $objOrUrl && ($refresh || !blessed($objOrUrl) || ref($objOrUrl) eq 'Slim::Schema::RemoteTrack' && $objOrUrl->url) ) {
 
 		$objOrUrl = Slim::Schema->objectForUrl({
 			'url'      => $objOrUrl,
-			'create'   => 1,
-			'readTags' => 1,
+			'create'   => 0,
+			'readTags' => 0,
 		});
 
 		if ($refresh) {
@@ -116,7 +116,7 @@ sub songs {
 	{
 		# Use $_ here to use perl's inline replace semantics
 
-		if ( $_ && !blessed($_) ) {
+		if ( $_ && (!blessed($_) || ref($_) eq 'Slim::Schema::RemoteTrack' && $_->url) ) {
 
 			# If we instantiate a Track from a URL then
 			# back-patch the playlist item with the Track. This could be common
@@ -124,8 +124,8 @@ sub songs {
 
 			my $track = Slim::Schema->objectForUrl({
 					'url'      => $_,
-					'create'   => 1,
-					'readTags' => 1,
+					'create'   => 0,
+					'readTags' => 0,
 				});
 
 			if (defined $track) {
@@ -147,8 +147,8 @@ sub refreshTrack {
 
 	my $track = Slim::Schema->objectForUrl( {
 		url      => $url,
-		create   => 1,
-		readTags => 1,
+		create   => 0,
+		readTags => 0,
 	} );
 
 	my $i = 0;

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -822,7 +822,7 @@ sub objectForUrl {
 
 	# Check to see if we have a remote track stored in our database
 	my $isRemote = Slim::Music::Info::isRemoteURL($url);
-	if ($isRemote && !$create && !$readTag) {
+	if ( $isRemote ) {
 		$track = $self->_retrieveTrack($url, $playlist, 'integrateRemote');
 	}
 


### PR DESCRIPTION
This change ensures that remote tracks which are in the database go through the same path as a local track in `statusQuery`. That is they will use `_getTagDataForTracks`.

This improves performance by not calling the remote service plugin handler and provides improved and consistent metadata through the use of `_getSongDataFromHash`, rather than having to keep the `$remoteMeta` logic in `_getSongData `in line.
