### PR TITLE
Re-implement PR1415

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4274,7 +4274,7 @@ sub statusQuery {
 		if (!$totalOnly) {
 			$track = Slim::Player::Playlist::track($client, $playlist_cur_index, $refreshTrack);
 
-			if ( ref($track) ne 'Slim::Schema::Track' && $track->remote ) {
+			if ( _notLocalTrackAndRemoteUrl($track) ) {
 				$tags .= "B" unless $totalOnly; # include button remapping
 				my $metadata = _songData($request, $track, $tags);
 				$request->addResult('remoteMeta', $metadata);
@@ -4327,7 +4327,7 @@ sub statusQuery {
 
 					push @addedFromWork, $track->added_from_work;
 
-					if ( ref($track) ne 'Slim::Schema::Track' && $track->remote ) {
+					if ( _notLocalTrackAndRemoteUrl($track) ) {
 						push @tracks, $track;
 					}
 					else {
@@ -5796,7 +5796,7 @@ sub _songData {
 
 	# If we have a remote track, check if a plugin can provide metadata
 	my $remoteMeta = {};
-	my $isRemote = $track->remote && ref($track) ne 'Slim::Schema::Track';
+	my $isRemote = _notLocalTrackAndRemoteUrl($track);
 	my $url = $track->url;
 
 	my $song;
@@ -6768,6 +6768,11 @@ sub _createIndexList {
 	}
 
 	return \@indexList;
+}
+
+sub _notLocalTrackAndRemoteUrl {
+	my $track = shift;
+	return ref($track) && ref($track) ne 'Slim::Schema::Track' && $track->can('remote') && $track->remote;
 }
 
 =head1 SEE ALSO

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4274,7 +4274,7 @@ sub statusQuery {
 		if (!$totalOnly) {
 			$track = Slim::Player::Playlist::track($client, $playlist_cur_index, $refreshTrack);
 
-			if ($track->remote) {
+			if ( ref($track) ne 'Slim::Schema::Track' && $track->remote ) {
 				$tags .= "B" unless $totalOnly; # include button remapping
 				my $metadata = _songData($request, $track, $tags);
 				$request->addResult('remoteMeta', $metadata);
@@ -4327,7 +4327,7 @@ sub statusQuery {
 
 					push @addedFromWork, $track->added_from_work;
 
-					if ( $track->remote ) {
+					if ( ref($track) ne 'Slim::Schema::Track' && $track->remote ) {
 						push @tracks, $track;
 					}
 					else {
@@ -4523,7 +4523,7 @@ sub songinfoQuery {
 
 	} elsif ( defined $url ){
 
-		$track = Slim::Schema->libraryOjectForUrl($url);
+		$track = Slim::Schema->libraryObjectForUrl($url);
 	}
 
 	# now build the result
@@ -5776,7 +5776,7 @@ sub _songData {
 	}
 
 	# figure out the track object
-	my $track = Slim::Schema->libraryOjectForUrl($pathOrObj);
+	my $track = Slim::Schema->libraryObjectForUrl($pathOrObj);
 
 	if (!blessed($track) || !$track->can('id')) {
 
@@ -5796,7 +5796,7 @@ sub _songData {
 
 	# If we have a remote track, check if a plugin can provide metadata
 	my $remoteMeta = {};
-	my $isRemote = $track->remote;
+	my $isRemote = $track->remote && ref($track) ne 'Slim::Schema::Track';
 	my $url = $track->url;
 
 	my $song;

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -84,7 +84,7 @@ sub track {
 		$objOrUrl = ${playList($client)}[$index];
 	}
 
-	if ( $objOrUrl && ($refresh || !blessed($objOrUrl) || ref($objOrUrl) eq 'Slim::Schema::RemoteTrack' && $objOrUrl->url) ) {
+	if ( $objOrUrl && ( $refresh || !blessed($objOrUrl) || _remoteTrackWithUrl($objOrUrl) ) ) {
 
 		$objOrUrl = Slim::Schema->libraryObjectForUrl({
 			'url'      => $objOrUrl,
@@ -93,7 +93,7 @@ sub track {
 		});
 
 		if ($refresh) {
-			$objOrUrl = refreshTrack($client, $objOrUrl->url);
+			$objOrUrl = refreshTrack($client, $objOrUrl->url, $objOrUrl);
 		}
 	}
 
@@ -116,7 +116,7 @@ sub songs {
 	{
 		# Use $_ here to use perl's inline replace semantics
 
-		if ( $_ && (!blessed($_) || ref($_) eq 'Slim::Schema::RemoteTrack' && $_->url) ) {
+		if ( $_ && (!blessed($_) || _remoteTrackWithUrl($_) ) ) {
 
 			# If we instantiate a Track from a URL then
 			# back-patch the playlist item with the Track. This could be common
@@ -143,9 +143,9 @@ sub songs {
 
 # Refresh track(s) in a client playlist from the database
 sub refreshTrack {
-	my ( $client, $url ) = @_;
+	my ( $client, $url, $track ) = @_;
 
-	my $track = Slim::Schema->libraryObjectForUrl( {
+	$track ||= Slim::Schema->objectForUrl( {
 		url      => $url,
 		create   => 1,
 		readTags => 1,
@@ -1228,6 +1228,10 @@ sub _playlistUrlForClient {
 	);
 }
 
+sub _remoteTrackWithUrl {
+	my $track = shift;
+	return ref($track) eq 'Slim::Schema::RemoteTrack' && $track->url;
+}
 
 1;
 

--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -84,9 +84,9 @@ sub track {
 		$objOrUrl = ${playList($client)}[$index];
 	}
 
-	if ( $objOrUrl && ($refresh || !blessed($objOrUrl)) ) {
+	if ( $objOrUrl && ($refresh || !blessed($objOrUrl) || ref($objOrUrl) eq 'Slim::Schema::RemoteTrack' && $objOrUrl->url) ) {
 
-		$objOrUrl = Slim::Schema->objectForUrl({
+		$objOrUrl = Slim::Schema->libraryObjectForUrl({
 			'url'      => $objOrUrl,
 			'create'   => 1,
 			'readTags' => 1,
@@ -116,13 +116,13 @@ sub songs {
 	{
 		# Use $_ here to use perl's inline replace semantics
 
-		if ( $_ && !blessed($_) ) {
+		if ( $_ && (!blessed($_) || ref($_) eq 'Slim::Schema::RemoteTrack' && $_->url) ) {
 
 			# If we instantiate a Track from a URL then
 			# back-patch the playlist item with the Track. This could be common
 			# for remote tracks.
 
-			my $track = Slim::Schema->objectForUrl({
+			my $track = Slim::Schema->libraryObjectForUrl({
 					'url'      => $_,
 					'create'   => 1,
 					'readTags' => 1,
@@ -145,7 +145,7 @@ sub songs {
 sub refreshTrack {
 	my ( $client, $url ) = @_;
 
-	my $track = Slim::Schema->objectForUrl( {
+	my $track = Slim::Schema->libraryObjectForUrl( {
 		url      => $url,
 		create   => 1,
 		readTags => 1,

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -87,9 +87,10 @@ sub new {
 	# Bug: 3390 - reload the track if it's changed.
 	my $url      = blessed($objOrUrl) && $objOrUrl->can('url') ? $objOrUrl->url : $objOrUrl;
 
- 	my $track    = Slim::Schema->objectForUrl({
+	my $track    = Slim::Schema->libraryObjectForUrl({
 		'url'      => $url,
-		'readTags' => 1
+		'readTags' => 1,
+		'matchUrl' => 1,
 	});
 
 	if (!blessed($track) || !$track->can('url')) {

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -87,10 +87,9 @@ sub new {
 	# Bug: 3390 - reload the track if it's changed.
 	my $url      = blessed($objOrUrl) && $objOrUrl->can('url') ? $objOrUrl->url : $objOrUrl;
 
-	my $track    = Slim::Schema->libraryObjectForUrl({
+	my $track    = Slim::Schema->objectForUrl({
 		'url'      => $url,
-		'readTags' => 1,
-		'matchUrl' => 1,
+		'readTags' => 1
 	});
 
 	if (!blessed($track) || !$track->can('url')) {

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -870,12 +870,10 @@ sub libraryObjectForUrl {
 
 	my $url = $args;
 	my $playlist;
-	my $matchUrl;
 
 	if (ref($args) eq 'HASH') {
 		$url        = $args->{'url'};
 		$playlist   = $args->{'playlist'};
-		$matchUrl   = $args->{'matchUrl'};
 	}
 
 	if (ref($url) eq 'Slim::Schema::RemoteTrack' && $url->url) {
@@ -883,7 +881,7 @@ sub libraryObjectForUrl {
 	}
 
 	if (!ref $url && Slim::Music::Info::isRemoteURL($url)) {
-		my $track = $self->_retrieveTrack($url, $playlist, $matchUrl ? undef : 'integrateRemote');
+		my $track = $self->_retrieveTrack($url, $playlist, 'integrateRemote');
 
 		return $track if $track;
 	}

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -872,8 +872,8 @@ sub libraryObjectForUrl {
 	my $playlist;
 
 	if (ref($args) eq 'HASH') {
-		$url        = $args->{'url'};
-		$playlist   = $args->{'playlist'};
+		$url      = $args->{'url'};
+		$playlist = $args->{'playlist'};
 	}
 
 	if (ref($url) eq 'Slim::Schema::RemoteTrack' && $url->url) {

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -864,23 +864,27 @@ remote track imported into the local database.
 
 =cut
 
-sub libraryOjectForUrl {
+sub libraryObjectForUrl {
 	my $self = shift;
 	my $args = shift;
 
 	my $url = $args;
 	my $playlist;
+	my $matchUrl;
+
+	if (ref($args) eq 'HASH') {
+		$url        = $args->{'url'};
+		$playlist   = $args->{'playlist'};
+		$matchUrl   = $args->{'matchUrl'};
+	}
 
 	if (ref($url) eq 'Slim::Schema::RemoteTrack' && $url->url) {
 		$url = $url->url;
 	}
-	elsif (ref($url) eq 'HASH') {
-		$url = $url->{'url'};
-		$playlist = $url->{'playlist'};
-	}
 
 	if (!ref $url && Slim::Music::Info::isRemoteURL($url)) {
-		my $track = $self->_retrieveTrack($url, $playlist, 'integrateRemote');
+		my $track = $self->_retrieveTrack($url, $playlist, $matchUrl ? undef : 'integrateRemote');
+
 		return $track if $track;
 	}
 


### PR DESCRIPTION
This re-implements #1415 on top of the remote-trackobj branch. From that PR:

> This change ensures that remote tracks which are in the database go through the same path as a local track in `statusQuery`. That is they will use `_getTagDataForTracks`.
> 
> This improves performance by not calling the remote service plugin handler and provides improved and consistent metadata through the use of `_getSongDataFromHash`, rather than having to keep the `$remoteMeta` logic in `_getSongData` in line.

Additionally, I've amended the new `libraryObjectForUrl` function so it handles a hash parameter with an object inside.

Tested with Qobuz (imported and not), local tracks, BBC Sounds, standard radio streams. Further testing advised (Spotify, BandCamp...) to make sure I've got it right this time!