### PR TITLE
Fix for squeezer

### DIFF
--- a/Slim/Menu/AlbumInfo.pm
+++ b/Slim/Menu/AlbumInfo.pm
@@ -233,13 +233,15 @@ sub infoContributors {
 		my ($items, $contributor, $role) = @_;
 
 		my $id = $contributor->id;
+		my $itemsFixedParams = { mode => 'albums', artist_id => $id, library_id => $library_id };
+		# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
+		$itemsFixedParams->{role_id} = $role if !grep { $_ eq $role } ('ARTIST','ALBUMARTIST','TRACKARTIST');
 
 		my %actions = (
 			allAvailableActionsDefined => 1,
 			items => {
 				command     => ['browselibrary', 'items'],
-				# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, (grep /^\Q$role\E$/, ('ARTIST','ALBUMARTIST','TRACKARTIST') ? '' : role_id => $role) },
+				fixedParams => $itemsFixedParams,
 			},
 			play => {
 				command     => ['playlistcontrol'],

--- a/Slim/Menu/AlbumInfo.pm
+++ b/Slim/Menu/AlbumInfo.pm
@@ -240,6 +240,7 @@ sub infoContributors {
 				command     => ['browselibrary', 'items'],
 				# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
 				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => ((grep /^$role$/, ('ARTIST','ALBUMARTIST','TRACKARTIST')) ? undef : $role) },
+				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, (grep /^\Q$role\E$/, ('ARTIST','ALBUMARTIST','TRACKARTIST') ? '' : role_id => $role) },
 			},
 			play => {
 				command     => ['playlistcontrol'],

--- a/Slim/Menu/AlbumInfo.pm
+++ b/Slim/Menu/AlbumInfo.pm
@@ -239,7 +239,6 @@ sub infoContributors {
 			items => {
 				command     => ['browselibrary', 'items'],
 				# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => ((grep /^$role$/, ('ARTIST','ALBUMARTIST','TRACKARTIST')) ? undef : $role) },
 				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, (grep /^\Q$role\E$/, ('ARTIST','ALBUMARTIST','TRACKARTIST') ? '' : role_id => $role) },
 			},
 			play => {

--- a/Slim/Menu/TrackInfo.pm
+++ b/Slim/Menu/TrackInfo.pm
@@ -356,13 +356,15 @@ sub infoContributors {
 		my ($items, $contributor, $role) = @_;
 
 		my $id = $contributor->id;
+		my $itemsFixedParams = { mode => 'albums', artist_id => $id, library_id => $library_id };
+		# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
+		$itemsFixedParams->{role_id} = $role if !grep { $_ eq $role } ('ARTIST','ALBUMARTIST','TRACKARTIST');
 
 		my %actions = (
 			allAvailableActionsDefined => 1,
 			items => {
 				command     => ['browselibrary', 'items'],
-				# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, (grep /^\Q$role\E$/, ('ARTIST','ALBUMARTIST','TRACKARTIST') ? '' : role_id => $role) },
+				fixedParams => $itemsFixedParams,
 			},
 			play => {
 				command     => ['playlistcontrol'],

--- a/Slim/Menu/TrackInfo.pm
+++ b/Slim/Menu/TrackInfo.pm
@@ -362,7 +362,7 @@ sub infoContributors {
 			items => {
 				command     => ['browselibrary', 'items'],
 				# If the role is ARTIST/ALBUMARTIST/TRACKARTIST, albumsQuery will sort it out, otherwise pass the role.
-				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, role_id => ((grep /^$role$/, ('ARTIST','ALBUMARTIST','TRACKARTIST')) ? undef : $role) },
+				fixedParams => { mode => 'albums', artist_id => $id, library_id => $library_id, (grep /^\Q$role\E$/, ('ARTIST','ALBUMARTIST','TRACKARTIST') ? '' : role_id => $role) },
 			},
 			play => {
 				command     => ['playlistcontrol'],


### PR DESCRIPTION
https://github.com/LMS-Community/slimserver/commit/c62e9a40b065192f0f2fe71dca308410e0b1df10 introduced an incompatibility with Squeezer: see https://github.com/kaaholst/android-squeezer/issues/848#issuecomment-3169505688

In brief, if we pass `role_id:undef` Squeezer takes that as a literal value of `"undef"`.