### PR TITLE
Decode UTF-8 name in html form parameters

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -586,6 +586,7 @@ sub processHTTP {
 					# representation of the unescaped
 					# UTF-8 string into a "real" UTF-8
 					# string with the appropriate magic set.
+					$name = Slim::Utils::Unicode::utf8decode($name);
 					if ($value ne '*') {
 						$value = Slim::Utils::Unicode::utf8decode($value);
 					}


### PR DESCRIPTION
A plugin uses non-ascii names in form.
It is required to decode as UTF-8.