### PR TITLE
Fix cached sql counts for search query results

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -694,7 +694,7 @@ sub albumsQuery {
 	my $stillScanning = Slim::Music::Import->stillScanning();
 
 	# Get count of all results, the count is cached until the next rescan done event
-	my $cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
+	my $cacheKey = _buildCacheKey($sql, $p, $search, $client);
 
 	if ( $sort =~ /^(?:new|changed|playcount|recentlyplayed)$/ && $cache->{$newAlbumsCacheKey} && !$ignoreNewAlbumsCache ) {
 		my $albumCount = scalar @{$cache->{$newAlbumsCacheKey}};
@@ -1247,7 +1247,7 @@ sub artistsQuery {
 	my $stillScanning = Slim::Music::Import->stillScanning();
 
 	# Get count of all results, the count is cached until the next rescan done event
-	$cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
+	$cacheKey = _buildCacheKey($sql, $p, $search, $client);
 
 	my $count = $cache->{$cacheKey};
 
@@ -1852,7 +1852,7 @@ sub genresQuery {
 	my $stillScanning = Slim::Music::Import->stillScanning();
 
 	# Get count of all results, the count is cached until the next rescan done event
-	my $cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
+	my $cacheKey = _buildCacheKey($sql, $p, $search, $client);
 
 	my $count = $cache->{$cacheKey};
 	if ( !$count ) {
@@ -5110,7 +5110,7 @@ sub worksQuery {
 
 	# Get count of unique composers, the count is cached until the next rescan done event
 	my $ccSql = sprintf($sql . " GROUP BY composer.id", "'c'");
-	my $cacheKey = md5_hex($ccSql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
+	my $cacheKey = _buildCacheKey($ccSql, $p, $search, $client);
 
 	my $composerCount = $cache->{$cacheKey};
 	if ( !$composerCount ) {
@@ -5136,7 +5136,7 @@ sub worksQuery {
 
 	# Get count of all results, the count is cached until the next rescan done event
 	my $cSql = sprintf($sql, "'c'");
-	$cacheKey = md5_hex($cSql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
+	$cacheKey = _buildCacheKey($cSql, $p, $search, $client);
 
 	my $count = $cache->{$cacheKey};
 	if ( !$count ) {
@@ -6535,7 +6535,7 @@ sub _getTagDataForTracks {
 	if ( $count_only || (my $limit = $args->{limit}) ) {
 		# Let the caller worry about the limit values
 
-		my $cacheKey = md5_hex($sql . Slim::Utils::Unicode::utf8on(join( ':', @$p, @$w )) . (_searchPhrase($search) || ''));
+		my $cacheKey = _buildCacheKey($sql, $p, $search, undef);
 
 		# use short lived cache, as we might be dealing with changing data (eg. playcount)
 		if ( my $cached = $bmfCache{$cacheKey} ) {
@@ -6794,10 +6794,14 @@ sub _notLocalTrackAndRemoteUrl {
 	return ref($track) && ref($track) ne 'Slim::Schema::Track' && $track->can('remote') && $track->remote;
 }
 
-sub _searchPhrase {
+sub _buildCacheKey {
+	my ($sql, $p, $search, $client) = @_;
+
 	# Slim::Utils::Text::ignoreCase (amongst other useful things) will remove the leading quote from a search phrase, so put it back.
-	my $search = shift;
-	return ($search =~ /^"/ ? '"' : '') . Slim::Utils::Text::ignoreCase($search, 1);
+	return $sql
+		. Slim::Utils::Unicode::utf8on(join( ':', @$p ))
+		. Slim::Music::VirtualLibraries->getLibraryIdForClient($client)
+		. ($search =~ /^"/ ? '"' : '') . Slim::Utils::Text::ignoreCase($search, 1);
 }
 
 =head1 SEE ALSO

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -6798,10 +6798,11 @@ sub _buildCacheKey {
 	my ($sql, $p, $search, $client) = @_;
 
 	# Slim::Utils::Text::ignoreCase (amongst other useful things) will remove the leading quote from a search phrase, so put it back.
-	return $sql
+	return md5_hex($sql
 		. Slim::Utils::Unicode::utf8on(join( ':', @$p ))
 		. Slim::Music::VirtualLibraries->getLibraryIdForClient($client)
-		. ($search =~ /^"/ ? '"' : '') . Slim::Utils::Text::ignoreCase($search, 1);
+		. ($search =~ /^"/ ? '"' : '') . Slim::Utils::Text::ignoreCase($search, 1)
+	);
 }
 
 =head1 SEE ALSO

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -694,7 +694,7 @@ sub albumsQuery {
 	my $stillScanning = Slim::Music::Import->stillScanning();
 
 	# Get count of all results, the count is cached until the next rescan done event
-	my $cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (Slim::Utils::Text::ignoreCase($search, 1) || ''));
+	my $cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
 
 	if ( $sort =~ /^(?:new|changed|playcount|recentlyplayed)$/ && $cache->{$newAlbumsCacheKey} && !$ignoreNewAlbumsCache ) {
 		my $albumCount = scalar @{$cache->{$newAlbumsCacheKey}};
@@ -1247,7 +1247,7 @@ sub artistsQuery {
 	my $stillScanning = Slim::Music::Import->stillScanning();
 
 	# Get count of all results, the count is cached until the next rescan done event
-	$cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (Slim::Utils::Text::ignoreCase($search, 1) || ''));
+	$cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
 
 	my $count = $cache->{$cacheKey};
 
@@ -1852,7 +1852,7 @@ sub genresQuery {
 	my $stillScanning = Slim::Music::Import->stillScanning();
 
 	# Get count of all results, the count is cached until the next rescan done event
-	my $cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client));
+	my $cacheKey = md5_hex($sql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
 
 	my $count = $cache->{$cacheKey};
 	if ( !$count ) {
@@ -5110,7 +5110,7 @@ sub worksQuery {
 
 	# Get count of unique composers, the count is cached until the next rescan done event
 	my $ccSql = sprintf($sql . " GROUP BY composer.id", "'c'");
-	my $cacheKey = md5_hex($ccSql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client));
+	my $cacheKey = md5_hex($ccSql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
 
 	my $composerCount = $cache->{$cacheKey};
 	if ( !$composerCount ) {
@@ -5136,7 +5136,7 @@ sub worksQuery {
 
 	# Get count of all results, the count is cached until the next rescan done event
 	my $cSql = sprintf($sql, "'c'");
-	$cacheKey = md5_hex($cSql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client));
+	$cacheKey = md5_hex($cSql . join( '', @{$p} ) . Slim::Music::VirtualLibraries->getLibraryIdForClient($client) . (_searchPhrase($search) || ''));
 
 	my $count = $cache->{$cacheKey};
 	if ( !$count ) {
@@ -6535,7 +6535,7 @@ sub _getTagDataForTracks {
 	if ( $count_only || (my $limit = $args->{limit}) ) {
 		# Let the caller worry about the limit values
 
-		my $cacheKey = md5_hex($sql . Slim::Utils::Unicode::utf8on(join( ':', @$p, @$w )) . (Slim::Utils::Text::ignoreCase($search, 1) || ''));
+		my $cacheKey = md5_hex($sql . Slim::Utils::Unicode::utf8on(join( ':', @$p, @$w )) . (_searchPhrase($search) || ''));
 
 		# use short lived cache, as we might be dealing with changing data (eg. playcount)
 		if ( my $cached = $bmfCache{$cacheKey} ) {
@@ -6792,6 +6792,12 @@ sub _createIndexList {
 sub _notLocalTrackAndRemoteUrl {
 	my $track = shift;
 	return ref($track) && ref($track) ne 'Slim::Schema::Track' && $track->can('remote') && $track->remote;
+}
+
+sub _searchPhrase {
+	# Slim::Utils::Text::ignoreCase (amongst other useful things) will remove the leading quote from a search phrase, so put it back.
+	my $search = shift;
+	return ($search =~ /^"/ ? '"' : '') . Slim::Utils::Text::ignoreCase($search, 1);
 }
 
 =head1 SEE ALSO


### PR DESCRIPTION
Caching of SQL query counts in Queries.pm are not distinguishing between searches with separate search terms and those with a search phrase (i.e. when the search string starts with a double quote).

This is leading to inaccurate results counts shown in the Default Skin search results page, and sometimes prevents the user browsing the full results at all, because the page doesn't think there are enough results to need to create a "More..." link.

The problem is that within the `Slim::Utils::Text::ignoreCase` call (specifically in `Slim::Utils::Text::ignorePunct`) the leading `"` is stripped out.

On the basis that this call is useful in other ways (eg transliteration) I've created a helper function in Queries.pm that puts the leading quote back. 