### PR TITLE
Add getInitialAudioBlock to FLAC.pm for seek support

### DIFF
--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -1007,6 +1007,52 @@ sub crc8 {
 	return $val;
 }
 
+=head2 getInitialAudioBlock( $class, $fh, $track, $time )
+
+Returns the FLAC header (fLaC marker + all metadata blocks) for prepending
+when seeking. This allows decoders that create new streams on seek to properly
+initialize, similar to how AIFF and WAV formats handle seeking.
+
+Only works for local files - remote streams return undef.
+
+=cut
+
+sub getInitialAudioBlock {
+	my ($class, $fh, $track, $time) = @_;
+
+	# Only works for local files - remote streams (Qobuz, Tidal, etc.)
+	# are not seekable and will throw an error on seek
+	my $canSeek = eval { seek($fh, 0, 0) };
+	return undef unless $canSeek;
+
+	# Get the audio_offset which tells us where audio frames start
+	# Everything before that is the header (fLaC marker + metadata blocks)
+	my $s = Audio::Scan->scan_fh(flac => $fh);
+	my $length = $s->{info}->{audio_offset} || return undef;
+
+	main::DEBUGLOG && $sourcelog->is_debug && $sourcelog->debug("FLAC getInitialAudioBlock: header length = $length bytes");
+
+	# Read the complete header (fLaC + all metadata blocks)
+	seek($fh, 0, 0);
+	read($fh, my $buffer, $length);
+	seek($fh, 0, 0);
+
+	if (length($buffer) != $length) {
+		$sourcelog->warn("FLAC getInitialAudioBlock: could not read full header");
+		return undef;
+	}
+
+	# Verify we got a valid FLAC header
+	if (substr($buffer, 0, 4) ne 'fLaC') {
+		$sourcelog->warn("FLAC getInitialAudioBlock: invalid FLAC header");
+		return undef;
+	}
+
+	main::DEBUGLOG && $sourcelog->is_debug && $sourcelog->debug("FLAC getInitialAudioBlock: returning $length byte header for seek");
+
+	return $buffer;
+}
+
 sub canSeek { 1 }
 
 =head1 SEE ALSO


### PR DESCRIPTION
  ## Summary

  FLAC.pm was missing the `getInitialAudioBlock` function that AIFF.pm and WAV.pm already implement. This caused seeking to fail for clients that create new decoder streams on seek.

  ## Problem

  When a client seeks in a FLAC file, the server finds the frame boundary and streams raw FLAC frames from that point—but does NOT prepend the `fLaC` header and STREAMINFO metadata (unlike AIFF/WAV).

  Players like squeezelite cache STREAMINFO client-side. However, clients using libraries like BASS that create new
  decoder instances on seek fail because they expect a complete FLAC stream.

  ## Solution

  Added `getInitialAudioBlock()` which:
  - Returns the complete FLAC header (`fLaC` + all metadata blocks)
  - Uses `audio_offset` from Audio::Scan to determine header length
  - Safely handles remote streams (Qobuz, Tidal) via `eval{}` - returns `undef`
  - Validates header integrity before returning

  ## Testing

  - Local FLAC files - seeking works correctly
  - Qobuz streams - returns `undef` gracefully, no errors
  - Verified in LyrPlay iOS app (BASS-based client)
  - Tested with Squeezelite v2.0.0-1476-pCP - no apparent issues with local files or Qobuzz
