### PR TITLE
Fix error calling getMetaDataFor() without valid $client

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5823,42 +5823,42 @@ sub _songData {
 	my $song;
 	if ( my $client = $request->client ) {
 		$song = $client->currentSongForUrl($url);
+	}
 
-		if ( $isRemote ) {
-			my $handler = Slim::Player::ProtocolHandlers->handlerForURL($url);
+	if ( $isRemote ) {
+		my $handler = Slim::Player::ProtocolHandlers->handlerForURL($url);
 
-			if ( $handler && $handler->can('getMetadataFor') ) {
-				# Don't modify source data
-				$remoteMeta = Storable::dclone(
-					$handler->getMetadataFor( $client, $url )
-				);
+		if ( $handler && $handler->can('getMetadataFor') ) {
+			# Don't modify source data
+			$remoteMeta = Storable::dclone(
+				$handler->getMetadataFor( $request->client, $url )
+			);
 
-				$remoteMeta->{a} = $remoteMeta->{artist};
-				$remoteMeta->{A} = $remoteMeta->{artist};
-				$remoteMeta->{E} = $remoteMeta->{extid};
-				$remoteMeta->{l} = $remoteMeta->{album};
-				$remoteMeta->{i} = $remoteMeta->{disc};
-				$remoteMeta->{K} = $remoteMeta->{cover};
-				$remoteMeta->{d} = ( $remoteMeta->{duration} || $remoteMeta->{secs} || 0 ) + 0;
-				$remoteMeta->{Y} = $remoteMeta->{replay_gain};
-				$remoteMeta->{o} = $remoteMeta->{type};
-				$remoteMeta->{r} = $remoteMeta->{bitrate};
-				$remoteMeta->{B} = $remoteMeta->{buttons};
-				$remoteMeta->{L} = $remoteMeta->{info_link};
-				$remoteMeta->{t} = $remoteMeta->{tracknum};
-				$remoteMeta->{y} = $remoteMeta->{year};
-				$remoteMeta->{T} = $remoteMeta->{samplerate};
-				$remoteMeta->{I} = $remoteMeta->{samplesize};
-				$remoteMeta->{W} = $remoteMeta->{releasetype};
-				$remoteMeta->{b} = $remoteMeta->{work};
-				$remoteMeta->{h} = $remoteMeta->{grouping};
-				$remoteMeta->{'1'} = $remoteMeta->{performance};
-				$remoteMeta->{z} = $remoteMeta->{subtitle};
+			$remoteMeta->{a} = $remoteMeta->{artist};
+			$remoteMeta->{A} = $remoteMeta->{artist};
+			$remoteMeta->{E} = $remoteMeta->{extid};
+			$remoteMeta->{l} = $remoteMeta->{album};
+			$remoteMeta->{i} = $remoteMeta->{disc};
+			$remoteMeta->{K} = $remoteMeta->{cover};
+			$remoteMeta->{d} = ( $remoteMeta->{duration} || $remoteMeta->{secs} || 0 ) + 0;
+			$remoteMeta->{Y} = $remoteMeta->{replay_gain};
+			$remoteMeta->{o} = $remoteMeta->{type};
+			$remoteMeta->{r} = $remoteMeta->{bitrate};
+			$remoteMeta->{B} = $remoteMeta->{buttons};
+			$remoteMeta->{L} = $remoteMeta->{info_link};
+			$remoteMeta->{t} = $remoteMeta->{tracknum};
+			$remoteMeta->{y} = $remoteMeta->{year};
+			$remoteMeta->{T} = $remoteMeta->{samplerate};
+			$remoteMeta->{I} = $remoteMeta->{samplesize};
+			$remoteMeta->{W} = $remoteMeta->{releasetype};
+			$remoteMeta->{b} = $remoteMeta->{work};
+			$remoteMeta->{h} = $remoteMeta->{grouping};
+			$remoteMeta->{'1'} = $remoteMeta->{performance};
+			$remoteMeta->{z} = $remoteMeta->{subtitle};
 
-				# Distance from the live edge of live remote stream. -1 is not live, 0 is live at the edge, >0 is distance in seconds from the live edge.
-				# $remoteMeta->{live_edge} contains distance from live edge. Will only be populated by 3rd party handlers that support dynamic adaptive live streams.
-				$remoteMeta->{V} = $remoteMeta->{live_edge} // ($song && $song->isLive() ? 0 : -1);
-			}
+			# Distance from the live edge of live remote stream. -1 is not live, 0 is live at the edge, >0 is distance in seconds from the live edge.
+			# $remoteMeta->{live_edge} contains distance from live edge. Will only be populated by 3rd party handlers that support dynamic adaptive live streams.
+			$remoteMeta->{V} = $remoteMeta->{live_edge} // ($song && $song->isLive() ? 0 : -1);
 		}
 	}
 

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5823,42 +5823,42 @@ sub _songData {
 	my $song;
 	if ( my $client = $request->client ) {
 		$song = $client->currentSongForUrl($url);
-	}
 
-	if ( $isRemote ) {
-		my $handler = Slim::Player::ProtocolHandlers->handlerForURL($url);
+		if ( $isRemote ) {
+			my $handler = Slim::Player::ProtocolHandlers->handlerForURL($url);
 
-		if ( $handler && $handler->can('getMetadataFor') ) {
-			# Don't modify source data
-			$remoteMeta = Storable::dclone(
-				$handler->getMetadataFor( $request->client, $url )
-			);
+			if ( $handler && $handler->can('getMetadataFor') ) {
+				# Don't modify source data
+				$remoteMeta = Storable::dclone(
+					$handler->getMetadataFor( $client, $url )
+				);
 
-			$remoteMeta->{a} = $remoteMeta->{artist};
-			$remoteMeta->{A} = $remoteMeta->{artist};
-			$remoteMeta->{E} = $remoteMeta->{extid};
-			$remoteMeta->{l} = $remoteMeta->{album};
-			$remoteMeta->{i} = $remoteMeta->{disc};
-			$remoteMeta->{K} = $remoteMeta->{cover};
-			$remoteMeta->{d} = ( $remoteMeta->{duration} || $remoteMeta->{secs} || 0 ) + 0;
-			$remoteMeta->{Y} = $remoteMeta->{replay_gain};
-			$remoteMeta->{o} = $remoteMeta->{type};
-			$remoteMeta->{r} = $remoteMeta->{bitrate};
-			$remoteMeta->{B} = $remoteMeta->{buttons};
-			$remoteMeta->{L} = $remoteMeta->{info_link};
-			$remoteMeta->{t} = $remoteMeta->{tracknum};
-			$remoteMeta->{y} = $remoteMeta->{year};
-			$remoteMeta->{T} = $remoteMeta->{samplerate};
-			$remoteMeta->{I} = $remoteMeta->{samplesize};
-			$remoteMeta->{W} = $remoteMeta->{releasetype};
-			$remoteMeta->{b} = $remoteMeta->{work};
-			$remoteMeta->{h} = $remoteMeta->{grouping};
-			$remoteMeta->{'1'} = $remoteMeta->{performance};
-			$remoteMeta->{z} = $remoteMeta->{subtitle};
+				$remoteMeta->{a} = $remoteMeta->{artist};
+				$remoteMeta->{A} = $remoteMeta->{artist};
+				$remoteMeta->{E} = $remoteMeta->{extid};
+				$remoteMeta->{l} = $remoteMeta->{album};
+				$remoteMeta->{i} = $remoteMeta->{disc};
+				$remoteMeta->{K} = $remoteMeta->{cover};
+				$remoteMeta->{d} = ( $remoteMeta->{duration} || $remoteMeta->{secs} || 0 ) + 0;
+				$remoteMeta->{Y} = $remoteMeta->{replay_gain};
+				$remoteMeta->{o} = $remoteMeta->{type};
+				$remoteMeta->{r} = $remoteMeta->{bitrate};
+				$remoteMeta->{B} = $remoteMeta->{buttons};
+				$remoteMeta->{L} = $remoteMeta->{info_link};
+				$remoteMeta->{t} = $remoteMeta->{tracknum};
+				$remoteMeta->{y} = $remoteMeta->{year};
+				$remoteMeta->{T} = $remoteMeta->{samplerate};
+				$remoteMeta->{I} = $remoteMeta->{samplesize};
+				$remoteMeta->{W} = $remoteMeta->{releasetype};
+				$remoteMeta->{b} = $remoteMeta->{work};
+				$remoteMeta->{h} = $remoteMeta->{grouping};
+				$remoteMeta->{'1'} = $remoteMeta->{performance};
+				$remoteMeta->{z} = $remoteMeta->{subtitle};
 
-			# Distance from the live edge of live remote stream. -1 is not live, 0 is live at the edge, >0 is distance in seconds from the live edge.
-			# $remoteMeta->{live_edge} contains distance from live edge. Will only be populated by 3rd party handlers that support dynamic adaptive live streams.
-			$remoteMeta->{V} = $remoteMeta->{live_edge} // ($song && $song->isLive() ? 0 : -1);
+				# Distance from the live edge of live remote stream. -1 is not live, 0 is live at the edge, >0 is distance in seconds from the live edge.
+				# $remoteMeta->{live_edge} contains distance from live edge. Will only be populated by 3rd party handlers that support dynamic adaptive live streams.
+				$remoteMeta->{V} = $remoteMeta->{live_edge} // ($song && $song->isLive() ? 0 : -1);
+			}
 		}
 	}
 

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -1046,7 +1046,7 @@ sub getMetadataFor {
 
 	# Check for parsed WMA metadata, this is here because WMA may
 	# use HTTP protocol handler. Check for container and track
-	my $song = $client->playingSong();
+	my $song = $client->playingSong() if $client;
 	my $current = ($song->track->url eq $url || $song->currentTrack->url eq $url) if $song;
 
 	if ( $current ) {


### PR DESCRIPTION
The following error message is logged when `getMetaDataFor` is called from `_songData` without a valid value in `$request->client`, which can happen under certain conditions.

Slim::Control::Request::execute (1884) Error: While trying to run function coderef [Slim::Control::Queries::playlistsTracksQuery]: [Can't call method "playingSong" on an undefined value at /usr/share/perl5/Slim/Player/Protocols/HTTP.pm line 1049. ]