### PR TITLE
Prevent "Error: Couldn't load module:  (jpg)" messages

### DIFF
--- a/Slim/Web/Graphics.pm
+++ b/Slim/Web/Graphics.pm
@@ -453,7 +453,7 @@ sub artworkRequest {
 			my $formatClass = Slim::Formats->classForFormat($ct);
 			my $body;
 
-			if (Slim::Formats->loadTagFormatForType($ct) && $formatClass->can('getCoverArt')) {
+			if ($formatClass && $formatClass->can('getCoverArt') && Slim::Formats->loadTagFormatForType($ct)) {
 				$body = $formatClass->getCoverArt($fullpath);
 			}
 


### PR DESCRIPTION
Check for a valid `$formatClass` before calling `loadTagFormatForType()` to avoid logging the following error msg when displaying cover art from the Now Playing view.

**Slim::Formats::loadTagFormatForType (121) Error: Couldn't load module:  (jpg) : [syntax error at (eval 5460) line 1, at EOF**

This error message has been polluting my LMS log for years and I assumed it was due to a missing perl module or obscure graphics package on my RPi, but I could never consistently reproduce it until now. 