### PR TITLE
Consider all of a track's genres for scrob exclusion

### DIFF
--- a/Slim/Plugin/AudioScrobbler/Plugin.pm
+++ b/Slim/Plugin/AudioScrobbler/Plugin.pm
@@ -396,14 +396,27 @@ sub newsongCallback {
 	my @ignoreGenres  = split(/\s*,\s*/, $prefs->get('ignoreGenres'));
 
 
-	my $genre = ($track->genre && ref $track->genre ? $track->genre->name : $track->genre) || $meta->{genre};
+	my @trackGenres = map { $_->name } $track->genres;
+	if (!@trackGenres && $meta->{genre}) {
+		push @trackGenres, $meta->{genre};
+	}
 
-	if ( (scalar @ignoreGenres && $genre && grep { $genre =~ /\Q$_\E/i } @ignoreGenres )
+	my $genreIgnored = 0;
+	if (scalar @ignoreGenres && scalar @trackGenres) {
+		foreach my $trackGenre (@trackGenres) {
+			if (grep { $trackGenre =~ /\Q$_\E/i } @ignoreGenres) {
+				$genreIgnored = 1;
+				last;
+			}
+		}
+	}
+
+	if ( $genreIgnored
 		|| (scalar @ignoreTitles && grep { $title =~ /\Q$_\E/i } @ignoreTitles)
 		|| (scalar @ignoreArtists && grep { ($track->artistName || $meta->{artist} || '') =~ /\Q$_\E/i } @ignoreArtists)
 		|| (scalar @ignoreAlbums && grep { ($track->albumname || $meta->{album} || '') =~ /\Q$_\E/i } @ignoreAlbums)
 	) {
-		main::DEBUGLOG && $log->debug( sprintf("Ignoring %s, it's failing one of the ignored items tests: %s, %s, %s", $title, $track->artistName || $meta->{artist}, $track->albumname || $meta->{album}, ($track->genre ? $track->genre->name : '')) );
+		main::DEBUGLOG && $log->debug( sprintf("Ignoring %s, it's failing one of the ignored items tests: %s; %s; %s", $title, $track->artistName || $meta->{artist}, $track->albumname || $meta->{album}, (@trackGenres ? join(', ', @trackGenres) : '')) );
 		return;
 	}
 

--- a/Slim/Plugin/AudioScrobbler/Plugin.pm
+++ b/Slim/Plugin/AudioScrobbler/Plugin.pm
@@ -395,29 +395,28 @@ sub newsongCallback {
 	my @ignoreArtists = split(/\s*,\s*/, $prefs->get('ignoreArtists'));
 	my @ignoreGenres  = split(/\s*,\s*/, $prefs->get('ignoreGenres'));
 
-
-	my @trackGenres = map { $_->name } $track->genres;
-	if (!@trackGenres && $meta->{genre}) {
-		push @trackGenres, $meta->{genre};
-	}
-
-	my $genreIgnored = 0;
-	if (scalar @ignoreGenres && scalar @trackGenres) {
-		foreach my $trackGenre (@trackGenres) {
-			if (grep { $trackGenre =~ /\Q$_\E/i } @ignoreGenres) {
-				$genreIgnored = 1;
-				last;
-			}
-		}
-	}
-
-	if ( $genreIgnored
-		|| (scalar @ignoreTitles && grep { $title =~ /\Q$_\E/i } @ignoreTitles)
+	if ( (scalar @ignoreTitles && grep { $title =~ /\Q$_\E/i } @ignoreTitles)
 		|| (scalar @ignoreArtists && grep { ($track->artistName || $meta->{artist} || '') =~ /\Q$_\E/i } @ignoreArtists)
 		|| (scalar @ignoreAlbums && grep { ($track->albumname || $meta->{album} || '') =~ /\Q$_\E/i } @ignoreAlbums)
 	) {
-		main::DEBUGLOG && $log->debug( sprintf("Ignoring %s, it's failing one of the ignored items tests: %s; %s; %s", $title, $track->artistName || $meta->{artist}, $track->albumname || $meta->{album}, (@trackGenres ? join(', ', @trackGenres) : '')) );
+		main::DEBUGLOG && $log->debug( sprintf("Ignoring %s, it's failing one of the ignored items tests: %s, %s", $title, $track->artistName || $meta->{artist}, $track->albumname || $meta->{album}) );
 		return;
+	}
+
+	if (scalar @ignoreGenres) {
+		my @trackGenres = map { $_->name } $track->genres;
+		if (!@trackGenres && $meta->{genre}) {
+			push @trackGenres, $meta->{genre};
+		}
+
+		if (scalar @trackGenres) {
+			foreach my $trackGenre (@trackGenres) {
+				if (grep { $trackGenre =~ /\Q$_\E/i } @ignoreGenres) {
+					main::DEBUGLOG && $log->debug( sprintf("Ignoring %s due to genre match: %s", $title, join(', ', @trackGenres)) );
+					return;
+				}
+			}
+		}
 	}
 
 	# We check again at half the song's length or 240 seconds, whichever comes first


### PR DESCRIPTION
The Audioscrobbler plugin allows genres to be ignored when scrobbling, but the functionality uses `$track->genre`, which only returns the first genre associated with the track. Extend the code to support checking all genres associated with the track. The code still allows for the `$meta->{genre}` fallback, but I couldn't figure out a protocol that accepted it.