### PR TITLE
Add Rescan Album feature

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -2673,6 +2673,89 @@ sub prefCommand {
 	$request->setStatusDone();
 }
 
+sub rescanAlbumCommand {
+	my $request = shift;
+
+	if ($request->isNotCommand([['rescan'], ['album']])) {
+		$request->setStatusBadDispatch();
+		return;
+	}
+
+	my $albumId = $request->getParam('album_id');
+	if (!$albumId) {
+		$log->warn("rescan album called without album_id");
+		$request->setStatusBadParams();
+		return;
+	}
+
+	my $album = Slim::Schema->find('Album', $albumId);
+	if (!$album) {
+		$log->warn("Album not found: $albumId");
+		$request->setStatusBadParams();
+		return;
+	}
+
+	# Find the directory containing this album's tracks
+	require File::Basename;
+	my %dirs;
+	for my $track ( $album->tracks ) {
+		my $url = $track->url;
+		next unless $url =~ m{^file://};
+		my $path = Slim::Utils::Misc::pathFromFileURL($url);
+		$dirs{ File::Basename::dirname($path) } = 1;
+	}
+
+	my @albumDirs = keys %dirs;
+	if (!@albumDirs) {
+		$log->warn("No local file tracks found for album $albumId");
+		$request->setStatusBadParams();
+		return;
+	}
+
+	my $singledir = shift @albumDirs;
+	main::INFOLOG && $log->info("Starting album rescan for album_id: $albumId, directory: $singledir");
+
+	# Force re-read of tags by resetting timestamps
+	my $basedir = Slim::Utils::Misc::fileURLFromPath($singledir);
+	my $dbh = Slim::Schema->dbh;
+	my $like = $basedir . '%';
+	my $rows = eval { $dbh->do('UPDATE tracks SET timestamp = 0 WHERE url LIKE ?', undef, $like) };
+	if ($@) {
+		$log->warn("Failed to prepare force-rescan for $singledir: $@");
+	} else {
+		main::INFOLOG && $log->info("Force-rescan prepared for $singledir (tracks updated: " . ($rows || 0) . ")");
+	}
+
+	# Queue additional directories if album spans multiple folders
+	for my $extraDir (@albumDirs) {
+		my $extraBase = Slim::Utils::Misc::fileURLFromPath($extraDir);
+		my $extraLike = $extraBase . '%';
+		eval { $dbh->do('UPDATE tracks SET timestamp = 0 WHERE url LIKE ?', undef, $extraLike) };
+	}
+
+	Slim::Schema->forceCommit;
+
+	# Run in-process scan
+	my @dirs = @{ Slim::Utils::Misc::getMediaDirs() };
+	if (scalar @dirs) {
+		if ( Slim::Utils::OSDetect::getOS->canAutoRescan && preferences('server')->get('autorescan') ) {
+			require Slim::Utils::AutoRescan;
+			Slim::Utils::AutoRescan->shutdown;
+		}
+
+		Slim::Utils::Progress->clear();
+
+		my $audiodirs = Slim::Utils::Misc::getAudioDirs($singledir);
+		Slim::Utils::Scanner::Local->rescan( $audiodirs, {
+			types    => 'list|audio',
+			scanName => 'directory',
+			progress => 1,
+		} ) if scalar @$audiodirs;
+	}
+
+	$request->setStatusDone();
+}
+
 sub rescanCommand {
 	my $request = shift;
 
@@ -2687,7 +2770,15 @@ sub rescanCommand {
 	my $singledir = $request->getParam('_singledir');
 
 	if ($singledir) {
-		$singledir = Slim::Utils::Misc::pathFromFileURL($singledir);
+		# If singledir is passed as a parameter (e.g. from CLI), it might be a file URL or a path.
+		if ( $singledir =~ m{^file://} ) {
+			$singledir = Slim::Utils::Misc::pathFromFileURL($singledir);
+		}
+		if ( $singledir =~ /^menu:\d+$/ ) {
+			main::INFOLOG && $log->info("Ignoring invalid singledir parameter: $singledir");
+			$request->setStatusDone();
+			return;
+		}
 
 		# don't run scan if newly added entry is disabled for all media types
 		if ( grep { /\Q$singledir\E/ } @{ Slim::Utils::Misc::getInactiveAudioDirs() }) {

--- a/Slim/Control/Request.pm
+++ b/Slim/Control/Request.pm
@@ -604,6 +604,7 @@ sub init {
 	addDispatch(['pref',           '_prefname',      '_newvalue'],                                     [0, 0, 1, \&Slim::Control::Commands::prefCommand]);
 	addDispatch(['remote',         '?'],                                                               [1, 1, 0, \&Slim::Control::Queries::cursonginfoQuery]);
 	addDispatch(['rescan',         '?'],                                                               [0, 1, 0, \&Slim::Control::Queries::rescanQuery]);
+	addDispatch(['rescan',         'album'],                                                           [0, 0, 1, \&Slim::Control::Commands::rescanAlbumCommand]);
 	addDispatch(['rescan',         '_mode',          '_singledir'],                                    [0, 0, 0, \&Slim::Control::Commands::rescanCommand]);
 	addDispatch(['rescanprogress'],                                                                    [0, 1, 1, \&Slim::Control::Queries::rescanprogressQuery]);
 	addDispatch(['restartserver'],                                                                     [0, 0, 0, \&Slim::Control::Commands::stopServer]);

--- a/Slim/Menu/AlbumInfo.pm
+++ b/Slim/Menu/AlbumInfo.pm
@@ -57,6 +57,8 @@ sub name {
 sub registerDefaultInfoProviders {
 	my $class = shift;
 
+	main::INFOLOG && $log->info("Registering AlbumInfo providers");
+
 	$class->SUPER::registerDefaultInfoProviders();
 
 	$class->registerInfoProvider( addalbum => (
@@ -72,6 +74,11 @@ sub registerDefaultInfoProviders {
 	$class->registerInfoProvider( playitem => (
 		after    => 'addalbumnext',
 		func      => \&playAlbum,
+	) );
+
+	$class->registerInfoProvider( rescan => (
+		after    => 'top',
+		func      => \&rescanAlbum,
 	) );
 
 #	$class->registerInfoProvider( artwork => (
@@ -565,6 +572,27 @@ sub addAlbum {
 		type        => $tags->{menuMode} ? 'text' : 'link',
 		playcontrol => $cmd,
 		name        => cstring($client, $add_string),
+	};
+}
+
+sub rescanAlbum {
+	my ( $client, $url, $album, $remoteMeta, $tags ) = @_;
+
+	return unless $album;
+
+	my $actions = {
+		items => {
+			command     => [ 'rescan', 'album' ],
+			fixedParams => { album_id => $album->id },
+		},
+	};
+	$actions->{'do'} = $actions->{'items'};
+
+	return {
+		itemActions => $actions,
+		nextWindow  => 'parent',
+		type        => 'link',
+		name        => cstring($client, 'RESCAN_ALBUM'),
 	};
 }
 

--- a/strings.txt
+++ b/strings.txt
@@ -6800,6 +6800,9 @@ SETUP_RESCAN
 	SV	Sök igenom mediebiblioteket igen
 	ZH_CN	重新扫描音乐库
 
+RESCAN_ALBUM
+	EN	Rescan Album
+
 SETUP_RESCAN_BUTTON
 	CS	Nové prohledání
 	DA	Gennemsøg igen


### PR DESCRIPTION
## Rescan Album Feature

### Summary
Adds a "Rescan Album" button to the album info menu that triggers a targeted rescan of an album's files, forcing re-read of metadata tags even if file timestamps haven't changed.

### Use Case
When you update metadata tags on music files (artist, title, album art, etc.), LMS may not detect changes if file modification times remain unchanged. Users may also use 3rd party tools to edit metadata on the fly when they spot errors, and want to see their changes reflected in Lyrion without triggering a full library rescan.  This feature allows users to selectively rescan a single album to pick up metadata edits without running a full library scan.

### Changes

**Slim/Menu/AlbumInfo.pm**
- Registers new `rescanAlbum` info provider
- Creates menu item using `itemActions` pattern matching existing play/add buttons

**Slim/Control/Request.pm**
- Adds dispatch: `['rescan', 'album']` with tagged parameters enabled

**Slim/Control/Commands.pm**
- New `rescanAlbumCommand` handler that:
  - Looks up album by ID and finds all track directories
  - Resets track timestamps to 0 (forces tag re-read)
  - Runs in-process scan on the album directory
  - Handles albums spanning multiple folders

**strings.txt**
- Adds `RESCAN_ALBUM` localization string

### Technical Notes
- Uses existing `Slim::Utils::Scanner::Local->rescan()` infrastructure
- Timestamp reset ensures scanner treats files as "changed" regardless of mtime
- Dispatch uses `[0, 0, 1, ...]` to enable tagged parameters (`album_id:N` format)
- Menu item uses `fixedParams` to pass album ID to command

### Testing
Verified on Material Skin - button appears in album info menu, triggers targeted scan, and correctly updates metadata from modified files.