### PR TITLE
Allow Replay Gain to be modified in a plugin's onStream() protocol handler routine. 

### DIFF
--- a/Slim/Player/StreamingController.pm
+++ b/Slim/Player/StreamingController.pm
@@ -1317,7 +1317,7 @@ sub _Stream {				# play -> Buffering, Streaming
 			'controller'  => $songStreamController,
 			'url'         => $songStreamController->streamUrl(),
 			'reconnect'   => $reconnect,
-			'replay_gain' => $replayGain,
+			'replay_gain' => $song->replayGain(),
 			'seekdata'    => $seekdata,
 			'fadeIn'      => $myFadeIn,
 			# we never set the 'loop' parameter


### PR DESCRIPTION
Populate a track's replay gain value from the Song object rather than from a local variable when streaming to a player so that it can be modified by a plugin's registered `onStream()` protocol handler routine if desired. This came up in a forum discussion of possible ways to allow the SqueezeDSP plugin to handle replay gain on the server side.