### PR TITLE
Fix incorrect ICY stream title sent during track change

### DIFF
--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -2323,7 +2323,8 @@ sub sendStreamingResponse {
 
 			unshift @$outbuf, $segment;
 
-			my $url = Slim::Player::Playlist::url($client);
+			my $songIndex = Slim::Player::Source::streamingSongIndex($client);
+			my $url = Slim::Player::Playlist::url($client, $songIndex);
 
 			my $title = $url ? Slim::Music::Info::getCurrentTitle($client, $url) : string('WELCOME_TO_SQUEEZEBOX_SERVER');
 			$title =~ tr/'/ /;


### PR DESCRIPTION
If no index parameter is passed to Slim::Player::Playlist::url(), it defaults to using Slim::Player::Source::playingSongIndex(). This means that upon track changes due to the currently playing song having ended we have a period where we stream the new song, but bundle it with the title of the previous song. Fix that by passing the index of the streaming song to avoid the fallback.