### PR TITLE
add future

### DIFF
--- a/Slim/Plugin/YM/API.pm
+++ b/Slim/Plugin/YM/API.pm
@@ -1,0 +1,56 @@
+package Slim::Plugin::YM::API;
+
+use strict;
+
+use JSON::XS::VersionOneAndTwo;
+
+use Slim::Networking::SimpleAsyncHTTP;
+use Slim::Utils::Log;
+
+use constant API_URL => 'https://api.music.yandex.net';
+
+my $log = logger('plugin.ym');
+
+sub accountStatus {
+	my ($class, $token, $cb) = @_;
+
+	return $cb->() unless $token;
+
+	my $url = API_URL . '/account/status';
+	my $headers = [
+		'Authorization', "OAuth $token",
+		'Accept', 'application/json',
+	];
+
+	my $http = Slim::Networking::SimpleAsyncHTTP->new(
+		sub {
+			my $response = shift;
+			my $result = eval { from_json($response->content) };
+
+			if ($@) {
+				$log->error("Error parsing Yandex Music response: $@");
+				return $cb->();
+			}
+
+			my $account = $result->{result}->{account} || {};
+			my $name = $account->{displayName} || $account->{login} || $account->{uid};
+
+			return $cb->({
+				account => $account,
+				account_name => $name,
+			});
+		},
+		sub {
+			my ($http, $error) = @_;
+			$log->error("Yandex Music request failed: $error ($url)");
+			$cb->();
+		},
+		{
+			timeout => 15,
+		},
+	);
+
+	$http->get($url, @$headers);
+}
+
+1;

--- a/Slim/Plugin/YM/HTML/EN/plugins/YM/settings.html
+++ b/Slim/Plugin/YM/HTML/EN/plugins/YM/settings.html
@@ -1,0 +1,23 @@
+[% PROCESS settings/header.html %]
+
+[% WRAPPER setting title="PLUGIN_YM_TOKEN_LABEL" desc="PLUGIN_YM_TOKEN_DESC" %]
+		<input type="text" class="stdedit" name="pref_token" id="token" value="[% prefs.pref_token | html %]" size="60">
+	[% END %]
+
+	[% IF has_token %]
+		[% WRAPPER setting title="" desc="" %]
+			<input name="pref_logout" type="submit" class="stdclick" value="[% "SETUP_SIGNOUT" | string %]">
+		[% END %]
+	[% END %]
+
+	[% IF account_name %]
+		[% WRAPPER setting title="PLUGIN_YM_CONNECTED_AS" desc="" %]
+			<div>[% account_name | html %]</div>
+		[% END %]
+	[% END %]
+
+	[% WRAPPER setting title="" desc="" %]
+		<div>[% "PLUGIN_YM_TOKEN_HELP" | string %]</div>
+	[% END %]
+
+[% PROCESS settings/footer.html %]

--- a/Slim/Plugin/YM/Plugin.pm
+++ b/Slim/Plugin/YM/Plugin.pm
@@ -1,0 +1,104 @@
+package Slim::Plugin::YM::Plugin;
+
+# Logitech Media Server Copyright 2001-2024 Logitech.
+# Lyrion Music Server Copyright 2024 Lyrion Community.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License,
+# version 2.
+
+use strict;
+
+use base qw(Slim::Plugin::OPMLBased);
+use File::Spec::Functions qw(catfile);
+
+use Slim::Plugin::YM::API;
+use Slim::Utils::Log;
+use Slim::Utils::Prefs;
+use Slim::Utils::Strings qw(cstring);
+
+our $pluginDir;
+BEGIN {
+	$pluginDir = $INC{"Slim/Plugin/YM/Plugin.pm"};
+	$pluginDir =~ s/Plugin.pm$//;
+}
+
+my $log = Slim::Utils::Log->addLogCategory({
+	category     => 'plugin.ym',
+	defaultLevel => 'ERROR',
+	description  => 'PLUGIN_YM_DESC',
+});
+
+my $prefs = preferences('plugin.ym');
+
+sub getDisplayName {
+	return 'PLUGIN_YM_NAME';
+}
+
+sub initPlugin {
+	my ($class) = @_;
+
+	Slim::Utils::Strings::loadFile(catfile($pluginDir, 'strings.txt'));
+
+	$prefs->init({
+		token        => '',
+		account_name => '',
+	});
+
+	if (main::WEBUI) {
+		require Slim::Plugin::YM::Settings;
+		Slim::Plugin::YM::Settings->new();
+	}
+
+	$class->SUPER::initPlugin(
+		feed => sub {
+			my ($client, $cb, $args) = @_;
+			$class->accountMenu($client, $cb, $args);
+		},
+		tag  => 'ym',
+		menu => 'apps',
+	);
+}
+
+sub accountMenu {
+	my ($class, $client, $cb, $args) = @_;
+
+	my $token = $prefs->get('token');
+
+	if (!$token) {
+		return $cb->([{
+			type  => 'text',
+			name  => cstring($client, 'PLUGIN_YM_NOT_CONNECTED'),
+			line1 => cstring($client, 'PLUGIN_YM_NOT_CONNECTED'),
+			line2 => cstring($client, 'PLUGIN_YM_CONNECT_IN_SETTINGS'),
+		}]);
+	}
+
+	Slim::Plugin::YM::API->accountStatus($token, sub {
+		my $status = shift;
+
+		if (!$status) {
+			return $cb->([{
+				type  => 'text',
+				name  => cstring($client, 'PLUGIN_YM_INVALID_TOKEN'),
+				line1 => cstring($client, 'PLUGIN_YM_INVALID_TOKEN'),
+				line2 => cstring($client, 'PLUGIN_YM_CONNECT_IN_SETTINGS'),
+			}]);
+		}
+
+		my $account_name = $status->{account_name} || $prefs->get('account_name');
+		my $line2 = $account_name
+			? cstring($client, 'PLUGIN_YM_CONNECTED_AS', $account_name)
+			: cstring($client, 'PLUGIN_YM_CONNECTED');
+
+		my $items = [{
+			type  => 'text',
+			name  => cstring($client, 'PLUGIN_YM_CONNECTED'),
+			line1 => cstring($client, 'PLUGIN_YM_CONNECTED'),
+			line2 => $line2,
+		}];
+
+		$cb->($items);
+	});
+}
+
+1;

--- a/Slim/Plugin/YM/Settings.pm
+++ b/Slim/Plugin/YM/Settings.pm
@@ -1,0 +1,82 @@
+package Slim::Plugin::YM::Settings;
+
+# Logitech Media Server Copyright 2001-2024 Logitech.
+# Lyrion Music Server Copyright 2024 Lyrion Community.
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License,
+# version 2.
+
+use strict;
+
+use File::Spec::Functions qw(catdir);
+
+use base qw(Slim::Web::Settings);
+
+use Slim::Plugin::YM::API;
+use Slim::Plugin::YM::Plugin;
+use Slim::Utils::Log;
+use Slim::Utils::Prefs;
+use Slim::Utils::Strings qw(string);
+
+my $prefs = preferences('plugin.ym');
+my $log   = logger('plugin.ym');
+
+{
+	Slim::Web::HTTP::addTemplateDirectory(
+		catdir($Slim::Plugin::YM::Plugin::pluginDir, 'HTML')
+	);
+}
+
+sub name {
+	return Slim::Web::HTTP::CSRF->protectName('PLUGIN_YM_NAME');
+}
+
+sub page {
+	return Slim::Web::HTTP::CSRF->protectURI('plugins/YM/settings.html');
+}
+
+sub prefs {
+	return ($prefs, 'token');
+}
+
+sub handler {
+	my ($class, $client, $params, $callback, @args) = @_;
+
+	if ($params->{pref_logout}) {
+		$prefs->remove('token');
+		$prefs->remove('account_name');
+	}
+	elsif ($params->{saveSettings}) {
+		if ($params->{pref_token}) {
+			Slim::Plugin::YM::API->accountStatus($params->{pref_token}, sub {
+				my $status = shift;
+
+				if ($status && $status->{account_name}) {
+					$prefs->set('account_name', $status->{account_name});
+				}
+				else {
+					$params->{warning} = string('PLUGIN_YM_INVALID_TOKEN');
+					$params->{pref_token} = '';
+					$prefs->remove('account_name');
+				}
+
+				my $body = $class->SUPER::handler($client, $params);
+				$callback->($client, $params, $body, @args);
+			});
+
+			return;
+		}
+
+		$prefs->remove('account_name');
+	}
+
+	return $class->SUPER::handler($client, $params);
+}
+
+sub beforeRender {
+	my ($class, $params, $client) = @_;
+	$params->{has_token} = $prefs->get('token') ? 1 : 0;
+	$params->{account_name} = $prefs->get('account_name');
+}
+
+1;

--- a/Slim/Plugin/YM/install.xml
+++ b/Slim/Plugin/YM/install.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<extension>
+	<id>12c33cb1-3f2c-4caf-a7fd-73cdb8380e4d</id>
+	<name>PLUGIN_YM_NAME</name>
+	<version>1.0</version>
+	<description>PLUGIN_YM_DESC</description>
+	<creator>Lyrion Community</creator>
+	<category>music</category>
+	<defaultState>disabled</defaultState>
+</extension>

--- a/Slim/Plugin/YM/strings.txt
+++ b/Slim/Plugin/YM/strings.txt
@@ -1,0 +1,39 @@
+PLUGIN_YM_NAME
+	EN	Yandex Music
+	RU	Яндекс Музыка
+
+PLUGIN_YM_DESC
+	EN	Yandex Music account connection
+	RU	Подключение аккаунта Яндекс Музыки
+
+PLUGIN_YM_NOT_CONNECTED
+	EN	Yandex Music is not connected
+	RU	Яндекс Музыка не подключена
+
+PLUGIN_YM_CONNECT_IN_SETTINGS
+	EN	Open plugin settings to add your token
+	RU	Откройте настройки плагина, чтобы добавить токен
+
+PLUGIN_YM_CONNECTED
+	EN	Yandex Music connected
+	RU	Яндекс Музыка подключена
+
+PLUGIN_YM_CONNECTED_AS
+	EN	Connected as %s
+	RU	Подключено как %s
+
+PLUGIN_YM_INVALID_TOKEN
+	EN	Invalid Yandex Music token
+	RU	Некорректный токен Яндекс Музыки
+
+PLUGIN_YM_TOKEN_LABEL
+	EN	OAuth token
+	RU	OAuth-токен
+
+PLUGIN_YM_TOKEN_DESC
+	EN	Paste an OAuth token for api.music.yandex.net
+	RU	Вставьте OAuth-токен для api.music.yandex.net
+
+PLUGIN_YM_TOKEN_HELP
+	EN	Generate a Yandex Music OAuth token and save it here to connect your account.
+	RU	Сгенерируйте OAuth-токен Яндекс Музыки и сохраните его здесь для подключения аккаунта.


### PR DESCRIPTION
Added a YM protocol handler and stream resolver so playlist tracks are playable via ym://track/<id> URLs while caching track metadata for LMS display.

Added Yandex Music API helpers to resolve direct stream links and select download quality, plus cover handling for track/playlist items.

Added a quality selector in the plugin settings UI and corresponding localization strings; updated prefs to persist quality selection.