### PR TITLE
New & changed scan - null values fix

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2007,12 +2007,23 @@ sub updateOrCreateBase {
 		# Update timestamp
 		$attributeHash->{updated_time} = time();
 
+		my $nullableColumns = {
+			performance => 1,
+			grouping => 1,
+			discsubtitle => 1,
+			musicbrainz_id => 1,
+		};
+		# Some taggers will not supply blank tags so create the attributes for columns which need to be nulled.
+		foreach my $col (keys %$nullableColumns) {
+			$attributeHash->{uc($col)} = undef if !exists $attributeHash->{uc($col)};
+		}
+
 		while (my ($key, $val) = each %$attributeHash) {
 
 			$key = lc($key);
 
-			## Need to set performance/grouping/discsubtitle to null if no value passed in (may have had a value before this scan)
-			if ( (defined $val && $val ne '' || $key eq "performance" || $key eq "grouping" || $key eq "discsubtitle") && exists $trackAttrs->{$key} ) {
+			# Some columns should be set to null if no value passed in (may have had a value before this scan)
+			if ( (defined $val && $val ne '' || $nullableColumns->{$key}) && exists $trackAttrs->{$key} ) {
 
 				# Bug 7731, filter out duplicate keys that end up as array refs
 				# https://github.com/LMS-Community/slimserver/issues/1378
@@ -2024,13 +2035,14 @@ sub updateOrCreateBase {
 			}
 
 			# Metadata is only included if it contains a non zero value
-			if ( main::STATISTICS && $val && blessed($trackPersistent) && exists $trackPersistentAttrs->{$key} ) {
+			if ( main::STATISTICS && ($val || $nullableColumns->{$key}) && blessed($trackPersistent) && exists $trackPersistentAttrs->{$key} ) {
 
 				main::INFOLOG && $log->is_info && $log->info("Updating persistent $url : $key to $val");
 
 				$trackPersistent->set_column( $key => $val );
 			}
 		}
+		$trackPersistent->update() if blessed($trackPersistent);
 
 		# _postCheckAttributes does an update
 		if (!$playlist) {


### PR DESCRIPTION
Issue #1493 

Also fix inconsistent behaviour when setting previously populated columns to null in a new & changed scan - depending on the user's tagging software, we might not get tags set to null at all.

Should we be extending the new list of nullable columns `$nullableColumns`?

This could fix other reported inconsistencies in the N&C scan, so I think it's worth backporting to 9.0.

I also found we need to issue an `update()` to the `TrackPersistent` object, otherwise the changed columns remain "dirty" and never get committed to the database. I don't know if this has never worked, or if there have been recent(ish) changes to the underlying libraries. 