### PR TITLE
Fix FLAC transcoding to MP3 for embedded cuesheets and when seeking in a stream

### DIFF
--- a/convert.conf
+++ b/convert.conf
@@ -135,7 +135,7 @@ aif mp3 * *
 	[lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ $FILE$ -
 
 flc mp3 * *
-	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}
+	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}E:{NOSTART=I}
 	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 wma mp3 * *

--- a/convert.conf
+++ b/convert.conf
@@ -136,7 +136,7 @@ aif mp3 * *
 
 flc mp3 * *
 	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}
-	[flac] -dcs $START$ $END$ -- $FILE$ | [lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
+	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 wma mp3 * *
 	# F:{PATH=%f}R:{PATH=%F}B:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}


### PR DESCRIPTION
This PR attempts to fix issues #514 and #1480. It is divided into two parts:
* Using raw PCM as an intermediary when transcoding. When seeking on a streaming FLAC, the default "wave" intermediary transcoding would throw an error that there wasn't an accurate sample count for the header.
* Add `NOSTART=I`, which allows embedded cuesheets to be both played and seeked.

The changes have been tested with the following types of FLACs:

| Description               | Sample Rate | Bit Depth |
|---------------------------|-------------|-----------|
| Local track               | 44.1kHz     | 16 bit    |
| Local track               | 48.0kHz     | 24 bit    |
| Embedded cue, track 2     | 44.1kHz     | 16 bit    |
| Streaming, Qobuz          | 44.1kHz     | 16 bit    |
| Streaming, Qobuz          | 96kHz       | 24 bit    |
| Streaming, TIDAL          | 44.1kHz     | 16 bit    |
| Streaming, generic Apache | 44.1kHz     | 16 bit    |

Previous code changes for FLAC to MP3 transcoding centered around TIDAL streaming in 2020, when support was handled with the WiMP plugin. I subscribed to a 30 day trial of TIDAL for testing, and it seemed like previous TIDAL workarounds have been deprecated and streaming behaves similar to Qobuz, which I'm much familiar with. I did test against a random FLAC radio (non-seekable) stream and it worked fine, but I'm not familiar with any nuances of that.

LAME echos the following warning with the Docker environment I'm testing against:
```
WARNING: libsndfile may ignore -r and perform fseek's on the input.
Compile without libsndfile if this is a problem.
```

I have not found a way to suppress this with LAME command arguments.