### PR TITLE
Modernize player modules and core strictness

### DIFF
--- a/Slim/Control/Jive.pm
+++ b/Slim/Control/Jive.pm
@@ -7,6 +7,7 @@ package Slim::Control::Jive;
 # version 2.
 
 use strict;
+use warnings;
 
 use POSIX qw(strftime);
 use Scalar::Util qw(blessed);

--- a/Slim/Player/Boom.pm
+++ b/Slim/Player/Boom.pm
@@ -12,12 +12,9 @@ package Slim::Player::Boom;
 # GNU General Public License for more details.
 
 use strict;
-use vars qw(@ISA);
+use warnings;
 
-BEGIN {
-	require Slim::Player::Squeezebox2;
-	push @ISA, qw(Slim::Player::Squeezebox2);
-}
+use parent qw(Slim::Player::Squeezebox2);
 
 use Slim::Hardware::BacklightLED;
 use Slim::Networking::Slimproto;

--- a/Slim/Player/Disconnected.pm
+++ b/Slim/Player/Disconnected.pm
@@ -17,15 +17,9 @@
 package Slim::Player::Disconnected;
 
 use strict;
-use vars qw(@ISA);
-use Slim::Player::Client;
+use warnings;
 
-use Slim::Display::NoDisplay;
-
-BEGIN {
-	require Slim::Player::Client;
-	push @ISA, qw(Slim::Player::Client);
-}
+use parent qw(Slim::Player::Client);
 
 sub new {
 	my ( $class, $id ) = @_;

--- a/Slim/Player/HTTP.pm
+++ b/Slim/Player/HTTP.pm
@@ -12,12 +12,9 @@
 package Slim::Player::HTTP;
 
 use strict;
-use vars qw(@ISA);
-use Slim::Player::Client;
+use warnings;
 
-use Slim::Display::NoDisplay;
-
-@ISA = qw(Slim::Player::Client);
+use parent qw(Slim::Player::Client);
 
 sub new {
 	my ($class, $id, $paddr, $tcpsock) = @_;

--- a/Slim/Player/Receiver.pm
+++ b/Slim/Player/Receiver.pm
@@ -12,12 +12,9 @@ package Slim::Player::Receiver;
 # GNU General Public License for more details.
 
 use strict;
-use vars qw(@ISA);
+use warnings;
 
-BEGIN {
-	require Slim::Player::Squeezebox2;
-	push @ISA, qw(Slim::Player::Squeezebox2);
-}
+use parent qw(Slim::Player::Squeezebox2);
 
 use Slim::Player::ProtocolHandlers;
 use Slim::Utils::Prefs;

--- a/Slim/Player/SqueezePlay.pm
+++ b/Slim/Player/SqueezePlay.pm
@@ -12,19 +12,9 @@ package Slim::Player::SqueezePlay;
 # GNU General Public License for more details.
 
 use strict;
-use vars qw(@ISA);
+use warnings;
 
-use Slim::Utils::Prefs;
-use Slim::Utils::Log;
-
-my $prefs = preferences('server');
-
-my $log = logger('network.protocol.slimproto');
-
-BEGIN {
-	require Slim::Player::Squeezebox2;
-	push @ISA, qw(Slim::Player::Squeezebox2);
-}
+use parent qw(Slim::Player::Squeezebox2);
 
 {
 

--- a/Slim/Player/Transporter.pm
+++ b/Slim/Player/Transporter.pm
@@ -14,12 +14,9 @@ package Slim::Player::Transporter;
 #
 
 use strict;
-use vars qw(@ISA);
+use warnings;
 
-BEGIN {
-	require Slim::Player::Squeezebox2;
-	push @ISA, qw(Slim::Player::Squeezebox2);
-}
+use parent qw(Slim::Player::Squeezebox2);
 
 use MIME::Base64;
 

--- a/Slim/Utils/Misc.pm
+++ b/Slim/Utils/Misc.pm
@@ -29,6 +29,7 @@ L<Slim::Utils::Misc> serves as a collection of miscellaneous utility
 =cut
 
 use strict;
+use warnings;
 use Exporter::Lite;
 
 our @EXPORT = qw(assert msg msgf errorMsg specified dumpFiltered);

--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -8,6 +8,7 @@ package Slim::Web::HTTP;
 # version 2.
 
 use strict;
+use warnings;
 
 use AnyEvent::Handle;
 use CGI::Cookie;


### PR DESCRIPTION
- Replaced legacy 'use vars / @ISA' inheritance with 'use parent' in Slim/Player/*.pm
- Standardized 'use warnings' in Slim/Web/HTTP.pm, Slim/Utils/Misc.pm, and Slim/Control/Jive.pm
