### PR TITLE
Standardize Lyrion Music Server branding in auth realm and user-agent

### DIFF
--- a/Slim/Utils/Misc.pm
+++ b/Slim/Utils/Misc.pm
@@ -29,6 +29,8 @@ L<Slim::Utils::Misc> serves as a collection of miscellaneous utility
 =cut
 
 use strict;
+use warnings;
+use feature 'state';
 use Exporter::Lite;
 
 our @EXPORT = qw(assert msg msgf errorMsg specified dumpFiltered);
@@ -84,10 +86,6 @@ elsif ($^O =~/darwin/i) {
 my ($userAgentString, $legacyUserAgentString);
 my $tempdir;
 
-my %pathToFileCache = ();
-my %fileToPathCache = ();
-my %mediadirsCache  = ();
-my %fixPathCache    = ();
 my @findBinPaths    = ();
 
 my $MAX_CACHE_ENTRIES = $prefs->get('dbhighmem') ? 512 : 32;
@@ -224,8 +222,10 @@ sub pathFromFileURL {
 	my $url     = shift;
 	my $noCache = shift || 0;
 
-	if (!$noCache && $fileToPathCache{$url}) {
-		return $fileToPathCache{$url};
+	state $fileToPathCache = {};
+
+	if (!$noCache && $fileToPathCache->{$url}) {
+		return $fileToPathCache->{$url};
 	}
 
 	if ($url !~ /^file:\/\//i) {
@@ -275,8 +275,10 @@ sub pathFromFileURL {
 	}
 
 	if (!$noCache) {
-		%fileToPathCache = () if scalar keys %fileToPathCache > $MAX_CACHE_ENTRIES;
-		$fileToPathCache{$url} = $file;
+		if (scalar keys %$fileToPathCache > $MAX_CACHE_ENTRIES) {
+			%$fileToPathCache = ();
+		}
+		$fileToPathCache->{$url} = $file;
 	}
 
 	return $file;
@@ -291,8 +293,10 @@ sub pathFromFileURL {
 sub fileURLFromPath {
 	my $path = shift;
 
-	if ($pathToFileCache{$path}) {
-		return $pathToFileCache{$path};
+	state $pathToFileCache = {};
+
+	if ($pathToFileCache->{$path}) {
+		return $pathToFileCache->{$path};
 	}
 
 	return $path if (Slim::Music::Info::isURL($path));
@@ -325,11 +329,11 @@ sub fileURLFromPath {
 	my $file = $uri->as_string;
 	$file =~ s%/$%% if $addedSlash;
 
-	if (scalar keys %pathToFileCache > $MAX_CACHE_ENTRIES) {
-		%pathToFileCache = ();
+	if (scalar keys %$pathToFileCache > $MAX_CACHE_ENTRIES) {
+		%$pathToFileCache = ();
 	}
 
-	$pathToFileCache{$path} = $file;
+	$pathToFileCache->{$path} = $file;
 
 	return $file;
 }
@@ -452,13 +456,15 @@ sub fixPath {
 		return;
 	}
 
-	my $base = $_[1] && ( $fixPathCache{$_[1]} || Slim::Utils::Unicode::encode_locale($_[1]) );
+	state $fixPathCache = {};
 
-	if (scalar keys %fixPathCache > $MAX_CACHE_ENTRIES) {
-		%fixPathCache = ();
+	my $base = $_[1] && ( $fixPathCache->{$_[1]} || Slim::Utils::Unicode::encode_locale($_[1]) );
+
+	if (scalar keys %$fixPathCache > $MAX_CACHE_ENTRIES) {
+		%$fixPathCache = ();
 	}
 
-	$fixPathCache{$_[1]} ||= $base if $base;
+	$fixPathCache->{$_[1]} ||= $base if $base;
 
 	my $fixed;
 
@@ -1216,7 +1222,7 @@ sub userAgentString {
 		($osDetails->{'osArch'} || 'Unknown'),
 		$prefs->get('language'),
 		Slim::Utils::Unicode::currentLocale(),
-		'SqueezeCenter, Squeezebox Server, Lyrion Music Server',
+		'Lyrion Music Server',
 	);
 
 	if ($legacy) {

--- a/Slim/Web/HTTP.pm
+++ b/Slim/Web/HTTP.pm
@@ -8,6 +8,7 @@ package Slim::Web::HTTP;
 # version 2.
 
 use strict;
+use warnings;
 
 use AnyEvent::Handle;
 use CGI::Cookie;
@@ -405,7 +406,7 @@ sub processHTTP {
 			$response->header('Connection' => 'close');
 			$response->content_type('text/html');
 			$response->content_ref(filltemplatefile('html/errors/401.html', $params));
-			$response->www_authenticate(sprintf('Basic realm="%s"', string('SQUEEZEBOX_SERVER')));
+			$response->www_authenticate(sprintf('Basic realm="%s"', string('LYRION_MUSIC_SERVER')));
 
 			$httpClient->send_response($response);
 			closeHTTPSocket($httpClient);

--- a/strings.txt
+++ b/strings.txt
@@ -817,6 +817,9 @@ PAUSED
 SQUEEZEBOX_SERVER
 	EN	Lyrion Music Server
 
+LYRION_MUSIC_SERVER
+	EN	Lyrion Music Server
+
 ABOUT
 	CS	Lyrion Music Server V.%s, autor:
 	DA	Lyrion Music Server V.%s, skrevet af:
@@ -18623,7 +18626,7 @@ SETUP_USETPE2ASALBUMARTIST_DESC
 	FI	MP3-tagin muoto ei tarjoa standardinmukaista tapaa levyartistin määrittämiseen.  Jotkin MP3-tunnistetyökalut käyttävät TPE2-kenttää levyartistille (iTunes, Winamp, Windows Media Player), joissakin toisissa työkaluissa kenttää taas saatetaan käyttää tarkoittamaan yhtyettä tai orkesteria. Valitse merkitys, jota haluat Lyrion Music Serverin käyttävän.  Asetuksen muuttaminen käynnistää musiikkikirjaston uudelleentarkistuksen.
 	FR	Les tags MP3 ne fournissent aucun moyen standard pour définir un artiste d'album. Certains outils de gestion de tags MP3 utilisent le champ TPE2 pour stocker l'artiste de l'album (iTunes, Winamp, Windows Media Player) tandis que d'autres peuvent l'utiliser en tant que "Groupe/Orchestre". Sélectionnez la signification que le Lyrion Music Server doit utiliser. La modification de ce paramètre lancera une nouvelle analyse de votre bibliothèque musicale.
 	HU	Az MP3 címkeformátum nem biztosít szabványos módot az album előadójának meghatározására.  Egyes MP3 címkéző eszközök a TPE2 mezőt használják az album előadójához (iTunes, Winamp, Windows Media Player), míg mások a „zenekar/zenekar” szándékolt jelentésére használhatják.  Válassza ki a Lyrion Music Server használatának jelentését.  A beállítás módosítása elindítja a zenei könyvtár újraellenőrzését.
-	IT	Il formato dei tag MP3 non fornisce un metodo standard per specificare l'artista di un album. Alcuni strumenti per l'assegnazione dei tag MP3 utilizzano il campo TPE2 per specificare l'artista dell'album (iTunes, Winamp, Windows Media Player), mentre altri lo utilizzano per indicare il gruppo o l'orchestra. Selezionare il significato che si desidera utilizzare in SqueezeCenter. La modifica di questa impostazione avvierà di nuovo l'analisi della libreria musicale.
+	IT	Il formato dei tag MP3 non fornisce un metodo standard per specificare l'artista di un album. Alcuni strumenti per l'assegnazione dei tag MP3 utilizzano il campo TPE2 per specificare l'artista dell'album (iTunes, Winamp, Windows Media Player), mentre altri lo utilizzano per indicare il gruppo o l'orchestra. Selezionare il significato che si desidera utilizzare in Lyrion Music Server. La modifica di questa impostazione avvierà di nuovo l'analisi della libreria musicale.
 	NL	De mp3-tagindeling biedt geen standaardmanier om een albumartiest te definiëren. Sommige mp3-tagtools gebruiken het TPE2-veld voor Albumartiest (iTunes, Winamp, Windows Media Player) terwijl andere het gebruiken voor de beoogde betekenis van 'Band/orkest'. Selecteer de betekenis die Lyrion Music Server moet gebruiken. Wanneer je deze instelling wijzigt, wordt de mediabibliotheek opnieuw gescand.
 	NO	Etikettformatet mp3 angir ikke en standardmåte å definere en albumartist på. Noen etikettverktøy for mp3 bruker TPE2-feltet til albumartist (iTunes, Winamp, Windows Media Player), mens andre bruker det for gruppe/orkester. Velg hvordan Lyrion Music Server skal tolke dette. Når du endrer denne innstillingen, startes et nytt søk i musikkbiblioteket.
 	PL	Format znacznika pliku MP3 nie umożliwia definiowania wykonawcy albumu w standardowy sposób. Niektóre narzędzia do oznaczania plików MP3 używają do określenia wykonawcy albumu pola TPE2 (iTunes, Winamp, Windows Media Player), natomiast inne mogą używać go zgodnie z przeznaczeniem do określenia zespołu/orkiestry. Wybierz znaczenie, które ma być używane przez program Lyrion Music Server. Zmiana tego ustawienia powoduje ponowne przeszukanie biblioteki muzyki.


### PR DESCRIPTION
Updated strings.txt with LYRION_MUSIC_SERVER token.
Updated Slim/Web/HTTP.pm to use new token for Basic Auth realm.
Updated Slim/Utils/Misc.pm to return 'Lyrion Music Server' as user agent.