### PR TITLE
FTS single track scan

### DIFF
--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -57,14 +57,22 @@ use constant SQL_CREATE_TRACK_ITEM => q{
 		GROUP BY tracks.id;
 };
 
-use constant SQL_DROP_WORKTEMP => q{
-	DROP TABLE IF EXISTS worktemp;
+use constant SQL_CREATE_WORKTEMP => q{
+	CREATE TEMPORARY TABLE IF NOT EXISTS worktemp (
+		id integer,
+		w3 text
+		)
 };
 
-use constant SQL_CREATE_WORKTEMP => q{
-	CREATE TEMPORARY TABLE worktemp AS
+use constant SQL_CLEAR_WORKTEMP => q{
+	DELETE FROM worktemp;
+};
+
+use constant SQL_POPULATE_WORKTEMP => q{
+	INSERT INTO worktemp (id, w3)
 			SELECT tracks.id AS id, UNIQUE_TOKENS(CONCAT_CONTRIBUTOR_ROLE(tracks.id, GROUP_CONCAT(contributor_track.contributor, ','), 'contributor_track')) AS w3
-			FROM tracks JOIN contributor_track ON contributor_track.track = tracks.id %s
+			FROM tracks JOIN contributor_track ON contributor_track.track = tracks.id
+			%s
 			GROUP BY tracks.id;
 };
 
@@ -144,6 +152,15 @@ use constant SQL_CREATE_PLAYLIST_ITEM => CAN_FTS4
 		SELECT 'YXLPLAYLISTSYYYYYYYYYYYYYYYYYYYY' || tracks.id, 'playlist', ?, '', ?, ''
 		FROM tracks
 		WHERE tracks.id = ?
+};
+
+use constant SQL_DELETE_FOR_TRACK => q{
+	DELETE FROM fulltext
+		WHERE id = ? || ?
+			OR ( fulltext.type = 'contributor' AND REPLACE(fulltext.id, 'YXLCONTRIBUTORSYYYYYYYYYYYYYYYYY', '') IN (SELECT contributor FROM contributor_track WHERE track=?) )
+			OR ( fulltext.type = 'contributor' AND fulltext.w10 <> ? AND NOT EXISTS (SELECT * FROM contributor_track WHERE contributor = REPLACE(fulltext.id, 'YXLCONTRIBUTORSYYYYYYYYYYYYYYYYY', '')) )
+			OR ( fulltext.type = 'work' AND REPLACE(fulltext.id, 'YXLWORKSYYYYYYYYYYYYYYYYYYYYYYYY', '') IN (SELECT work FROM tracks WHERE id=?) )
+			OR ( fulltext.type = 'work' AND NOT EXISTS (SELECT * FROM works WHERE id = REPLACE(fulltext.id, 'YXLWORKSYYYYYYYYYYYYYYYYYYYYYYYY', '')) )
 };
 
 my $log = Slim::Utils::Log->addLogCategory({
@@ -233,29 +250,25 @@ sub checkSingleTrack {
 
 	my $dbh = Slim::Schema->dbh;
 
-	my $deletionSql = 'DELETE FROM fulltext WHERE id = ? || ?';
-	my @params = ($trackObj->urlmd5, $trackObj->id);
+	my $deletionSql = SQL_DELETE_FOR_TRACK;
+	my @params = ($trackObj->urlmd5, $trackObj->id, $trackObj->id, uc(Slim::Music::Info::variousArtistString()), $trackObj->id);
 
 	if ($trackObj->albumid) {
-		$deletionSql .= ' OR id=?';
-		push @params, sprintf('YXLALBUMSYYYYYYYYYYYYYYYYYYYYYYY%s', $trackObj->albumid);
+		$deletionSql .= q{ OR id = 'YXLALBUMSYYYYYYYYYYYYYYYYYYYYYYY' || ?};
+		push @params, $trackObj->albumid;
 	}
-
-#	if ($trackObj->artistid) {
-#		$deletionSql .= ' OR id=?';
-#		push @params, sprintf('YXLCONTRIBUTORSYYYYYYYYYYYYYYYYY%s', $trackObj->artistid);
-#	}
-	$deletionSql .= " OR ( fulltext.type = 'contributor' AND substr(fulltext.id,33) in (SELECT contributor FROM contributor_track WHERE track=?) )";
-	push @params, $trackObj->id;
-	$deletionSql .= " OR ( fulltext.type = 'contributor' AND fulltext.w10 <> ? AND NOT EXISTS (SELECT * FROM contributor_track WHERE contributor = substr(fulltext.id,33)) )";
-	push @params, uc(Slim::Music::Info::variousArtistString());
 
 	$dbh->do($deletionSql, undef, @params);
 
 	$dbh->do( sprintf(SQL_CREATE_TRACK_ITEM,       'WHERE tracks.id=?'),       undef, $trackObj->id );
-	$dbh->do( sprintf(SQL_CREATE_ALBUM_ITEM,       'WHERE albums.id=?'),       undef, $trackObj->albumid )  if $trackObj->albumid;
-#	$dbh->do( sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, 'WHERE contributors.id=?'), undef, $trackObj->artistid ) if $trackObj->artistid;
+	$dbh->do( sprintf(SQL_CREATE_ALBUM_ITEM,       'WHERE albums.id=?'),       undef, $trackObj->albumid ) if $trackObj->albumid;
 	$dbh->do( sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, 'WHERE contributors.id in (SELECT contributor FROM contributor_track WHERE track=?)'), undef, $trackObj->id );
+	if ($trackObj->work) {
+		$dbh->do( SQL_CREATE_WORKTEMP );
+		$dbh->do( SQL_CLEAR_WORKTEMP );
+		$dbh->do( sprintf(SQL_POPULATE_WORKTEMP, 'WHERE tracks.work=?'),   undef, $trackObj->get_column('work') );
+		$dbh->do( sprintf(SQL_CREATE_WORK_ITEM,  'WHERE tracks.work=?'), undef, $trackObj->get_column('work') );
+	}
 }
 
 sub checkPlaylist {
@@ -616,8 +629,9 @@ sub _rebuildIndex {
 	$scanlog->error("Create fulltext index for works");
 	$progress && $progress->update(string('WORKS'));
 	Slim::Schema->forceCommit if main::SCANNER;
-	$dbh->do(SQL_DROP_WORKTEMP) or $scanlog->error($dbh->errstr);
-	$sql = sprintf(SQL_CREATE_WORKTEMP, '');
+	$dbh->do(SQL_CREATE_WORKTEMP) or $scanlog->error($dbh->errstr);
+	$dbh->do(SQL_CLEAR_WORKTEMP) or $scanlog->error($dbh->errstr);
+	$sql = sprintf(SQL_POPULATE_WORKTEMP, '');
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
 	$sql = sprintf(SQL_CREATE_WORK_ITEM, '');
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);

--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -265,9 +265,9 @@ sub checkSingleTrack {
 	$dbh->do( sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, 'WHERE contributors.id in (SELECT contributor FROM contributor_track WHERE track=?)'), undef, $trackObj->id );
 	if ($trackObj->work) {
 		$dbh->do( SQL_CREATE_WORKTEMP );
+		$dbh->do( sprintf(SQL_POPULATE_WORKTEMP, 'WHERE tracks.work=?'), undef, $trackObj->workid);
+		$dbh->do( sprintf(SQL_CREATE_WORK_ITEM,  'WHERE tracks.work=?'), undef, $trackObj->workid);
 		$dbh->do( SQL_CLEAR_WORKTEMP );
-		$dbh->do( sprintf(SQL_POPULATE_WORKTEMP, 'WHERE tracks.work=?'),   undef, $trackObj->get_column('work') );
-		$dbh->do( sprintf(SQL_CREATE_WORK_ITEM,  'WHERE tracks.work=?'), undef, $trackObj->get_column('work') );
 	}
 }
 

--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -28,7 +28,7 @@ use constant LARGE_RESULTSET => 500;
 =cut
 
 use constant SQL_CREATE_TRACK_ITEM => q{
-	INSERT %s INTO fulltext (id, type, w10, w5, w3, w1)
+	INSERT INTO fulltext (id, type, w10, w5, w3, w1)
 		SELECT tracks.urlmd5 || tracks.id, 'track',
 		-- weight 10
 		UNIQUE_TOKENS(LOWER(IFNULL(tracks.title, '')) || ' ' || IFNULL(tracks.titlesearch, '') || ' ' || IFNULL(tracks.customsearch, '')),
@@ -64,12 +64,12 @@ use constant SQL_DROP_WORKTEMP => q{
 use constant SQL_CREATE_WORKTEMP => q{
 	CREATE TEMPORARY TABLE worktemp AS
 			SELECT tracks.id AS id, UNIQUE_TOKENS(CONCAT_CONTRIBUTOR_ROLE(tracks.id, GROUP_CONCAT(contributor_track.contributor, ','), 'contributor_track')) AS w3
-			FROM tracks JOIN contributor_track ON contributor_track.track = tracks.id
+			FROM tracks JOIN contributor_track ON contributor_track.track = tracks.id %s
 			GROUP BY tracks.id;
 };
 
 use constant SQL_CREATE_WORK_ITEM => q{
-	INSERT %s INTO fulltext (id, type, w10, w5, w3, w1)
+	INSERT INTO fulltext (id, type, w10, w5, w3, w1)
 
 		SELECT 'YXLWORKSYYYYYYYYYYYYYYYYYYYYYYYY' || works.id, 'work',
 		-- weight 10
@@ -92,7 +92,7 @@ use constant SQL_CREATE_WORK_ITEM => q{
 };
 
 use constant SQL_CREATE_ALBUM_ITEM => q{
-	INSERT %s INTO fulltext (id, type, w10, w5, w3, w1)
+	INSERT INTO fulltext (id, type, w10, w5, w3, w1)
 		SELECT 'YXLALBUMSYYYYYYYYYYYYYYYYYYYYYYY' || albums.id, 'album',
 		-- weight 10
 		UNIQUE_TOKENS(LOWER(IFNULL(albums.title, '')) || ' ' || IFNULL(albums.titlesearch, '') || ' ' || IFNULL(albums.customsearch, '') || ' '
@@ -115,7 +115,7 @@ use constant SQL_CREATE_ALBUM_ITEM => q{
 };
 
 use constant SQL_CREATE_CONTRIBUTOR_ITEM => q{
-	INSERT %s INTO fulltext (id, type, w10, w5, w3, w1)
+	INSERT INTO fulltext (id, type, w10, w5, w3, w1)
 		SELECT 'YXLCONTRIBUTORSYYYYYYYYYYYYYYYYY' || contributors.id, 'contributor',
 		-- weight 10
 		UNIQUE_TOKENS(LOWER(IFNULL(contributors.name, '')) || ' ' || IFNULL(contributors.namesearch, '') || ' ' || IFNULL(contributors.customsearch, '')),
@@ -233,9 +233,29 @@ sub checkSingleTrack {
 
 	my $dbh = Slim::Schema->dbh;
 
-	$dbh->do( sprintf(SQL_CREATE_TRACK_ITEM,       'OR REPLACE', 'WHERE tracks.id=?'),       undef, $trackObj->id );
-	$dbh->do( sprintf(SQL_CREATE_ALBUM_ITEM,       'OR REPLACE', 'WHERE albums.id=?'),       undef, $trackObj->albumid )  if $trackObj->albumid;
-	$dbh->do( sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, 'OR REPLACE', 'WHERE contributors.id=?'), undef, $trackObj->artistid ) if $trackObj->artistid;
+	my $deletionSql = 'DELETE FROM fulltext WHERE id = ? || ?';
+	my @params = ($trackObj->urlmd5, $trackObj->id);
+
+	if ($trackObj->albumid) {
+		$deletionSql .= ' OR id=?';
+		push @params, sprintf('YXLALBUMSYYYYYYYYYYYYYYYYYYYYYYY%s', $trackObj->albumid);
+	}
+
+#	if ($trackObj->artistid) {
+#		$deletionSql .= ' OR id=?';
+#		push @params, sprintf('YXLCONTRIBUTORSYYYYYYYYYYYYYYYYY%s', $trackObj->artistid);
+#	}
+	$deletionSql .= " OR ( fulltext.type = 'contributor' AND substr(fulltext.id,33) in (SELECT contributor FROM contributor_track WHERE track=?) )";
+	push @params, $trackObj->id;
+	$deletionSql .= " OR ( fulltext.type = 'contributor' AND fulltext.w10 <> ? AND NOT EXISTS (SELECT * FROM contributor_track WHERE contributor = substr(fulltext.id,33)) )";
+	push @params, uc(Slim::Music::Info::variousArtistString());
+
+	$dbh->do($deletionSql, undef, @params);
+
+	$dbh->do( sprintf(SQL_CREATE_TRACK_ITEM,       'WHERE tracks.id=?'),       undef, $trackObj->id );
+	$dbh->do( sprintf(SQL_CREATE_ALBUM_ITEM,       'WHERE albums.id=?'),       undef, $trackObj->albumid )  if $trackObj->albumid;
+#	$dbh->do( sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, 'WHERE contributors.id=?'), undef, $trackObj->artistid ) if $trackObj->artistid;
+	$dbh->do( sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, 'WHERE contributors.id in (SELECT contributor FROM contributor_track WHERE track=?)'), undef, $trackObj->id );
 }
 
 sub checkPlaylist {
@@ -326,7 +346,7 @@ sub parseSearchTerm {
 	# Check if the search string contains CJK (Chinese/Japanese/Korean) characters
 	# \p{Han} matches Chinese Han characters (covers both simplified and traditional Chinese, and Kanji)
 	# \p{Hiragana} matches Japanese Hiragana syllabary
-	# \p{Katakana} matches Japanese Katakana syllabary  
+	# \p{Katakana} matches Japanese Katakana syllabary
 	# \p{Hangul} matches Korean Hangul syllables
 	my $isCJK = ( $search =~ /\p{Han}|\p{Hiragana}|\p{Katakana}|\p{Hangul}/ );
 
@@ -335,10 +355,10 @@ sub parseSearchTerm {
 	while ($search =~ s/"(.+?)"//) {
 		my $quoted = $1;
 		if ( $isCJK ) {
-			# Since SQLite's full-text tokenizer does not use CJK punctuation for word segmentation, 
+			# Since SQLite's full-text tokenizer does not use CJK punctuation for word segmentation,
 			# we replace ASCII punctuation while preserving CJK punctuation.
 			#
-			# Punctuation characters; in the ‘C’ locale and ASCII character encoding, 
+			# Punctuation characters; in the ‘C’ locale and ASCII character encoding,
 			# this is ! " # $ % & ' ( ) * + , - . / : ; < = > ? @ [ \ ] ^ _ ` { | } ~.
 			# https://www.gnu.org/software/grep/manual/html_node/Character-Classes-and-Bracket-Expressions.html
 			$quoted =~ s/[!"#\$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~]/ /g;
@@ -568,7 +588,7 @@ sub _rebuildIndex {
 	$progress && $progress->update(string('SONGS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 
-	my $sql = sprintf(SQL_CREATE_TRACK_ITEM, '', '');
+	my $sql = sprintf(SQL_CREATE_TRACK_ITEM, '');
 
 #	main::DEBUGLOG && $scanlog->is_debug && $scanlog->debug($sql);
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
@@ -577,7 +597,7 @@ sub _rebuildIndex {
 	$scanlog->error("Create fulltext index for albums");
 	$progress && $progress->update(string('ALBUMS'));
 	Slim::Schema->forceCommit if main::SCANNER;
-	$sql = sprintf(SQL_CREATE_ALBUM_ITEM, '', '');
+	$sql = sprintf(SQL_CREATE_ALBUM_ITEM, '');
 
 #	main::DEBUGLOG && $scanlog->is_debug && $scanlog->debug($sql);
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
@@ -587,7 +607,7 @@ sub _rebuildIndex {
 	$progress && $progress->update(string('ARTISTS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 
-	$sql = sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, '', '');
+	$sql = sprintf(SQL_CREATE_CONTRIBUTOR_ITEM, '');
 
 #	main::DEBUGLOG && $scanlog->is_debug && $scanlog->debug($sql);
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
@@ -597,8 +617,9 @@ sub _rebuildIndex {
 	$progress && $progress->update(string('WORKS'));
 	Slim::Schema->forceCommit if main::SCANNER;
 	$dbh->do(SQL_DROP_WORKTEMP) or $scanlog->error($dbh->errstr);
-	$dbh->do(SQL_CREATE_WORKTEMP) or $scanlog->error($dbh->errstr);
-	$sql = sprintf(SQL_CREATE_WORK_ITEM, '', '');
+	$sql = sprintf(SQL_CREATE_WORKTEMP, '');
+	$dbh->do($sql) or $scanlog->error($dbh->errstr);
+	$sql = sprintf(SQL_CREATE_WORK_ITEM, '');
 	$dbh->do($sql) or $scanlog->error($dbh->errstr);
 	main::idleStreams() unless main::SCANNER;
 

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -59,7 +59,6 @@ use constant SCAN_WORKS_FOR_MY_CLASSICAL_GENRES => 2;
 my $log = logger('database.info');
 
 my $prefs = preferences('server');
-my $scanWorks = $prefs->get('worksScan') if main::SCANNER;
 
 # Singleton objects for Unknowns
 our ($_unknownArtist, $_unknownGenre, $_unknownAlbumId) = ('', '', undef);
@@ -3360,11 +3359,10 @@ sub canFulltextSearch {
 
 sub _workRequired {
 	my $genres = shift;
-	my $wantWorks = defined $scanWorks ? $scanWorks : $prefs->get('worksScan');
 
-	return $wantWorks == SCAN_WORKS_FOR_MY_CLASSICAL_GENRES
+	return $prefs->get('worksScan') == SCAN_WORKS_FOR_MY_CLASSICAL_GENRES
 		? Slim::Schema::Genre->isMyClassicalGenre($genres)
-		: $scanWorks;
+		: SCAN_WORKS_FOR_MY_CLASSICAL_GENRES;
 }
 
 =head1 SEE ALSO


### PR DESCRIPTION
Based on @michaelherger changes in #1506.

Further changes to ensure that fulltext YXLCONTRIBUTORS... rows are fully recreated.

Amended #1506 statements commented out with replacement statements immediately below.

This is obviously heavier on the database engine - do we need to look again at an onFinished handler?