### PR TITLE
FTS exclude tokens

### DIFF
--- a/Slim/Plugin/FullTextSearch/Plugin.pm
+++ b/Slim/Plugin/FullTextSearch/Plugin.pm
@@ -387,7 +387,7 @@ sub parseSearchTerm {
 		push @quoted, '"' . $quoted . '"';
 	}
 
-	my @tokens = grep /\w+/, split(/[\s[:punct:]]/, $search);
+	my @tokens = grep /\-?\w/, split(/(?[ ( [:punct:] - [-] ) + \s ])|\b\-/, $search);
 	my $noOfTokens = scalar(@tokens) + scalar(@quoted);
 
 	my @tokens = map {


### PR DESCRIPTION
Since this was added:
https://github.com/LMS-Community/slimserver/blob/ab95b3ee586b38a12236de365d5457f0ba1e32d1/Slim/Plugin/FullTextSearch/Plugin.pm#L390

this line
https://github.com/LMS-Community/slimserver/blob/ab95b3ee586b38a12236de365d5457f0ba1e32d1/Slim/Plugin/FullTextSearch/Plugin.pm#L455-L456

has been inoperative, because the `-` is always used as a split character because of `[:punct:]`.

This changes the regex so that `-` is only used as a split character when preceeded by `\w`, so a search of `spider-man` will generate tokens `["spider", "man"]`
but a search of `spider -man` will generate tokens `["spider", "-man"]`

This is using https://perldoc.pl/perlrecharclass#Extended-Bracketed-Character-Classes which "became available in Perl 5.18, as experimental; accepted in 5.36." So I don't know if we should do a Perl version check, or if there is a more compatible way of writing the regex?
