### PR TITLE
Fix work images and artwork precaching

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -5149,6 +5149,10 @@ sub worksQuery {
 
 	}
 
+	push @{$w}, "NOT EXISTS (SELECT 1 FROM tracks t2 WHERE tracks.album=t2.album AND tracks.work=t2.work
+			AND (tracks.performance IS NULL AND t2.performance IS NULL OR tracks.performance=t2.performance)
+			AND tracks.id > t2.id)";
+
 	if (defined $libraryID) {
 		push @{$w}, 'EXISTS (SELECT 1 FROM library_album WHERE library_album.album = albums.id AND library_album.library = ?)';
 		push @{$p}, $libraryID;

--- a/Slim/Music/Artwork.pm
+++ b/Slim/Music/Artwork.pm
@@ -666,7 +666,7 @@ sub precacheAllArtwork {
 	}
 	. ($force ? '' : ' AND    tracks.cover_cached IS NULL')
 	. qq{
-		GROUP BY tracks.cover
+		GROUP BY tracks.cover, tracks.album
  	};
 
 	my $sth_update_tracks = $dbh->prepare( qq{
@@ -816,7 +816,7 @@ sub precacheAllArtwork {
 			FROM   tracks
 			WHERE  tracks.album = ?
 			AND    tracks.coverid IS NOT NULL
-			ORDER BY tracks.disc, tracks.tracknum
+			ORDER BY CASE WHEN CAST(CAST(tracks.cover AS INTEGER) AS TEXT) = tracks.cover THEN '1' ELSE '0' END, tracks.disc, tracks.tracknum
 			LIMIT 1
 	 	});
 


### PR DESCRIPTION
Ensure that only the image from the first track of a work-instance is used even when there are multiple images for the set of tracks making up the work-instance.

This can happen with embedded track images of different sizes, for example.

