### PR TITLE
Fix implicit dependency on Slim::Utils::DateTime in Rescan plugin

### DIFF
--- a/Slim/Plugin/Rescan/Plugin.pm
+++ b/Slim/Plugin/Rescan/Plugin.pm
@@ -23,6 +23,7 @@ if ( main::WEBUI ) {
 use Scalar::Util qw(blessed);
 
 use Slim::Control::Request;
+use Slim::Utils::DateTime;
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 use Slim::Utils::Strings qw(cstring);


### PR DESCRIPTION
Fixes #1518

`Slim::Plugin::Rescan::Plugin` calls `Slim::Utils::DateTime::timeDigits()` in two places but never declares the dependency. This works incidentally because `Slim::Utils::DateTime` is loaded earlier by another module, but would produce a runtime error if load order ever changed.

One-line fix: add `use Slim::Utils::DateTime` to the `use` block.