### PR TITLE
Prevent errors due to missing $client object in getMetadataFor()

### DIFF
--- a/Slim/Player/Playlist.pm
+++ b/Slim/Player/Playlist.pm
@@ -1,7 +1,7 @@
 package Slim::Player::Playlist;
 
 # Logitech Media Server Copyright 2001-2024 Logitech.
-# Lyrion Music Server Copyright 2024 Lyrion Community.
+# Lyrion Music Server Copyright 2024-2026 Lyrion Community.
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License,
 # version 2.
@@ -65,7 +65,7 @@ sub track {
 	$refresh ||= 0;
 	$useShuffled = 1 unless defined $useShuffled;
 
-	if (count($client) == 0) {
+	if (!$client || count($client) == 0) {
 		return;
 	}
 

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -1033,7 +1033,7 @@ sub getMetadataFor {
 
 	# Check for an alternate metadata provider for this URL
 	my $provider = Slim::Formats::RemoteMetadata->getProviderFor($url);
-	if ( $provider ) {
+	if ( $client && $provider ) {
 		my $metadata = eval { $provider->( $client, $url ) };
 		if ( $@ ) {
 			my $name = main::DEBUGLOG ? Slim::Utils::PerlRunTime::realNameForCodeRef($provider) : 'unk';
@@ -1073,7 +1073,7 @@ sub getMetadataFor {
 
 	my ($artist, $title);
 	# Radio tracks, return artist and title if the metadata looks like Artist - Title
-	if ( my $currentTitle = Slim::Music::Info::getCurrentTitle( $client, $url ) ) {
+	if ( $client && (my $currentTitle = Slim::Music::Info::getCurrentTitle( $client, $url ) ) ) {
 		my @dashes = $currentTitle =~ /( - )/g;
 		if ( scalar @dashes == 1 ) {
 			($artist, $title) = split /\s+-\s+/, $currentTitle;
@@ -1092,8 +1092,8 @@ sub getMetadataFor {
 	my $cover = $cache->get( "remote_image_$url" );
 
 	# Item may be a playlist, so get the real URL playing
-	if ( Slim::Music::Info::isPlaylist($url) ) {
-		if (my $cur = $client->currentTrackForUrl($url)) {
+	if ( $client && (Slim::Music::Info::isPlaylist($url) ) ) {
+		if ( my $cur = $client->currentTrackForUrl($url)) {
 			$url = $cur->url;
 		}
 	}

--- a/Slim/Player/Protocols/HTTP.pm
+++ b/Slim/Player/Protocols/HTTP.pm
@@ -1033,7 +1033,7 @@ sub getMetadataFor {
 
 	# Check for an alternate metadata provider for this URL
 	my $provider = Slim::Formats::RemoteMetadata->getProviderFor($url);
-	if ( $client && $provider ) {
+	if ( $provider ) {
 		my $metadata = eval { $provider->( $client, $url ) };
 		if ( $@ ) {
 			my $name = main::DEBUGLOG ? Slim::Utils::PerlRunTime::realNameForCodeRef($provider) : 'unk';
@@ -1073,7 +1073,7 @@ sub getMetadataFor {
 
 	my ($artist, $title);
 	# Radio tracks, return artist and title if the metadata looks like Artist - Title
-	if ( $client && (my $currentTitle = Slim::Music::Info::getCurrentTitle( $client, $url ) ) ) {
+	if ( my $currentTitle = Slim::Music::Info::getCurrentTitle( $client, $url ) ) {
 		my @dashes = $currentTitle =~ /( - )/g;
 		if ( scalar @dashes == 1 ) {
 			($artist, $title) = split /\s+-\s+/, $currentTitle;
@@ -1092,8 +1092,8 @@ sub getMetadataFor {
 	my $cover = $cache->get( "remote_image_$url" );
 
 	# Item may be a playlist, so get the real URL playing
-	if ( $client && (Slim::Music::Info::isPlaylist($url) ) ) {
-		if ( my $cur = $client->currentTrackForUrl($url)) {
+	if ( Slim::Music::Info::isPlaylist($url) ) {
+		if (my $cur = $client->currentTrackForUrl($url)) {
 			$url = $cur->url;
 		}
 	}


### PR DESCRIPTION
Another case of error messages due to **getMetadataFor()** not validating the _$client_. In this case:

`Slim::Player::Protocols::HTTP::getMetadataFor (1040) Metadata provider Plugins::RadioNowPlaying::Plugin::provider failed: Can't call method "master" on an undefined value at /usr/share/perl5/Slim/Player/Playlist.pm line 183.`