### PR TITLE
Fix FLAC to MP3 transcoding for mono tracks

### DIFF
--- a/convert.conf
+++ b/convert.conf
@@ -136,7 +136,7 @@ aif mp3 * *
 
 flc mp3 * *
 	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}E:{NOSTART=I}
-	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
+	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer --endian little -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t raw -c 2 - | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 wma mp3 * *
 	# F:{PATH=%f}R:{PATH=%F}B:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}

--- a/convert.conf
+++ b/convert.conf
@@ -136,7 +136,7 @@ aif mp3 * *
 
 flc mp3 * *
 	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}E:{NOSTART=I}
-	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer --endian little -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t raw -c 2 - | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
+	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --endian=little --sign=signed -- $FILE$ | [sox] -q -t raw --endian little --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t raw -c 2 - | [lame] --silent -r --little-endian --signed --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 wma mp3 * *
 	# F:{PATH=%f}R:{PATH=%F}B:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}
@@ -373,7 +373,7 @@ mp3 mp3 transcode *
 
 flc flc transcode *
 	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}E:{NOSTART=I}
-	[flac] -dcs $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ -L - -t flac $RESAMPLE$ -C 0  -
+	[flac] -dcs $START$ $END$ --force-raw-format --endian=little --sign=signed -- $FILE$ | [sox] -q -t raw --endian little --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t flac $RESAMPLE$ -C 0 -
 
 # This example transcodes MP3s to MP3s, if the target machine has the
 # given MAC address. This rule will take precedence over the


### PR DESCRIPTION
I discovered that #1500 caused mono FLAC files to play at double speed (chipmunk-style). This was due to `lame` assuming the stdin data is stereo. To work around this, `sox` has been added before lame in order to guarantee stereo output. The change also works with 3+ channel FLAC files from <https://github.com/sfiera/flac-test-files>, which would have played at varying degrees of slowness previously.

I tried to use `sox` as a replacement for `flac` as the FLAC decoder, but FLACs with embedded cuesheets and seeking on streamed FLACs stopped working. I believe this is because `sox` requires parsing the FLAC metadata when decoding (https://github.com/chirlu/sox/blob/42b3557e13e0fe01a83465b672d89faddbe65f49/src/flac.c#L241). Cuesheets and seeked streams would be sent mid-file and beyond the metadata.

This has the added benefit of aligning `flc mp3 * *` with `flc flc * *` by using `sox` for processing. I kept `lame` to preserve the configurable bitrate processing, and because `sox` may not be compiled with MP3 support (the current Docker image does not).

Finally, just as a cleanup task, I updated the parameter order to be endian and then signed, which is aligned with the rest of the converts.