### PR TITLE
Fix FLAC to MP3 transcoding for mono tracks (9.1 rebase)

### DIFF
--- a/convert.conf
+++ b/convert.conf
@@ -136,7 +136,7 @@ aif mp3 * *
 
 flc mp3 * *
 	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}E:{NOSTART=I}
-	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
+	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer --endian little -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t raw -c 2 - | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 wma mp3 * *
 	# F:{PATH=%f}R:{PATH=%F}B:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}

--- a/convert.conf
+++ b/convert.conf
@@ -136,7 +136,7 @@ aif mp3 * *
 
 flc mp3 * *
 	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}E:{NOSTART=I}
-	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer --endian little -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t raw -c 2 - | [lame] --silent -r --signed --little-endian --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
+	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --endian=little --sign=signed -- $FILE$ | [sox] -q -t raw --endian little --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t raw -c 2 - | [lame] --silent -r --little-endian --signed --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
 wma mp3 * *
 	# F:{PATH=%f}R:{PATH=%F}B:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}
@@ -373,7 +373,7 @@ mp3 mp3 transcode *
 
 flc flc transcode *
 	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}E:{NOSTART=I}
-	[flac] -dcs $START$ $END$ --force-raw-format --sign=signed --endian=little -- $FILE$ | [sox] -q -t raw --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ -L - -t flac $RESAMPLE$ -C 0  -
+	[flac] -dcs $START$ $END$ --force-raw-format --endian=little --sign=signed -- $FILE$ | [sox] -q -t raw --endian little --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t flac $RESAMPLE$ -C 0 -
 
 # This example transcodes MP3s to MP3s, if the target machine has the
 # given MAC address. This rule will take precedence over the


### PR DESCRIPTION
The same as #1528 but rebased on top of public/9.1.