### PR TITLE
Add "Default Adjustment for Local Tracks" player option.

### DIFF
--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -399,6 +399,10 @@
 			[% WRAPPER settingGroup title="SETUP_REPLAYGAIN_REMOTE" desc="SETUP_REPLAYGAIN_REMOTE_DESC" %]
 				<input type="text" class="stdedit sliderInput_-20_20_0.1" name="pref_remoteReplayGain" id="pref_remoteReplayGain" value="[% prefs.pref_remoteReplayGain | html %]" size="5">
 			[% END %]
+
+			[% WRAPPER settingGroup title="SETUP_REPLAYGAIN_LOCAL" desc="SETUP_REPLAYGAIN_LOCAL_DESC" %]
+				<input type="text" class="stdedit sliderInput_-15_15_0.1" name="pref_localReplayGain" id="pref_localReplayGain" value="[% prefs.pref_localReplayGain | html %]" size="5">
+			[% END %]
 		[% END %]
 	[% END %]
 

--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -401,7 +401,7 @@
 			[% END %]
 
 			[% WRAPPER settingGroup title="SETUP_REPLAYGAIN_LOCAL" desc="SETUP_REPLAYGAIN_LOCAL_DESC" %]
-				<input type="text" class="stdedit sliderInput_-20_20_0.1" name="pref_localReplayGain" id="pref_localReplayGain" value="[% prefs.pref_localReplayGain | html %]" size="5">
+				<input type="text" class="stdedit sliderInput_-10_10_0.1" name="pref_localReplayGain" id="pref_localReplayGain" value="[% prefs.pref_localReplayGain | html %]" size="5">
 			[% END %]
 		[% END %]
 	[% END %]

--- a/HTML/EN/settings/player/audio.html
+++ b/HTML/EN/settings/player/audio.html
@@ -401,7 +401,7 @@
 			[% END %]
 
 			[% WRAPPER settingGroup title="SETUP_REPLAYGAIN_LOCAL" desc="SETUP_REPLAYGAIN_LOCAL_DESC" %]
-				<input type="text" class="stdedit sliderInput_-15_15_0.1" name="pref_localReplayGain" id="pref_localReplayGain" value="[% prefs.pref_localReplayGain | html %]" size="5">
+				<input type="text" class="stdedit sliderInput_-20_20_0.1" name="pref_localReplayGain" id="pref_localReplayGain" value="[% prefs.pref_localReplayGain | html %]" size="5">
 			[% END %]
 		[% END %]
 	[% END %]

--- a/Slim/Player/ReplayGain.pm
+++ b/Slim/Player/ReplayGain.pm
@@ -50,16 +50,12 @@ sub fetchGainMode {
 	# only support track gain for remote streams
 	if ( $track->remote ) {
 		# Only use the default remote gain value if the track gain value is undefined, as 0 is a valid gain value
-		my $remoteTrackGain = defined $track->replay_gain() ? $track->replay_gain() : $prefs->client($client)->get('remoteReplayGain');
-		return preventClipping( $remoteTrackGain, $track->replay_peak() );
+		return preventClipping( $track->replay_gain() // $prefs->client($client)->get('remoteReplayGain'), $track->replay_peak() );
 	}
-
-	# Only use the default local gain value if the track gain value is undefined, as 0 is a valid gain value
-	my $localTrackGain = defined $track->replay_gain() ? $track->replay_gain() : $prefs->client($client)->get('localReplayGain');
 	
 	# Mode 1 is use track gain
 	if ($rgmode == 1) {
-		return preventClipping( $localTrackGain, $track->replay_peak() );
+		return preventClipping( $track->replay_gain() // $prefs->client($client)->get('localReplayGain'), $track->replay_peak() );
 	}
 
 	my $album = $track->album();
@@ -78,8 +74,9 @@ sub fetchGainMode {
 		# use album gain
 		return preventClipping( $album->replay_gain(), $album->replay_peak() );
 	}
+	
 	# use track gain
-	return preventClipping( $localTrackGain, $track->replay_peak() );
+	return preventClipping( $track->replay_gain() // $prefs->client($client)->get('localReplayGain'), $track->replay_peak() );
 }
 
 sub findTracksByIndex {

--- a/Slim/Player/ReplayGain.pm
+++ b/Slim/Player/ReplayGain.pm
@@ -39,7 +39,6 @@ sub fetchGainMode {
 	return undef if !$rgmode;
 
 	if (!blessed($track) || !$track->can('replay_gain')) {
-
 		return 0;
 	}
 
@@ -50,18 +49,22 @@ sub fetchGainMode {
 
 	# only support track gain for remote streams
 	if ( $track->remote ) {
-		return preventClipping( $track->replay_gain() || $prefs->client($client)->get('remoteReplayGain'), $track->replay_peak() );
+		# Only use the default remote gain value if the track gain value is undefined, as 0 is a valid gain value
+		my $remoteTrackGain = defined $track->replay_gain() ? $track->replay_gain() : $prefs->client($client)->get('remoteReplayGain');
+		return preventClipping( $remoteTrackGain, $track->replay_peak() );
 	}
 
+	# Only use the default local gain value if the track gain value is undefined, as 0 is a valid gain value
+	my $localTrackGain = defined $track->replay_gain() ? $track->replay_gain() : $prefs->client($client)->get('localReplayGain');
+	
 	# Mode 1 is use track gain
 	if ($rgmode == 1) {
-		return preventClipping( $track->replay_gain(), $track->replay_peak() );
+		return preventClipping( $localTrackGain, $track->replay_peak() );
 	}
 
 	my $album = $track->album();
 
 	if (!blessed($album) || !$album->can('replay_gain')) {
-
 		return 0;
 	}
 
@@ -70,13 +73,13 @@ sub fetchGainMode {
 		return preventClipping( $album->replay_gain(), $album->replay_peak() );
 	}
 
-	# Mode 3 is determine dynamically whether to use album or track
+	# Mode 3 is determine dynamically whether to use album or track (smart gain)
 	if (defined $album->replay_gain() && ($class->trackAlbumMatch($client, -1) || $class->trackAlbumMatch($client, 1))) {
-
+		# use album gain
 		return preventClipping( $album->replay_gain(), $album->replay_peak() );
 	}
-
-	return preventClipping( $track->replay_gain(), $track->replay_peak() );
+	# use track gain
+	return preventClipping( $localTrackGain, $track->replay_peak() );
 }
 
 sub findTracksByIndex {

--- a/Slim/Player/SqueezeSlave.pm
+++ b/Slim/Player/SqueezeSlave.pm
@@ -28,11 +28,13 @@ my $prefs = preferences('server');
 our $defaultPrefs = {
 	'replayGainMode'     => 0,
 	'remoteReplayGain'   => -5,
+	'localReplayGain'    => 0,
 	'minSyncAdjust'      => 30, # ms
 	'maxBitrate'         => 0,  # no bitrate limiting
 };
 
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'remoteReplayGain');
+$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -15, 'high' => 15 }, 'localReplayGain');
 
 sub initPrefs {
 	my $client = shift;

--- a/Slim/Player/SqueezeSlave.pm
+++ b/Slim/Player/SqueezeSlave.pm
@@ -34,7 +34,7 @@ our $defaultPrefs = {
 };
 
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'remoteReplayGain');
-$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'localReplayGain');
+$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -10, 'high' => 10 }, 'localReplayGain');
 
 sub initPrefs {
 	my $client = shift;

--- a/Slim/Player/SqueezeSlave.pm
+++ b/Slim/Player/SqueezeSlave.pm
@@ -34,7 +34,7 @@ our $defaultPrefs = {
 };
 
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'remoteReplayGain');
-$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -15, 'high' => 15 }, 'localReplayGain');
+$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'localReplayGain');
 
 sub initPrefs {
 	my $client = shift;

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -46,6 +46,7 @@ our $defaultPrefs = {
 	'transitionSmart'    => 1,
 	'replayGainMode'     => 0,
 	'remoteReplayGain'   => -5,
+	'localReplayGain'    => 0,
 	'disableDac'         => 0,
 	'minSyncAdjust'      => 10,	# ms
 	'outputChannels'     => 0,
@@ -53,6 +54,7 @@ our $defaultPrefs = {
 };
 
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'remoteReplayGain');
+$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -15, 'high' => 15 }, 'localReplayGain');
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -25, 'high' => 25 }, 'balance');
 $prefs->setChange( sub { $_[2]->volume($_[2]->volume); }, 'balance');
 

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -54,7 +54,7 @@ our $defaultPrefs = {
 };
 
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'remoteReplayGain');
-$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'localReplayGain');
+$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -10, 'high' => 10 }, 'localReplayGain');
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -25, 'high' => 25 }, 'balance');
 $prefs->setChange( sub { $_[2]->volume($_[2]->volume); }, 'balance');
 

--- a/Slim/Player/Squeezebox2.pm
+++ b/Slim/Player/Squeezebox2.pm
@@ -54,7 +54,7 @@ our $defaultPrefs = {
 };
 
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'remoteReplayGain');
-$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -15, 'high' => 15 }, 'localReplayGain');
+$prefs->setValidate({ 'validator' => 'numlimit', 'low' => -20, 'high' => 20 }, 'localReplayGain');
 $prefs->setValidate({ 'validator' => 'numlimit', 'low' => -25, 'high' => 25 }, 'balance');
 $prefs->setChange( sub { $_[2]->volume($_[2]->volume); }, 'balance');
 

--- a/Slim/Web/Settings/Player/Audio.pm
+++ b/Slim/Web/Settings/Player/Audio.pm
@@ -81,7 +81,7 @@ sub prefs {
 	}
 
 	if ($client->canDoReplayGain(0)) {
-		push @prefs, 'replayGainMode', 'remoteReplayGain';
+		push @prefs, 'replayGainMode', 'remoteReplayGain', 'localReplayGain';
 	}
 
 	if ($client->hasHeadSubOut()) {

--- a/strings.txt
+++ b/strings.txt
@@ -5640,30 +5640,30 @@ SETUP_REPLAYGAIN_REMOTE_DESC
 	ZH_CN	远程流媒体服务通常不支持任何形式的音量调整。如果您在播放远程曲目与本地曲目混合时，这可能会导致不希望的音量变化。定义一个默认值，该值应适用于任何未定义音量调整值的远程流。
 
 SETUP_REPLAYGAIN_LOCAL
-	CS	;
-	DA	;
+	CS	Výchozí úprava pro místní skladby
+	DA	Tilpasning af volumen for lokale musikfiler
 	DE	Anpassung für lokale Musikdateien
 	EN	Default Adjustment for Local Tracks
-	FR	;
-	HU	;
-	NL	;
-	NO	;
-	PL	;
-	SV	;
-	ZH_CN	;
+	FR	Ajustement du volume pour les morceaux locaux
+	HU	A helyi számok alapértelmezett beállítása
+	NL	Aanpassing voor lokale muziekbestanden
+	NO	Standardvolum for lokale musikkfiler
+	PL	Domyślna wartość dla lokalnych utworów
+	SV	Standardanpassning av volymen för lokala spår
+	ZH_CN	本地曲目默认调整
 
 SETUP_REPLAYGAIN_LOCAL_DESC
-	CS	;
-	DA	;
+	CS	Ne všechny místní skladby obsahují informace „Replay Gain“. Při použití režimu „Zesílení skladby“ nebo „Inteligentní zesílení“ při přehrávání směsi skladeb, které tyto informace obsahují i neobsahují, může docházet k velkým změnám hlasitosti mezi skladbami. Definujte výchozí hodnotu úpravy, která se použije na skladby bez informací „Replay Gain“, aby se toto chování zmírnilo.
+	DA	Ikke alle lokale musikfiler indeholder oplysninger om "Replay Gain". Hvis du bruger "Forstærkning af nummer" eller "Dynamisk forstærkning" til at afspille en blanding af numre med og uden disse oplysninger, kan der forekomme store ændringer i lydstyrken mellem numrene. Definér en standardværdi for justering, som skal anvendes på numre uden "Replay Gain"-oplysninger for at mindske dette.
 	DE	Nicht alle lokale Musikdateien enthalten "Replay Gain" Informationen. Wenn einer der Lautstärken-Normalisierung-Modi "Titel-Normalisierung" oder "Intelligente Normalisierung" verwendet wird, kann es beim Abspielen eines Mix von Musikdateien mit und ohne "Replay Gain" Informationen zu großen Lautstärkeunterschieden kommen. Definiere einen Standardwert, der bei Musikdateien ohne "Replay Gain" Informationen angewandt wird, um diese Unterschiede auszugleichen.
 	EN	All local tracks may not contain "Replay Gain" information. When using "Track gain" or "Smart gain" mode to play a mixture of tracks that do and do not contain this information, large volume changes may occur between tracks. Define a default adjustment value which should be applied to tracks without "Replay Gain" information in order to mitigate this behavior.
-	FR	;
-	HU	;
-	NL	;
-	NO	;
-	PL	;
-	SV	;
-	ZH_CN	;
+	FR	Tous les morceaux locaux ne contiennent pas forcément d'informations de "Replay Gain". Lors de l'utilisation du mode "gain morceau" ou "gain intelligent" pour lire un mélange de morceaux avec et sans ces informations, d'importantes variations de volume peuvent se produire entre les morceaux. Définissez une valeur d'ajustement par défaut à appliquer aux morceaux sans informations de "Replay Gain" afin d'atténuer ce comportement.
+	HU	Nem minden helyi műsorszám tartalmaz „Replay Gain” információt. Ha a „Track gain” vagy az „intelligens” erősítés módot használja olyan műsorszámok vegyes lejátszásához, amelyek tartalmazzák ezt az információt, illetve amelyek nem, nagy hangerőkülönbségek léphetnek fel a számok között. Adjon meg egy alapértelmezett korrekciós értéket, amelyet a „Replay Gain” információ nélküli műsorszámokra kell alkalmazni ennek mérséklésére.
+	NL	Niet alle lokale muziekbestanden bevatten 'Replay Gain'-informatie. Wanneer je 'volumeaanpassing van nummers' of 'slimme' aanpassingsselectie gebruikt om een mix van nummers met en zonder deze informatie af te spelen, kunnen er grote volumeverschillen tussen nummers ontstaan. Stel een standaardwaarde in die moet worden toegepast op nummers zonder 'Replay Gain'-informatie om dit effect te beperken.
+	NO	Ikke alle lokale musikkfiler inneholder «Replay Gain»-informasjon. Hvis du bruker «Track gain» eller «Smart gain» når du spiller av en blanding av spor med og uten denne informasjonen, kan det oppstå store volumendringer mellom sporene. Sett en standardjustering som skal brukes på spor uten «Replay Gain»-informasjon for å redusere dette.
+	PL	Nie wszystkie lokalne utwory zawierają informacje „Replay Gain”. Podczas korzystania z opcji „Wzmocnienie utworu” lub „Inteligentne” dotyczącej wzmocnienia do odtwarzania mieszanki utworów z tymi informacjami i bez nich mogą wystąpić duże zmiany głośności między utworami. Ustal domyślną wartość korekty, która będzie stosowana do utworów bez informacji „Replay Gain”, aby ograniczyć to zjawisko.
+	SV	Alla lokala spår innehåller inte information om "Replay Gain". När du använder "Volymutjämning av spår" eller "Smart volymjustering" för att spela en blandning av spår med och utan denna information kan stora volymskillnader uppstå mellan spåren. Ange ett standardvärde för volymjustering som ska användas för spår utan "Replay Gain"-information för att minska detta.
+	ZH_CN	并非所有本地曲目都包含“回放增益”信息。当使用“曲目增益”或“智能”增益模式播放同时包含和不包含此信息的曲目时，曲目之间可能会出现较大的音量变化。定义一个默认调整值，该值应应用于没有“回放增益”信息的曲目，以减轻这种情况。
 
 REPLAYGAIN_DISABLED
 	CS	Žádná úprava hlasitosti

--- a/strings.txt
+++ b/strings.txt
@@ -5642,7 +5642,7 @@ SETUP_REPLAYGAIN_REMOTE_DESC
 SETUP_REPLAYGAIN_LOCAL
 	CS	;
 	DA	;
-	DE	;
+	DE	Anpassung für lokale Musikdateien
 	EN	Default Adjustment for Local Tracks
 	FR	;
 	HU	;
@@ -5655,7 +5655,7 @@ SETUP_REPLAYGAIN_LOCAL
 SETUP_REPLAYGAIN_LOCAL_DESC
 	CS	;
 	DA	;
-	DE	;
+	DE	Nicht alle lokale Musikdateien enthalten "Replay Gain" Informationen. Wenn einer der Lautstärken-Normalisierung-Modi "Titel-Normalisierung" oder "Intelligente Normalisierung" verwendet wird, kann es beim Abspielen eines Mix von Musikdateien mit und ohne "Replay Gain" Informationen zu großen Lautstärkeunterschieden kommen. Definiere einen Standardwert, der bei Musikdateien ohne "Replay Gain" Informationen angewandt wird, um diese Unterschiede auszugleichen.
 	EN	All local tracks may not contain "Replay Gain" information. When using "Track gain" or "Smart gain" mode to play a mixture of tracks that do and do not contain this information, large volume changes may occur between tracks. Define a default adjustment value which should be applied to tracks without "Replay Gain" information in order to mitigate this behavior.
 	FR	;
 	HU	;

--- a/strings.txt
+++ b/strings.txt
@@ -5630,7 +5630,7 @@ SETUP_REPLAYGAIN_REMOTE_DESC
 	CS	Vzdálená streamovací služba často nepodporuje žádnou formu úpravy hlasitosti. Pokud přehráváte vzdálené skladby spolu s místními, může to vést k nežádoucím změnám hlasitosti. Definujte výchozí hodnotu, která by měla být použita pro každý vzdálený datový proud, který sám nedefinuje hodnotu úpravy hlasitosti.
 	DA	Internet streamingtjenester understøtter ofte ikke volumenregulering. Hvis du veksler mellem streaming og lokale musikfiler kan det medføre uønskede ændringer i volumen. Definér ønsket volumen for streamingtjenester, som ikke selv har defineret volumenjustering.
 	DE	Internet Streaming Dienste stellen selten Werte für die Lautstärken-Normalisierung zur Verfügung. Dies kann dazu führen, dass Musikstücke von Online-Diensten erheblich lauter wiedergegeben werden, als lokale Musikstücke. Definiere einen Standard-Wert, der bei Internet-Streams verwendet werden soll.
-	EN	Remote streaming service often don't support any form of volume adjustment. If you're playing remote tracks mixed in with local tracks, this can lead to undesired volume changes. Define a default value which should be applied to any remote stream not defining a volume adjustment value itself.
+	EN	Remote streaming services often don't support any form of volume adjustment. If you're playing remote tracks mixed in with local tracks, this can lead to undesired volume changes. Define a default value which should be applied to any remote stream not defining a volume adjustment value itself.
 	FR	La musique en streaming sur Internet donne rarement le gain pour ajuster le volume. Cela peut conduire à subir des variations importantes de volume entre des morceaux en ligne et de la musqique en local. Définir une valeur par défaut à utiliser pour le streaming sur Internet si l'information de normalisation est absente.
 	HU	A távoli streaming szolgáltatás gyakran nem támogatja a hangerőszabályozás semmilyen formáját. Ha távoli számokat játszik le helyi számokkal keverve, ez nemkívánatos hangerő-változásokhoz vezethet. Határozzon meg egy alapértelmezett értéket, amelyet minden olyan távoli adatfolyamra alkalmazni kell, amely nem határozza meg magát a hangerő-beállítási értéket.
 	NL	Online streamingdiensten bieden meestal geen vorm van volumenormalisering aan. Internetstreams kunnen hierdoor duidelijk harder weergegeven worden dan lokale bestanden. Stel een standaardwaarde in die bij internetstreams moet worden gebruikt.
@@ -5638,6 +5638,32 @@ SETUP_REPLAYGAIN_REMOTE_DESC
 	PL	Zdalne strumienie często nie przesyłają żadnych danych, które pozwalałyby na automatyczne dopasowanie głośności. Odtwarzanie utworów ze zdalnych strumieni wymieszanych z lokalnymi utworami może doprowadzić do niepożądanych zmian głośności. Ustal domyślną wartość, która będzie użyta dla każdego zdalnego strumienia, który nie określa własnego poziomu głośności.
 	SV	Strömningstjänster understöder för det mesta inte volymnormalisering. Därför kan du uppleva plötsliga volymskillnader när du byter mellan lokal musik och strömningstjänster. Bestäm ett standardvärde för volymjustering som skall användas på strömningstjänster.
 	ZH_CN	远程流媒体服务通常不支持任何形式的音量调整。如果您在播放远程曲目与本地曲目混合时，这可能会导致不希望的音量变化。定义一个默认值，该值应适用于任何未定义音量调整值的远程流。
+
+SETUP_REPLAYGAIN_LOCAL
+	CS	;
+	DA	;
+	DE	;
+	EN	Default Adjustment for Local Tracks
+	FR	;
+	HU	;
+	NL	;
+	NO	;
+	PL	;
+	SV	;
+	ZH_CN	;
+
+SETUP_REPLAYGAIN_LOCAL_DESC
+	CS	;
+	DA	;
+	DE	;
+	EN	All local tracks may not contain "Replay Gain" information. When using "Track gain" or "Smart gain" mode to play a mixture of tracks that do and do not contain this information, large volume changes may occur between tracks. Define a default adjustment value which should be applied to tracks without "Replay Gain" information in order to mitigate this behavior.
+	FR	;
+	HU	;
+	NL	;
+	NO	;
+	PL	;
+	SV	;
+	ZH_CN	;
 
 REPLAYGAIN_DISABLED
 	CS	Žádná úprava hlasitosti


### PR DESCRIPTION
This PR adds support for defining a default volume adjustment for local tracks which do not contain Replay Gain tags, similar to the "Default Adjustment for Remote Streams" option. This will allow the user to reduce volume jumps when playing a mixture of tracks with and without Replay Gain tracks in "Track gain" and "Smart gain" modes. The default adjustment is '0'.

Note that all the string literals besides the English ones have only placeholder entries (";") with this commit.