### PR TITLE
#1555 - Use plural ALBUMARTISTS / ARTISTS as authoritative source of individual contributors

### DIFF
--- a/Changelog9.html
+++ b/Changelog9.html
@@ -30,6 +30,7 @@
 	<ul>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1517">#1517</a> - Fix work images and artwork precaching (@darrell-k)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1553">#1553</a> - Allow plugins to shut down before closing the database (@SamInPgh)</li>
+		<li><a href="https://github.com/LMS-Community/slimserver/issues/1555">#1555</a> - Scanner: stop-gap to prevent contributor row poisoning when the MusicBrainz ID count does not match the artist name count. (@Rouzax)</li>
 		<li></li>
 	</ul>
 	<br />

--- a/Changelog9.html
+++ b/Changelog9.html
@@ -31,6 +31,7 @@
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1517">#1517</a> - Fix work images and artwork precaching (@darrell-k)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/pull/1553">#1553</a> - Allow plugins to shut down before closing the database (@SamInPgh)</li>
 		<li><a href="https://github.com/LMS-Community/slimserver/issues/1555">#1555</a> - Scanner: stop-gap to prevent contributor row poisoning when the MusicBrainz ID count does not match the artist name count. (@Rouzax)</li>
+		<li><a href="https://github.com/LMS-Community/slimserver/issues/1555">#1555</a> - Scanner: read the Picard-convention plural tags ALBUMARTISTS and ARTISTS as the authoritative list of individual contributors for the ALBUMARTIST and ARTIST roles, zipped positionally with MUSICBRAINZ_ALBUMARTIST_ID / MUSICBRAINZ_ARTIST_ID. The singular tag still provides the album/track display string. Behaviour for libraries without plural tags is unchanged. Run <code>wipecache</code> to benefit on already-scanned libraries. (@Rouzax)</li>
 		<li></li>
 	</ul>
 	<br />

--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2842,6 +2842,7 @@ sub _preCheckAttributes {
 			MUSICBRAINZ_ARTIST_ID MUSICBRAINZ_ALBUMARTIST_ID MUSICBRAINZ_ALBUM_ID
 			MUSICBRAINZ_ALBUM_TYPE MUSICBRAINZ_ALBUM_STATUS RELEASETYPE
 			ALBUM_EXTID ARTIST_EXTID WORK WORKSORT
+			ARTISTS ALBUMARTISTS TRACKARTISTS
 		))
 	{
 
@@ -3126,34 +3127,109 @@ sub _mergeAndCreateContributors {
 			$attributes->{'TRACKARTISTSORT'} = delete $attributes->{'ARTISTSORT'};
 			$attributes->{'MUSICBRAINZ_TRACKARTIST_ID'} = delete $attributes->{'MUSICBRAINZ_ARTIST_ID'} if $attributes->{'MUSICBRAINZ_ARTIST_ID'};
 
+			# Issue #1555 - carry the plural ARTISTS tag across too, so the
+			# per-role plural lookup below finds it under TRACKARTISTS.
+			$attributes->{'TRACKARTISTS'} = delete $attributes->{'ARTISTS'} if $attributes->{'ARTISTS'};
+
 			main::DEBUGLOG && $isDebug && $log->debug(sprintf("-- Contributor '%s' of role 'ARTIST' transformed to role 'TRACKARTIST'",
-				$attributes->{'TRACKARTIST'},
+				ref($attributes->{'TRACKARTIST'}) eq 'ARRAY'
+					? join(' / ', @{$attributes->{'TRACKARTIST'}})
+					: $attributes->{'TRACKARTIST'},
 			));
 		}
 	}
 
 	my %contributors = ();
 
+	# Issue #1555 - roles for which a plural Picard tag (ARTISTS,
+	# ALBUMARTISTS, TRACKARTISTS) is the authoritative individual-contributor
+	# list. The singular tag remains the display string; the plural tag,
+	# when present as a non-empty arrayref after trimming, supersedes
+	# splitList parsing of the singular for contributor-row creation.
+	my %pluralRoles = map { $_ => 1 } qw(ARTIST ALBUMARTIST TRACKARTIST);
+
 	for my $tag (Slim::Schema::Contributor->contributorRoles) {
 
-		my $contributor = $attributes->{$tag} || next;
+		my $contributor = $attributes->{$tag};
+		my $brainzID    = $attributes->{"MUSICBRAINZ_${tag}_ID"};
+		my $sortBy      = $attributes->{$tag . 'SORT'};
+		my $usedPlural  = 0;
 
-		# Bug 17322, strip leading/trailing spaces from name
-		$contributor =~ s/^ +//;
-		$contributor =~ s/ +$//;
+		# Issue #1555 - prefer the plural Picard tag as the individual
+		# contributor list when it is a non-empty arrayref with at least
+		# one non-blank name. Trim, drop empty-name slots, and drop the
+		# corresponding MBID slot so positional alignment is preserved.
+		# Empty-string MBID slots (for contributors without an MBID,
+		# Picard convention) are kept; Contributor->add's `if ($mbid)`
+		# guard handles them. A scalar plural value is treated as "not
+		# plural" and falls through to the legacy singular path.
+		#
+		# Sort alignment: Picard has no standard plural sort tag, but a
+		# user script can overwrite the singular ALBUMARTISTSORT /
+		# ARTISTSORT tag with a multi-value list aligned to the plural
+		# names (using %_albumartists_sort% / %_artists_sort%). Accept
+		# that if the sort tag is an arrayref of matching length after
+		# empty-slot filtering. Otherwise pass undef so Contributor->add
+		# falls back to sort-by-name rather than polluting the first
+		# contributor with the joined singular sort string.
+		if ($pluralRoles{$tag}) {
+			my $plural = $attributes->{$tag . 'S'};
+			if (ref($plural) eq 'ARRAY' && @$plural) {
+				my $pluralMbid = $attributes->{"MUSICBRAINZ_${tag}_ID"};
+				my $pluralSort = $attributes->{$tag . 'SORT'};
+				my @mbids      = ref($pluralMbid) eq 'ARRAY' ? @$pluralMbid : ();
+				my @sorts      = ref($pluralSort) eq 'ARRAY' ? @$pluralSort : ();
+				my (@names, @alignedMbids, @alignedSorts);
+				for (my $i = 0; $i < @$plural; $i++) {
+					my $name = $plural->[$i];
+					next unless defined $name;
+					$name =~ s/^\s+//; $name =~ s/\s+$//;
+					next if $name eq '';
+					push @names, $name;
+					push @alignedMbids, $mbids[$i] if @mbids;
+					push @alignedSorts, $sorts[$i] if @sorts;
+				}
+				if (@names) {
+					$contributor = \@names;
+					$brainzID    = @mbids ? \@alignedMbids : $brainzID;
+					$sortBy      = (@sorts && @alignedSorts == @names) ? \@alignedSorts : undef;
+					$usedPlural  = 1;
+					main::DEBUGLOG && $isDebug && $log->debug(sprintf(
+						"-- Using plural %sS (%d entries) as contributor source for role '%s'%s",
+						$tag, scalar @names, $tag,
+						$sortBy ? ' with aligned sort' : '',
+					));
+				}
+			}
+		}
+
+		# Skip unless we have a source of contributor names for this role.
+		# Empty string, undef, or an empty plural array all skip.
+		next unless $usedPlural || (defined $contributor && (ref $contributor || $contributor ne ''));
+
+		# Bug 17322, strip leading/trailing spaces from name. splitTag
+		# already trims arrayref elements, so the regex strip is scalar
+		# only.
+		unless (ref $contributor) {
+			$contributor =~ s/^ +//;
+			$contributor =~ s/ +$//;
+		}
 
 		# Is ARTISTSORT/TSOP always right for non-artist
 		# contributors? I think so. ID3 doesn't have
 		# "BANDSORT" or similar at any rate.
 		push @{ $contributors{$tag} }, Slim::Schema::Contributor->add({
 			'artist'   => $contributor,
-			'brainzID' => $attributes->{"MUSICBRAINZ_${tag}_ID"},
-			'sortBy'   => $attributes->{$tag.'SORT'},
+			'brainzID' => $brainzID,
+			'sortBy'   => $sortBy,
 			# only store EXTID for track artist, as we don't have it for other roles
 			'extid'    => $tag eq 'ARTIST' && $attributes->{'ARTIST_EXTID'},
 		});
 
-		main::DEBUGLOG && $isDebug && $log->is_debug && $log->debug(sprintf("-- Track has contributor '$contributor' of role '$tag'"));
+		main::DEBUGLOG && $isDebug && $log->is_debug && $log->debug(sprintf(
+			"-- Track has contributor '%s' of role '$tag'",
+			ref($contributor) eq 'ARRAY' ? join(' / ', @$contributor) : $contributor,
+		));
 	}
 
 	# Bug 15553, Primary contributor can only be Album Artist or Artist,

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -33,6 +33,7 @@ my @allAlbumLinkRoles;
 my @inArtistsRoles;
 
 my $prefs = preferences('server');
+my $log   = logger('scan.scanner');
 
 initializeRoles();
 
@@ -248,6 +249,20 @@ sub add {
 	my @brainzIDList;
 	if ($brainzID) {
 		@brainzIDList = Slim::Music::Info::splitTag($brainzID);
+
+		# Issue #1555 - if the MBID count differs from the name count, the
+		# positional pairing below would bind an MBID to a joined-display name
+		# (e.g. "Artist A & Artist B" with 2 MBIDs, or "Artist A ft. Artist B"
+		# with 1 name after splitTag and 2 MBIDs), poisoning the contributor
+		# row. Drop the ambiguous MBIDs rather than mis-bind them.
+		if (@brainzIDList && scalar(@brainzIDList) != scalar(@artistList)) {
+			main::INFOLOG && $log->is_info && $log->info(
+				"Ignoring MBID list for '$artist': name count ("
+				. scalar(@artistList) . ") differs from MBID count ("
+				. scalar(@brainzIDList) . ")"
+			);
+			@brainzIDList = ();
+		}
 	}
 
 	# Using native DBI here to improve performance during scanning
@@ -355,8 +370,6 @@ sub isInLibrary {
 # from this contributor still exists in the database.  If not, delete the contributor.
 sub rescan {
 	my ( $class, $ids, $albumId ) = @_;
-
-	my $log = logger('scan.scanner');
 
 	my $dbh = Slim::Schema->dbh;
 


### PR DESCRIPTION
## Summary

Structural fix for #1555. Reads the Picard-convention plural tags `ALBUMARTISTS` and `ARTISTS` as arrayrefs and uses them as the authoritative individual-contributor list, so the name <-> MBID pairing stops depending on `splitList` heuristics over joined display strings. The singular `ALBUMARTIST` / `ARTIST` tag remains the album / track display string.

Stacks on the stop-gap PR #1556 (the length-mismatch guard in `Contributor::add`). The guard remains in place as the safety net for the legacy single-string fall-back path and for files where the plural tag is absent or scalar.

Contributes to #1555 (does not close it; closing waits until both PRs land). Also addresses the long-standing symptom reported in the closed #1052.

References:
- Picard tag mapping: https://picard-docs.musicbrainz.org/en/latest/appendices/tag_mapping.html
- Picard basic variables: https://picard-docs.musicbrainz.org/en/latest/variables/tags_basic.html

This is a behavioural change to the scanner. **Design feedback welcome before merge.** Specifically: the plural-detection logic lives inside the contributor loop and keys off `$tag . 'S'` (only firing for ARTIST / ALBUMARTIST / TRACKARTIST). An alternative is a pre-loop expansion pass that unwraps the plural arrayref onto the singular slot. I picked the in-loop form because it keeps the TRACKARTIST compilation transform the only place that mutates `$attributes` pre-loop. Happy to refactor either way.

## Scope of benefit (read this first)

Confirmed against the Picard docs:

- **`ARTISTS` (plural track artists) is written by default by Picard** (since Picard 2.x, as a standard tag across Vorbis / ID3v2 TXXX / MP4 freeform / ASF). So the track-level ARTIST role gets the full plural-path benefit for any Picard-tagged library without user configuration. This is the primary user-visible win, and it covers the "Artist A ft. Artist B" track-credit case that prompted the follow-up report on #1555.
- **`ALBUMARTISTS` is NOT a standard Picard tag.** It is not in Picard's tag mapping. Users who want it must add a small Picard script (`$setmulti(albumartists,%_albumartists%)`) or use another tagger / workflow that writes it (Jellyfin- and Navidrome-friendly Mp3tag templates, beets with the mb plugin, etc.). For vanilla-Picard libraries the ALBUMARTIST role falls back to the legacy singular path, which is still protected from MBID poisoning by #1556's length-mismatch guard but does not get the per-individual split.

We cannot recover the per-individual ALBUMARTIST split from LMS's side when the plural tag is absent: Picard's join phrases are configurable, and guessing from the singular joined string is exactly what `splitList` already does best-effort. This PR is forward-compatible: as soon as a user's library carries the tag, the fix kicks in.

## Design notes

1. **Precedence.** Plural-path triggers only when `$attributes->{$tag.'S'}` is a non-empty arrayref with at least one non-blank entry. A scalar plural value falls through to the legacy singular path. Single-element plural arrayref counts (Picard signal "this is one authoritative individual").
2. **Display string.** The singular `ALBUMARTIST` / `ARTIST` tag remains the album / track display string. Skin-visible names are unchanged.
3. **Primary contributor.** First entry of the plural arrayref.
4. **Sort tag.** Picard does not define a new plural sort tag name, but the Picard internal variables `%_albumartists_sort%` and `%_artists_sort%` do carry per-individual sort data from MusicBrainz, and users can script those onto the existing `ALBUMARTISTSORT` / `ARTISTSORT` tags as multi-value content (e.g. `$setmulti(albumartistsort,%_albumartists_sort%)`). When the plural path is used, this PR checks whether the sort tag is an arrayref whose length matches the filtered plural names and, if so, uses it positionally for per-individual sort (e.g. `van Buuren, Armin` for Armin). Otherwise it passes `sortBy => undef`, which falls back to sort-by-name. Passing the joined singular sort string would pollute only the first contributor's sort with the whole joined value and leave the rest falling back to name; the symmetric name-fallback is strictly better.
5. **Empty MBID slots.** The Picard "this individual has no MBID" convention (empty string at the aligned index) is preserved positionally by this PR. `Contributor::add`'s existing `if ($mbid)` guard handles empty slots. Note: LMS's existing `Slim::Formats::sanitizeTagValues` rejects any `MUSICBRAINZ_*ID` tag containing a non-UUID element, including empty strings, and strips the whole tag. That stripping is pre-existing and orthogonal to this PR; a separate sanitizer relaxation would be needed to make empty slots end-to-end functional.
6. **Empty / whitespace-only name slots in the plural arrayref.** Trimmed and dropped along with their aligned MBID slot before passing to `Contributor::add`.
7. **Roles.** ARTIST, ALBUMARTIST, and TRACKARTIST only. COMPOSER / CONDUCTOR / BAND etc. are unchanged per scope.
8. **TRACKARTIST compilation transform** (Bug 2317 / 2638) is extended to also migrate `ARTISTS` to `TRACKARTISTS`, symmetric with the existing singular and MBID migrations.
9. **Fall-back is unchanged.** Files without plural tags, or with plural tags as scalars, follow the existing path including `splitList` splitting, byte-for-byte. #1556's length-mismatch guard is the safety net there.

## Patch surface

- `Slim/Schema.pm`: three hunks (`_preCheckAttributes` deferred-list addition; `_mergeAndCreateContributors` plural-aware loop with sort-tag alignment; TRACKARTIST transform extension).
- `Changelog9.html`: one bullet under the in-progress release.

No DB schema change. No format-parser change. No change to `Slim/Schema/Contributor.pm` (the stop-gap from #1556 stays intact).

## Backwards compatibility

- No schema change, no automatic migration.
- Files without plural tags, or with plural tags as scalars, see zero behavioural difference.
- Users must `wipecache` to benefit on already-scanned libraries.
- Users who tuned `splitList` to work around the absence of plural-tag reading may find it is no longer needed. It is not removed; they can keep or clear it.
- The "primary contributor" semantic is defined as "first entry of the plural list". In rare edge cases where existing databases relied on an arbitrary order, the ordering may shift on rescan.

## Verification

Manual end-to-end verification against a hand-built fixture set (silent Opus / FLAC / MP3 / MP4 files tagged with mutagen). Pre-fix vs post-fix scan dumped from the SQLite library DB. Diff captured.

### Fixture matrix (Opus, 11 scenarios)

| # | Scenario | Pre-fix | Post-fix |
|---|----------|---------|----------|
| 1 | Plural + aligned MBIDs (the #1555 reproduction) | "Armin van Buuren & KI/KI" + first MBID (poisoned) | Two rows, each individual with their own MBID |
| 2 | Plural without explicit MBIDs | "A & B" joined (one row) | A, B as separate rows |
| 3 | Plural with three aligned MBIDs | "A, B & C" joined, MBIDs dropped | A, B, C each with their own MBID |
| 4 | Singular only (regression guard) | A (one row) | A (unchanged) |
| 5 | Joined singular + splitList (regression guard) | A, B via splitTag | A, B unchanged |
| 6 | Plural + COMPILATION=1 | "A & B" joined ARTIST + first MBID | A, B as separate ARTIST rows; ALBUMARTIST=Various Artists preserved |
| 7 | `ft.` track-artist (the follow-up case) | ALBUMARTIST and TRACKARTIST both joined; one MBID stuck on ALBUMARTIST | ALBUMARTIST individuals + 2 TRACKARTIST rows, all with correct MBIDs |
| 8 | Plural with empty name slot | "A, , B" joined | A, B (empty slot dropped + aligned MBID dropped) |
| 9 | Plural present, ALBUMARTIST singular missing | "No Artist" (plural ignored) | A, B as separate rows |
| 10 | Scalar plural value (buggy tagger) | A & B joined | A & B singular fall-through (unchanged) |
| 11 | Plural length != MBID length (existing #1556 guard) | "A & B" + first MBID | A, B separate rows; #1556 guard drops the unaligned MBID |

### Multi-track album

3-track album, all tracks share `ALBUMARTISTS=[Armin, KI/KI]` plural; track 1 has single ARTIST=Armin, track 2 single ARTIST=KI/KI, track 3 plural ARTISTS=[Armin, KI/KI]. Album-level resolves to two ALBUMARTIST rows aggregated across tracks; per-track ARTIST / TRACKARTIST rows correctly reflect each track's own credits. No joined rows at any level.

### Various Artists compilation

3-track VA compilation with canonical MB Various Artists MBID (`89ad4ac3-39f7-470e-963a-56509c546377`), `COMPILATION=1`. Each track has its own ARTIST + plural ARTISTS + MBIDs; track 2 is a two-artist collab. Album row resolves to "Various Artists" primary; `contributor_album` aggregates all individual track artists as ARTIST rows; per-track ARTIST rows correctly reflect each track's credits.

### Sort-tag alignment

Verified in two modes by inspecting `contributors.namesort` after rescan:

- No plural sort tag present: each plural-path contributor gets its own name-based sort (`ARMIN VAN BUUREN`, `KI KI`). The joined `ALBUMARTISTSORT` string does not leak into the first contributor.
- Aligned plural sort tag present (user scripted `%_albumartists_sort%` onto `ALBUMARTISTSORT` as multi-value, per the Picard convention described above): each contributor gets its own per-individual sort from the aligned slot (`VAN BUUREN ARMIN` for Armin, not name-fallback `ARMIN VAN BUUREN`).

### Cross-format

Same happy-path tags written to FLAC, MP4 (M4A), and MP3:

| Format | Result |
|--------|--------|
| FLAC (Vorbis Comments) | Works. Two individual ALBUMARTIST rows with MBIDs. |
| MP4 / M4A (iTunes `----:com.apple.iTunes:ARTISTS` freeform) | Works. Two individual ALBUMARTIST rows with MBIDs. |
| MP3 (ID3v2.4 TXXX) | **Partial.** Poisoning gone, but only the first individual recovered. See "Known limitations" below. |
| ASF / WMA (`WM/ARTISTS`) | Not tested here. Likely depends on `Audio::Scan`'s WMA reader, may or may not surface multi-value. Flagging for a reviewer with a WMA test library. |
| APEv2 | Not tested here. Rare in practice. |

### CI / smoketest

`bash t/00_smoketest.sh` passes (server starts, jsonrpc responds with version 9.2.0).

## Known limitations

### MP3

Picard writes plural tags into MP3 files as ID3v2.4 multi-value text frames (one TXXX frame per descriptor, multiple values null-separated within the frame's text field, per the spec). The vendored `Audio::Scan` module (`CPAN/arch/<perl>/Audio/Scan.{pm,so}`, sourced from `slimserver-vendor`) returns only the first value of multi-value TXXX frames, truncating at the first null. By the time `MP3.pm` sees the tag, the second and subsequent values are already lost.

Effect with this PR:
- Before: `Armin van Buuren & KI/KI` joined contributor row with first MBID bound (poisoned).
- After: `Armin van Buuren` row alone with first MBID; KI/KI is missing entirely from the MP3 album.

This is an improvement (no more poisoning) but is not the full multi-contributor benefit. Two paths to a complete MP3 fix:

1. Patch `Audio::Scan` upstream (XS / C source in `slimserver-vendor`) to fully support ID3v2.4 multi-value text frames. Cleanest, most correct, but requires upstream coordination and rebuilds across all platforms.
2. Add a small Perl-level ID3v2.4 TXXX re-parser inside `Slim/Formats/MP3.pm` for `ALBUMARTISTS` / `ARTISTS` / `MUSICBRAINZ_ALBUMARTISTID` / `MUSICBRAINZ_ARTISTID` only. ~50-100 lines using `pack` / `unpack` on the raw frame bytes; opens the file a second time per scan. Separate small follow-up PR.

Recommend shipping this PR as-is and addressing MP3 in a follow-up. Happy to do either.

### Default-Picard ALBUMARTIST libraries

As noted in "Scope of benefit", vanilla Picard does not write `ALBUMARTISTS`, so default-Picard libraries see the ARTIST-role win but retain the legacy ALBUMARTIST singular-path behaviour (now safe under #1556's guard). Users who want the full album-level split should add the Picard script referenced above, or switch to a workflow that writes `ALBUMARTISTS`.

FLAC, Ogg, Opus, and MP4 / M4A are unaffected by the `Audio::Scan` limitation and gain the full benefit whenever the plural tag is present.

## Test plan

- [x] Smoketest (`bash t/00_smoketest.sh`).
- [x] Opus fixture matrix (11 scenarios) before / after diff.
- [x] Multi-track album fixture before / after.
- [x] Various Artists compilation fixture before / after.
- [x] Cross-format fixtures (FLAC, MP3, MP4).
- [x] Sort-tag alignment verification (`namesort` inspection).
- [ ] CI on push.
- [ ] Maintainer review of the design (in-loop plural detection vs pre-loop expansion).
- [ ] Optional: WMA test fixture.