### PR TITLE
Update AnyEvent::DNS to 7.17

### DIFF
--- a/CPAN/AnyEvent/DNS.pm
+++ b/CPAN/AnyEvent/DNS.pm
@@ -35,14 +35,51 @@ use AnyEvent (); BEGIN { AnyEvent::common_sense }
 use AnyEvent::Util qw(AF_INET6);
 
 our $VERSION = $AnyEvent::VERSION;
+our @DNS_FALLBACK; # some public dns servers as fallback
 
-# some public dns servers
-our @DNS_FALLBACK = (
-   (v8.8.8.8, v8.8.4.4)[rand 2], # google public dns
-   (v209.244.0.3, v209.244.0.4)[rand 2], # level3
-   (v4.2.2.1, v4.2.2.3, v4.2.2.4, v4.2.2.5, v4.2.2.6)[rand 4], # vnsc-pri.sys.gtei.net
-);
-push @DNS_FALLBACK, splice @DNS_FALLBACK, rand $_, 1 for reverse 1..@DNS_FALLBACK;
+{
+   my $prep = sub {
+      $_ = $_->[rand @$_] for @_;
+      push @_, splice @_, rand $_, 1 for reverse 1..@_; # shuffle
+      $_ = pack "H*", $_ for @_;
+      \@_
+   };
+
+   my $ipv4 = $prep->(
+      ["08080808", "08080404"], # 8.8.8.8, 8.8.4.4 - google public dns
+      ["01010101", "01000001"], # 1.1.1.1, 1.0.0.1 - cloudflare public dns
+      ["50505050", "50505151"], # 80.80.80.80, 80.80.81.81 - freenom.world
+##      ["d1f40003", "d1f30004"], # v209.244.0.3/4 - resolver1/2.level3.net - status unknown
+##      ["04020201", "04020203", "04020204", "04020205", "04020206"], # v4.2.2.1/3/4/5/6 - vnsc-pri.sys.gtei.net - effectively public
+##      ["cdd22ad2", "4044c8c8"], # 205.210.42.205, 64.68.200.200 - cache1/2.dnsresolvers.com - verified public
+#      ["8d010101"], # 141.1.1.1 - cable&wireless, now vodafone - status unknown
+# 84.200.69.80      # dns.watch
+# 84.200.70.40      # dns.watch
+# 37.235.1.174      # freedns.zone
+# 37.235.1.177      # freedns.zone
+# 213.73.91.35      # dnscache.berlin.ccc.de
+# 194.150.168.168   # dns.as250.net; Berlin/Frankfurt
+# 85.214.20.141     # FoeBud (digitalcourage.de)
+# 77.109.148.136    # privacyfoundation.ch
+# 77.109.148.137    # privacyfoundation.ch
+# 91.239.100.100    # anycast.censurfridns.dk
+# 89.233.43.71      # ns1.censurfridns.dk
+# 204.152.184.76    # f.6to4-servers.net, ISC, USA
+   );
+
+   my $ipv6 = $prep->(
+      ["20014860486000000000000000008888", "20014860486000000000000000008844"], # 2001:4860:4860::8888/8844 - google ipv6
+      ["26064700470000000000000000001111", "26064700470000000000000000001001"], # 2606:4700:4700::1111/1001 - cloudflare dns
+   );
+
+   undef $ipv4 unless $AnyEvent::PROTOCOL{ipv4};
+   undef $ipv6 unless $AnyEvent::PROTOCOL{ipv6};
+
+   ($ipv6, $ipv4) = ($ipv4, $ipv6)
+      if $AnyEvent::PROTOCOL{ipv6} > $AnyEvent::PROTOCOL{ipv4};
+
+   @DNS_FALLBACK = (@$ipv4, @$ipv6);
+}
 
 =item AnyEvent::DNS::a $domain, $cb->(@addrs)
 
@@ -63,14 +100,23 @@ Tries to resolve the given domain name into a list of name servers.
 
 =item AnyEvent::DNS::txt $domain, $cb->(@hostnames)
 
-Tries to resolve the given domain name into a list of text records.
+Tries to resolve the given domain name into a list of text records. Only
+the first text string per record will be returned. If you want all
+strings, you need to call the resolver manually:
+
+   resolver->resolve ($domain => "txt", sub {
+      for my $record (@_) {
+         my (undef, undef, undef, @txt) = @$record;
+         # strings now in @txt
+      }
+   });
 
 =item AnyEvent::DNS::srv $service, $proto, $domain, $cb->(@srv_rr)
 
 Tries to resolve the given service, protocol and domain name into a list
 of service records.
 
-Each C<$srv_rr> is an array reference with the following contents: 
+Each C<$srv_rr> is an array reference with the following contents:
 C<[$priority, $weight, $transport, $target]>.
 
 They will be sorted with lowest priority first, then randomly
@@ -81,21 +127,22 @@ Example:
    AnyEvent::DNS::srv "sip", "udp", "schmorp.de", sub { ...
    # @_ = ( [10, 10, 5060, "sip1.schmorp.de" ] )
 
+=item AnyEvent::DNS::any $domain, $cb->(@rrs)
+
+Tries to resolve the given domain and passes all resource records found
+to the callback. Note that this uses a DNS C<ANY> query, which, as of RFC
+8482, are officially deprecated.
+
 =item AnyEvent::DNS::ptr $domain, $cb->(@hostnames)
 
 Tries to make a PTR lookup on the given domain. See C<reverse_lookup>
 and C<reverse_verify> if you want to resolve an IP address to a hostname
 instead.
 
-=item AnyEvent::DNS::any $domain, $cb->(@rrs)
-
-Tries to resolve the given domain and passes all resource records found to
-the callback.
-
 =item AnyEvent::DNS::reverse_lookup $ipv4_or_6, $cb->(@hostnames)
 
 Tries to reverse-resolve the given IPv4 or IPv6 address (in textual form)
-into it's hostname(s). Handles V4MAPPED and V4COMPAT IPv6 addresses
+into its hostname(s). Handles V4MAPPED and V4COMPAT IPv6 addresses
 transparently.
 
 =item AnyEvent::DNS::reverse_verify $ipv4_or_6, $cb->(@hostnames)
@@ -111,7 +158,7 @@ address you originally resolved.
 
 Example:
 
-   AnyEvent::DNS::ptr "2001:500:2f::f", sub { print shift };
+   AnyEvent::DNS::reverse_verify "2001:500:2f::f", sub { print shift };
    # => f.root-servers.net
 
 =cut
@@ -126,7 +173,7 @@ sub a($$) {
    my ($domain, $cb) = @_;
 
    resolver->resolve ($domain => "a", sub {
-      $cb->(map $_->[3], @_);
+      $cb->(map $_->[4], @_);
    });
 }
 
@@ -134,7 +181,7 @@ sub aaaa($$) {
    my ($domain, $cb) = @_;
 
    resolver->resolve ($domain => "aaaa", sub {
-      $cb->(map $_->[3], @_);
+      $cb->(map $_->[4], @_);
    });
 }
 
@@ -142,7 +189,7 @@ sub mx($$) {
    my ($domain, $cb) = @_;
 
    resolver->resolve ($domain => "mx", sub {
-      $cb->(map $_->[4], sort { $a->[3] <=> $b->[3] } @_);
+      $cb->(map $_->[5], sort { $a->[4] <=> $b->[4] } @_);
    });
 }
 
@@ -150,7 +197,7 @@ sub ns($$) {
    my ($domain, $cb) = @_;
 
    resolver->resolve ($domain => "ns", sub {
-      $cb->(map $_->[3], @_);
+      $cb->(map $_->[4], @_);
    });
 }
 
@@ -158,7 +205,7 @@ sub txt($$) {
    my ($domain, $cb) = @_;
 
    resolver->resolve ($domain => "txt", sub {
-      $cb->(map $_->[3], @_);
+      $cb->(map $_->[4], @_);
    });
 }
 
@@ -171,7 +218,7 @@ sub srv($$$$) {
 
       # classify by priority
       my %pri;
-      push @{ $pri{$_->[3]} }, [ @$_[3,4,5,6] ]
+      push @{ $pri{$_->[4]} }, [ @$_[4,5,6,7] ]
          for @_;
 
       # order by priority
@@ -201,7 +248,7 @@ sub ptr($$) {
    my ($domain, $cb) = @_;
 
    resolver->resolve ($domain => "ptr", sub {
-      $cb->(map $_->[3], @_);
+      $cb->(map $_->[4], @_);
    });
 }
 
@@ -245,7 +292,7 @@ sub reverse_lookup($$) {
       or return $cb->();
 
    resolver->resolve ($ip => "ptr", sub {
-      $cb->(map $_->[3], @_);
+      $cb->(map $_->[4], @_);
    });
 }
 
@@ -273,7 +320,7 @@ sub reverse_verify($$) {
          resolver->resolve ("$name." => ($af == (AF_INET) ? "a" : "aaaa"), sub {
             for (@_) {
                push @res, $name
-                  if $_->[3] eq $ip;
+                  if $_->[4] eq $ip;
             }
             $cb->(@res) unless --$cnt;
          });
@@ -354,11 +401,25 @@ our %type_id = (
    minfo =>  14,
    mx    =>  15,
    txt   =>  16,
+   sig   =>  24,
+   key   =>  25,
+   gpos  =>  27, # rfc1712
    aaaa  =>  28,
+   loc   =>  29, # rfc1876
    srv   =>  33,
    naptr =>  35, # rfc2915
    dname =>  39, # rfc2672
    opt   =>  41,
+   ds    =>  43, # rfc4034
+   sshfp =>  44, # rfc4255
+   rrsig =>  46, # rfc4034
+   nsec  =>  47, # rfc4034
+   dnskey=>  48, # rfc4034
+   smimea=>  53, # rfc8162
+   cds   =>  59, # rfc7344
+   cdnskey=> 60, # rfc7344
+   openpgpkey=> 61, # rfc7926
+   csync =>  62, # rfc7929
    spf   =>  99,
    tkey  => 249,
    tsig  => 250,
@@ -366,6 +427,8 @@ our %type_id = (
    axfr  => 252,
    mailb => 253,
    "*"   => 255,
+   uri   => 256,
+   caa   => 257, # rfc6844
 );
 
 our %type_str = reverse %type_id;
@@ -394,7 +457,7 @@ if ($] < 5.008) {
 sub _enc_qd() {
    (_enc_name $_->[0]) . pack "nn",
      ($_->[1] > 0 ? $_->[1] : $type_id {$_->[1]}),
-     ($_->[2] > 0 ? $_->[2] : $class_id{$_->[2] || "in"})
+     ($_->[3] > 0 ? $_->[2] : $class_id{$_->[2] || "in"})
 }
 
 sub _enc_rr() {
@@ -526,6 +589,7 @@ our %dec_rr = (
     },
     39 => sub { local $ofs = $ofs - length; _dec_name }, # dname
     99 => sub { unpack "(C/a*)*", $_ }, # spf
+   257 => sub { unpack "CC/a*a*", $_ }, # caa
 );
 
 sub _dec_rr {
@@ -538,8 +602,8 @@ sub _dec_rr {
       $name,
       $type_str{$rt}  || $rt,
       $class_str{$rc} || $rc,
+      $ttl,
       ($dec_rr{$rt} || sub { $_ })->(),
-      $ttl, # we need TTL values -andy
    ]
 }
 
@@ -561,6 +625,7 @@ Examples:
                  'uni-karlsruhe.de',
                  'soa',
                  'in',
+                 600,
                  'netserv.rz.uni-karlsruhe.de',
                  'hostmaster.rz.uni-karlsruhe.de',
                  2008052201, 10800, 1800, 2592000, 86400
@@ -573,7 +638,8 @@ Examples:
      'aa' => '',
      'an' => [],
      'rd' => 1,
-     'op' => 'query'
+     'op' => 'query',
+     '__' => '<original dns packet>',
    }
    
    # a successful reply
@@ -582,13 +648,13 @@ Examples:
      'qd' => [ [ 'www.google.de', 'a', 'in' ] ],
      'rc' => 0,
      'ar' => [
-               [ 'a.l.google.com', 'a', 'in', '209.85.139.9' ],
-               [ 'b.l.google.com', 'a', 'in', '64.233.179.9' ],
-               [ 'c.l.google.com', 'a', 'in', '64.233.161.9' ],
+               [ 'a.l.google.com', 'a', 'in', 3600, '209.85.139.9' ],
+               [ 'b.l.google.com', 'a', 'in', 3600, '64.233.179.9' ],
+               [ 'c.l.google.com', 'a', 'in', 3600, '64.233.161.9' ],
              ],
      'ns' => [
-               [ 'l.google.com', 'ns', 'in', 'a.l.google.com' ],
-               [ 'l.google.com', 'ns', 'in', 'b.l.google.com' ],
+               [ 'l.google.com', 'ns', 'in', 3600, 'a.l.google.com' ],
+               [ 'l.google.com', 'ns', 'in', 3600, 'b.l.google.com' ],
              ],
      'tc' => '',
      'ra' => 1,
@@ -596,13 +662,14 @@ Examples:
      'id' => 64265,
      'aa' => '',
      'an' => [
-               [ 'www.google.de', 'cname', 'in', 'www.google.com' ],
-               [ 'www.google.com', 'cname', 'in', 'www.l.google.com' ],
-               [ 'www.l.google.com', 'a', 'in', '66.249.93.104' ],
-               [ 'www.l.google.com', 'a', 'in', '66.249.93.147' ],
+               [ 'www.google.de', 'cname', 'in', 3600, 'www.google.com' ],
+               [ 'www.google.com', 'cname', 'in', 3600, 'www.l.google.com' ],
+               [ 'www.l.google.com', 'a', 'in', 3600, '66.249.93.104' ],
+               [ 'www.l.google.com', 'a', 'in', 3600, '66.249.93.147' ],
              ],
      'rd' => 1,
-     'op' => 0
+     'op' => 0,
+     '__' => '<original dns packet>',
    }
 
 =cut
@@ -615,6 +682,7 @@ sub dns_unpack($) {
    local $ofs = 6 * 2;
 
    {
+      __ => $pkt,
       id => $id,
       qr => ! ! ($flags & 0x8000),
       aa => ! ! ($flags & 0x0400),
@@ -637,6 +705,70 @@ sub dns_unpack($) {
 
 =back
 
+=head3 Extending DNS Encoder and Decoder
+
+This section describes an I<experimental> method to extend the DNS encoder
+and decoder with new opcode, rcode, class and type strings, as well as
+resource record decoders.
+
+Since this is experimental, it can change, as anything can change, but
+this interface is expe ctedc to be relatively stable and was stable during
+the whole existance of C<AnyEvent::DNS> so far.
+
+Note that, since changing the decoder or encoder might break existing
+code, you should either be sure to control for this, or only temporarily
+change these values, e.g. like so:
+
+   my $decoded = do {
+      local $AnyEvent::DNS::opcode_str{7} = "yxrrset";
+      AnyEvent::DNS::dns_unpack $mypkt
+   };
+
+=over 4
+
+=item %AnyEvent::DNS::opcode_id, %AnyEvent::DNS::opcode_str
+
+Two hashes that map lowercase opcode strings to numerical id's (For the
+encoder), or vice versa (for the decoder). Example: add a new opcode
+string C<notzone>.
+
+   $AnyEvent::DNS::opcode_id{notzone} = 10;
+   $AnyEvent::DNS::opcode_str{10} = 'notzone';
+
+=item %AnyEvent::DNS::rcode_id, %AnyEvent::DNS::rcode_str
+
+Same as above, for for rcode values.
+
+=item %AnyEvent::DNS::class_id, %AnyEvent::DNS::class_str
+
+Same as above, but for resource record class names/values.
+
+=item %AnyEvent::DNS::type_id, %AnyEvent::DNS::type_str
+
+Same as above, but for resource record type names/values.
+
+=item %AnyEvent::DNS::dec_rr
+
+This hash maps resource record type values to code references. When
+decoding, they are called with C<$_> set to the undecoded data portion and
+C<$ofs> being the current byte offset. of the record. You should have a
+look at the existing implementations to understand how it works in detail,
+but here are two examples:
+
+Decode an A record. A records are simply four bytes with one byte per
+address component, so the decoder simply unpacks them and joins them with
+dots in between:
+
+   $AnyEvent::DNS::dec_rr{1} = sub { join ".", unpack "C4", $_ };
+
+Decode a CNAME record, which contains a potentially compressed domain
+name.
+
+   package AnyEvent::DNS; # for %dec_rr, $ofsd and &_dec_name
+   $dec_rr{5} = sub { local $ofs = $ofs - length; _dec_name };
+
+=back
+
 =head2 THE AnyEvent::DNS RESOLVER CLASS
 
 This is the class which does the actual protocol work.
@@ -654,10 +786,11 @@ our $NOW;
 =item AnyEvent::DNS::resolver
 
 This function creates and returns a resolver that is ready to use and
-should mimic the default resolver for your system as good as possible.
+should mimic the default resolver for your system as good as possible. It
+is used by AnyEvent itself as well.
 
-It only ever creates one resolver and returns this one on subsequent
-calls.
+It only ever creates one resolver and returns this one on subsequent calls
+- see C<$AnyEvent::DNS::RESOLVER>, below, for details.
 
 Unless you have special needs, prefer this function over creating your own
 resolver object.
@@ -665,11 +798,21 @@ resolver object.
 The resolver is created with the following parameters:
 
    untaint          enabled
-   max_outstanding  $ENV{PERL_ANYEVENT_MAX_OUTSTANDING_DNS}
+   max_outstanding  $ENV{PERL_ANYEVENT_MAX_OUTSTANDING_DNS} (default 10)
 
 C<os_config> will be used for OS-specific configuration, unless
 C<$ENV{PERL_ANYEVENT_RESOLV_CONF}> is specified, in which case that file
 gets parsed.
+
+=item $AnyEvent::DNS::RESOLVER
+
+This variable stores the default resolver returned by
+C<AnyEvent::DNS::resolver>, or C<undef> when the default resolver hasn't
+been instantiated yet.
+
+One can provide a custom resolver (e.g. one with caching functionality)
+by storing it in this variable, causing all subsequent resolves done via
+C<AnyEvent::DNS::resolver> to be done via the custom one.
 
 =cut
 
@@ -679,12 +822,11 @@ sub resolver() {
    $RESOLVER || do {
       $RESOLVER = new AnyEvent::DNS
          untaint         => 1,
-         exists $ENV{PERL_ANYEVENT_MAX_OUTSTANDING_DNS}
-            ? (max_outstanding => $ENV{PERL_ANYEVENT_MAX_OUTSTANDING_DNS}*1 || 1) : (),
+         max_outstanding => $ENV{PERL_ANYEVENT_MAX_OUTSTANDING_DNS}*1 || 10,
       ;
 
-      exists $ENV{PERL_ANYEVENT_RESOLV_CONF}
-         ? length $ENV{PERL_ANYEVENT_RESOLV_CONF} && $RESOLVER->_parse_resolv_conf_file ($ENV{PERL_ANYEVENT_RESOLV_CONF})
+      $ENV{PERL_ANYEVENT_RESOLV_CONF}
+         ? $RESOLVER->_load_resolv_conf_file ($ENV{PERL_ANYEVENT_RESOLV_CONF})
          : $RESOLVER->os_config;
 
       $RESOLVER
@@ -701,9 +843,9 @@ The following options are supported:
 
 =item server => [...]
 
-A list of server addresses (default: C<v127.0.0.1>) in network format
-(i.e. as returned by C<AnyEvent::Socket::parse_address> - both IPv4 and
-IPv6 are supported).
+A list of server addresses (default: C<v127.0.0.1> or C<::1>) in network
+format (i.e. as returned by C<AnyEvent::Socket::parse_address> - both IPv4
+and IPv6 are supported).
 
 =item timeout => [...]
 
@@ -754,6 +896,7 @@ sub new {
       max_outstanding => 10,
       reuse   => 300,
       %arg,
+      inhibit => 0,
       reuse_q => [],
    }, $class;
 
@@ -769,7 +912,7 @@ sub new {
    if (socket my $fh4, AF_INET , Socket::SOCK_DGRAM(), 0) {
       ++$got_socket;
 
-      AnyEvent::Util::fh_nonblocking $fh4, 1;
+      AnyEvent::fh_unblock $fh4;
       $self->{fh4} = $fh4;
       $self->{rw4} = AE::io $fh4, 0, sub {
          if (my $peer = recv $fh4, my $pkt, MAX_PKT, 0) {
@@ -782,7 +925,7 @@ sub new {
       ++$got_socket;
 
       $self->{fh6} = $fh6;
-      AnyEvent::Util::fh_nonblocking $fh6, 1;
+      AnyEvent::fh_unblock $fh6;
       $self->{rw6} = AE::io $fh6, 0, sub {
          if (my $peer = recv $fh6, my $pkt, MAX_PKT, 0) {
             $wself->_recv ($pkt, $peer);
@@ -798,12 +941,24 @@ sub new {
    $self
 }
 
+# called to start asynchronous configuration
+sub _config_begin {
+   ++$_[0]{inhibit};
+}
+
+# called when done with async config
+sub _config_done {
+   --$_[0]{inhibit};
+   $_[0]->_compile;
+   $_[0]->_scheduler;
+}
+
 =item $resolver->parse_resolv_conf ($string)
 
 Parses the given string as if it were a F<resolv.conf> file. The following
 directives are supported (but not necessarily implemented).
 
-C<#>-style comments, C<nameserver>, C<domain>, C<search>, C<sortlist>,
+C<#>- and C<;>-style comments, C<nameserver>, C<domain>, C<search>, C<sortlist>,
 C<options> (C<timeout>, C<attempts>, C<ndots>).
 
 Everything else is silently ignored.
@@ -819,16 +974,16 @@ sub parse_resolv_conf {
    my $attempts;
 
    for (split /\n/, $resolvconf) {
-      s/#.*$//; # not quite legal, but many people insist
+      s/\s*[;#].*$//; # not quite legal, but many people insist
 
       if (/^\s*nameserver\s+(\S+)\s*$/i) {
          my $ip = $1;
          if (my $ipn = AnyEvent::Socket::parse_address ($ip)) {
             push @{ $self->{server} }, $ipn;
          } else {
-            warn "nameserver $ip invalid and ignored\n";
+            AE::log 5 => "nameserver $ip invalid and ignored, while parsing resolver config.";
          }
-      } elsif (/^\s*domain\s+(\S*)\s+$/i) {
+      } elsif (/^\s*domain\s+(\S*)\s*$/i) {
          $self->{search} = [$1];
       } elsif (/^\s*search\s+(.*?)\s*$/i) {
          $self->{search} = [split /\s+/, $1];
@@ -846,6 +1001,8 @@ sub parse_resolv_conf {
                # debug, rotate, no-check-names, inet6
             }
          }
+      } else {
+         # silently skip stuff we don't understand
       }
    }
 
@@ -855,14 +1012,21 @@ sub parse_resolv_conf {
    $self->_compile;
 }
 
-sub _parse_resolv_conf_file {
+sub _load_resolv_conf_file {
    my ($self, $resolv_conf) = @_;
 
-   open my $fh, "<", $resolv_conf
-      or Carp::croak "$resolv_conf: $!";
+   $self->_config_begin;
 
-   local $/;
-   $self->parse_resolv_conf (<$fh>);
+   require AnyEvent::IO;
+   AnyEvent::IO::aio_load ($resolv_conf, sub {
+      if (my ($contents) = @_) {
+         $self->parse_resolv_conf ($contents);
+      } else {
+         AE::log 4 => "$resolv_conf: $!";
+      }
+
+      $self->_config_done;
+   });
 }
 
 =item $resolver->os_config
@@ -871,15 +1035,22 @@ Tries so load and parse F</etc/resolv.conf> on portable operating
 systems. Tries various egregious hacks on windows to force the DNS servers
 and searchlist out of the system.
 
+This method must be called at most once before trying to resolve anything.
+
 =cut
 
 sub os_config {
    my ($self) = @_;
 
+   $self->_config_begin;
+
    $self->{server} = [];
    $self->{search} = [];
 
    if ((AnyEvent::WIN32 || $^O =~ /cygwin/i)) {
+      # TODO: this blocks the program, but should not, but I
+      # am too lazy to implement and test it. need to boot windows. ugh.
+
       #no strict 'refs';
 
       # there are many options to find the current nameservers etc. on windows
@@ -910,7 +1081,7 @@ sub os_config {
          1
       }) {
          # we use ipconfig parsing because, despite all its brokenness,
-         # it seems most stable in practise.
+         # it seems quite stable in practise.
          # unfortunately it wants a console window.
          # for good measure, we append a fallback nameserver to our list.
 
@@ -941,22 +1112,27 @@ sub os_config {
          }
       }
 
-      # always add the fallback servers
+      # always add the fallback servers on windows
       push @{ $self->{server} }, @DNS_FALLBACK;
 
-      $self->_compile;
+      $self->_config_done;
    } else {
-      # try resolv.conf everywhere else
+      # try /etc/resolv.conf everywhere else
 
-      $self->_parse_resolv_conf_file ("/etc/resolv.conf")
-         if -e "/etc/resolv.conf";
+      require AnyEvent::IO;
+      AnyEvent::IO::aio_stat ("/etc/resolv.conf", sub {
+         $self->_load_resolv_conf_file ("/etc/resolv.conf")
+            if @_;
+         $self->_config_done;
+      });
    }
 }
 
 =item $resolver->timeout ($timeout, ...)
 
-Sets the timeout values. See the C<timeout> constructor argument (and note
-that this method uses the values itself, not an array-reference).
+Sets the timeout values. See the C<timeout> constructor argument (and
+note that this method expects the timeout values themselves, not an
+array-reference).
 
 =cut
 
@@ -978,7 +1154,7 @@ sub max_outstanding {
    my ($self, $max) = @_;
 
    $self->{max_outstanding} = $max;
-   $self->_scheduler;
+   $self->_compile;
 }
 
 sub _compile {
@@ -988,8 +1164,10 @@ sub _compile {
    my %server; $self->{server} = [grep 0 < length, grep !$server{$_}++, @{ $self->{server} }];
 
    unless (@{ $self->{server} }) {
-      # use 127.0.0.1 by default, and one opendns nameserver as fallback
-      $self->{server} = [v127.0.0.1, $DNS_FALLBACK[rand @DNS_FALLBACK]];
+      # use 127.0.0.1/::1 by default, add public nameservers as fallback
+      my $default = $AnyEvent::PROTOCOL{ipv6} > $AnyEvent::PROTOCOL{ipv4}
+                    ? "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\1" : "\x7f\x00\x00\x01";
+      $self->{server} = [$default, @DNS_FALLBACK];
    }
 
    my @retry;
@@ -1028,7 +1206,7 @@ sub _recv {
 
    my ($port, $host) = AnyEvent::Socket::unpack_sockaddr ($peer);
 
-   return unless $port == 53 && grep $_ eq $host, @{ $self->{server} };
+   return unless $port == DOMAIN_PORT && grep $_ eq $host, @{ $self->{server} };
 
    $self->_feed ($pkt);
 }
@@ -1126,6 +1304,8 @@ sub _exec {
 sub _scheduler {
    my ($self) = @_;
 
+   return if $self->{inhibit};
+
    #no strict 'refs';
 
    $NOW = time;
@@ -1159,7 +1339,7 @@ sub _scheduler {
          $self->_exec ($req);
 
       } elsif (my $cb = shift @{ $self->{wait} }) {
-         # found a wait_for_slot callback, call that one first
+         # found a wait_for_slot callback
          $cb->($self);
 
       } else {
@@ -1176,7 +1356,9 @@ This is the main low-level workhorse for sending DNS requests.
 This function sends a single request (a hash-ref formated as specified
 for C<dns_pack>) to the configured nameservers in turn until it gets a
 response. It handles timeouts, retries and automatically falls back to
-virtual circuit mode (TCP) when it receives a truncated reply.
+virtual circuit mode (TCP) when it receives a truncated reply. It does not
+handle anything else, such as the domain searchlist or relative names -
+use C<< ->resolve >> for that.
 
 Calls the callback with the decoded response packet if a reply was
 received, or no arguments in case none of the servers answered.
@@ -1185,6 +1367,13 @@ received, or no arguments in case none of the servers answered.
 
 sub request($$) {
    my ($self, $req, $cb) = @_;
+
+   # _enc_name barfs on names that are too long, which is often outside
+   # program control, so check for too long names here.
+   for (@{ $req->{qd} }) {
+      return AE::postpone sub { $cb->(undef) }
+         if 255 < length $_->[0];
+   }
 
    push @{ $self->{queue} }, [dns_pack $req, $cb];
    $self->_scheduler;
@@ -1205,16 +1394,17 @@ none on any error or if the name could not be found.
 
 CNAME chains (although illegal) are followed up to a length of 10.
 
-The callback will be invoked with arraryefs of the form C<[$name, $type,
-$class, @data>], where C<$name> is the domain name, C<$type> a type string
-or number, C<$class> a class name and @data is resource-record-dependent
-data. For C<a> records, this will be the textual IPv4 addresses, for C<ns>
-or C<cname> records this will be a domain name, for C<txt> records these
-are all the strings and so on.
+The callback will be invoked with arraryefs of the form C<[$name,
+$type, $class, $ttl, @data>], where C<$name> is the domain name,
+C<$type> a type string or number, C<$class> a class name, C<$ttl> is the
+remaining time-to-live and C<@data> is resource-record-dependent data, in
+seconds. For C<a> records, this will be the textual IPv4 addresses, for
+C<ns> or C<cname> records this will be a domain name, for C<txt> records
+these are all the strings and so on.
 
 All types mentioned in RFC 1035, C<aaaa>, C<srv>, C<naptr> and C<spf> are
-decoded. All resource records not known to this module will have
-the raw C<rdata> field as fourth entry.
+decoded. All resource records not known to this module will have the raw
+C<rdata> field as fifth array element.
 
 Note that this resolver is just a stub resolver: it requires a name server
 supporting recursive queries, will not do any recursive queries itself and
@@ -1257,15 +1447,15 @@ Examples:
 
    # shortened result:
    # [
-   #   [ 'google.com', 'soa', 'in', 'ns1.google.com', 'dns-admin.google.com',
+   #   [ 'google.com', 'soa', 'in', 3600, 'ns1.google.com', 'dns-admin.google.com',
    #     2008052701, 7200, 1800, 1209600, 300 ],
    #   [
-   #     'google.com', 'txt', 'in',
+   #     'google.com', 'txt', 'in', 3600,
    #     'v=spf1 include:_netblocks.google.com ~all'
    #   ],
-   #   [ 'google.com', 'a', 'in', '64.233.187.99' ],
-   #   [ 'google.com', 'mx', 'in', 10, 'smtp2.google.com' ],
-   #   [ 'google.com', 'ns', 'in', 'ns2.google.com' ],
+   #   [ 'google.com', 'a', 'in', 3600, '64.233.187.99' ],
+   #   [ 'google.com', 'mx', 'in', 3600, 10, 'smtp2.google.com' ],
+   #   [ 'google.com', 'ns', 'in', 3600, 'ns2.google.com' ],
    # ]
 
    # resolve a records:
@@ -1273,7 +1463,7 @@ Examples:
 
    # result:
    # [
-   #   [ 'ruth.schmorp.de', 'a', 'in', '129.13.162.95' ]
+   #   [ 'ruth.schmorp.de', 'a', 'in', 86400, '129.13.162.95' ]
    # ]
 
    # resolve any records, but return only a and aaaa records:
@@ -1286,8 +1476,8 @@ Examples:
 
    # result:
    # [
-   #   [ 'test1.laendle', 'a', 'in', '10.0.0.255' ],
-   #   [ 'test1.laendle', 'aaaa', 'in', '3ffe:1900:4545:0002:0240:0000:0000:f7e1' ]
+   #   [ 'test1.laendle', 'a', 'in', 86400, '10.0.0.255' ],
+   #   [ 'test1.laendle', 'aaaa', 'in', 60, '3ffe:1900:4545:0002:0240:0000:0000:f7e1' ]
    # ]
 
 =cut
@@ -1296,74 +1486,78 @@ sub resolve($%) {
    my $cb = pop;
    my ($self, $qname, $qtype, %opt) = @_;
 
-   my @search = $qname =~ s/\.$//
-      ? ""
-      : $opt{search}
-        ? @{ $opt{search} }
-        : ($qname =~ y/.//) >= $self->{ndots}
-          ? ("", @{ $self->{search} })
-          : (@{ $self->{search} }, "");
+   $self->wait_for_slot (sub {
+      my $self = shift;
 
-   my $class = $opt{class} || "in";
+      my @search = $qname =~ s/\.$//
+         ? ""
+         : $opt{search}
+           ? @{ $opt{search} }
+           : ($qname =~ y/.//) >= $self->{ndots}
+             ? ("", @{ $self->{search} })
+             : (@{ $self->{search} }, "");
 
-   my %atype = $opt{accept}
-      ? map +($_ => 1), @{ $opt{accept} }
-      : ($qtype => 1);
+      my $class = $opt{class} || "in";
 
-   # advance in searchlist
-   my ($do_search, $do_req);
-   
-   $do_search = sub {
-      @search
-         or (undef $do_search), (undef $do_req), return $cb->();
+      my %atype = $opt{accept}
+         ? map +($_ => 1), @{ $opt{accept} }
+         : ($qtype => 1);
 
-      (my $name = lc "$qname." . shift @search) =~ s/\.$//;
-      my $depth = 10;
+      # advance in searchlist
+      my ($do_search, $do_req);
+      
+      $do_search = sub {
+         @search
+            or (undef $do_search), (undef $do_req), return $cb->();
 
-      # advance in cname-chain
-      $do_req = sub {
-         $self->request ({
-            rd => 1,
-            qd => [[$name, $qtype, $class]],
-         }, sub {
-            my ($res) = @_
-               or return $do_search->();
+         (my $name = lc "$qname." . shift @search) =~ s/\.$//;
+         my $depth = 10;
 
-            my $cname;
+         # advance in cname-chain
+         $do_req = sub {
+            $self->request ({
+               rd => 1,
+               qd => [[$name, $qtype, $class]],
+            }, sub {
+               my ($res) = @_
+                  or return $do_search->();
 
-            while () {
-               # results found?
-               my @rr = grep $name eq lc $_->[0] && ($atype{"*"} || $atype{$_->[1]}), @{ $res->{an} };
+               my $cname;
 
-               (undef $do_search), (undef $do_req), return $cb->(@rr)
-                  if @rr;
+               while () {
+                  # results found?
+                  my @rr = grep $name eq lc $_->[0] && ($atype{"*"} || $atype{$_->[1]}), @{ $res->{an} };
 
-               # see if there is a cname we can follow
-               @rr = grep $name eq lc $_->[0] && $_->[1] eq "cname", @{ $res->{an} };
+                  (undef $do_search), (undef $do_req), return $cb->(@rr)
+                     if @rr;
 
-               if (@rr) {
-                  $depth--
-                     or return $do_search->(); # cname chain too long
+                  # see if there is a cname we can follow
+                  my @rr = grep $name eq lc $_->[0] && $_->[1] eq "cname", @{ $res->{an} };
 
-                  $cname = 1;
-                  $name = lc $rr[0][3];
+                  if (@rr) {
+                     $depth--
+                        or return $do_search->(); # cname chain too long
 
-               } elsif ($cname) {
-                  # follow the cname
-                  return $do_req->();
+                     $cname = 1;
+                     $name = lc $rr[0][4];
 
-               } else {
-                  # no, not found anything
-                  return $do_search->();
-               }
-             }
-         });
+                  } elsif ($cname) {
+                     # follow the cname
+                     return $do_req->();
+
+                  } else {
+                     # no, not found anything
+                     return $do_search->();
+                  }
+                }
+            });
+         };
+
+         $do_req->();
       };
 
-      $do_req->();
-   };
-
-   $do_search->();
+      $do_search->();
+   });
 }
 
 =item $resolver->wait_for_slot ($cb->($resolver))
@@ -1399,14 +1593,13 @@ sub wait_for_slot {
 
 use AnyEvent::Socket (); # circular dependency, so do not import anything and do it at the end
 
-1;
-
 =back
 
 =head1 AUTHOR
 
    Marc Lehmann <schmorp@schmorp.de>
-   http://home.schmorp.de/
+   http://anyevent.schmorp.de
 
 =cut
 
+1

--- a/Slim/Networking/Async/DNS.pm
+++ b/Slim/Networking/Async/DNS.pm
@@ -70,8 +70,8 @@ sub resolve {
 			return;
 		}
 
-		my $addr = $res->[3];
-		my $ttl	 = $res->[4];
+		my $addr = $res->[4];
+		my $ttl	 = $res->[3];
 
 		main::DEBUGLOG && $log->is_debug && $log->debug( "Got DNS response $addr for $host (ttl $ttl)" );
 


### PR DESCRIPTION
The slimserver change (adding of ttl) has been done upstream, but they applied a different order with respect to the slimserver version.

I applied the change in `Slim/Networking/Async/DNS.pm` in [Debian](https://sources.debian.org/src/slimserver/9.1.0%2Bdfsg-4/debian/patches/fix-lms-for-newer-anyeventdns-in-debian.patch) to enable the use of the Debian version of `AnyEvent`. `AnyEvent::DNS` is part of `AnyEvent`, but I don't update all of `AnyEvent` in this PR as I didn't check all differences (yet).
