### PR TITLE
SQLiteHelper: move attachment of persist.db to postConnect

### DIFF
--- a/Slim/Utils/SQLiteHelper.pm
+++ b/Slim/Utils/SQLiteHelper.pm
@@ -111,20 +111,6 @@ sub on_connect_do {
 	# Highmem we'll let it use memory
 	push @{$sql}, 'PRAGMA temp_store = MEMORY' if $prefs->get('dbhighmem');
 
-	# We create this even if main::STATISTICS is not false so that the SQL always works
-	# Track Persistent data is in another file, in the prefs folder rather than cache
-	my $persistentdb = $class->dbFile('persist.db', 'persistent');
-
-	# we need to move the persist.db out of the cache folder
-	_migrateDBFile($class->dbFile('persist.db'), $persistentdb);
-
-	# we need to migrate long 7.6.0 file names to shorter 7.6.1 filenames: Windows can't handle the long version
-	_migrateDBFile($class->dbFile('squeezebox-persistent.db'), $persistentdb);
-
-	push @{$sql}, "ATTACH '$persistentdb' AS persistentdb";
-	push @{$sql}, 'PRAGMA persistentdb.journal_mode = WAL';
-	push @{$sql}, 'PRAGMA persistentdb.cache_size = ' . $class->_cacheSize;
-
 	return $sql;
 }
 
@@ -353,6 +339,20 @@ sub postConnect {
 	my ( $class, $dbh ) = @_;
 
 	$dbh->func( 'MD5', 1, sub { md5_hex( $_[0] ) }, 'create_function' );
+
+	# We create this even if main::STATISTICS is not false so that the SQL always works
+	# Track Persistent data is in another file, in the prefs folder rather than cache
+	my $persistentdb = $class->dbFile('persist.db', 'persistent');
+
+	# we need to move the persist.db out of the cache folder
+	_migrateDBFile($class->dbFile('persist.db'), $persistentdb);
+
+	# we need to migrate long 7.6.0 file names to shorter 7.6.1 filenames: Windows can't handle the long version
+	_migrateDBFile($class->dbFile('squeezebox-persistent.db'), $persistentdb);
+
+	$dbh->do("ATTACH '$persistentdb' AS persistentdb");
+	$dbh->do('PRAGMA persistentdb.journal_mode = WAL');
+	$dbh->do('PRAGMA persistentdb.cache_size = ' . $class->_cacheSize);
 
 	# http://search.cpan.org/~adamk/DBD-SQLite-1.33/lib/DBD/SQLite.pm#Transaction_and_Database_Locking
 	$dbh->{sqlite_use_immediate_transaction} = 1;


### PR DESCRIPTION
I bisected with which commit in DBIx::Class the `data persistentdb is already in use` message start to appear if one is replacing the `CPAN/DBIx` directory with newer versions. I believe this change can be applied independent of updating the DBIx::Class.

 DBIx::Class got stricter since commit [e69b5335]( https://github.com/Perl5/DBIx-Class/commit/e69b53350cbc835b0de96f0c1f9af4e31ac94fdd) with checking sanity and apparently in the logic in slimserver the on_connect_do method was called multiple times. This results in the following error:
`DBD::SQLite::db do failed: database persistentdb is already in use`

While this might be the result of a bug somewhere, the [commit message](https://github.com/Perl5/DBIx-Class/commit/e69b53350cbc835b0de96f0c1f9af4e31ac94fdd) suggests this might be an issue outside of slimserver.

As postConnect is called immediately after on_connect_do, moving the code related to the persist.db there seems like a good solution.
