### PR TITLE
Alarm: add Dismiss option to Jive alarm popup

### DIFF
--- a/Slim/Control/Jive.pm
+++ b/Slim/Control/Jive.pm
@@ -2462,10 +2462,11 @@ sub jiveAlarmCommand {
 	my $request    = shift;
 	my $client     = $request->client || return;
 
-	# this command can issue either a snooze or a cancel
-	my $snooze      = $request->getParam('snooze') ? 1 : undef;
-	my $stop        = $request->getParam('stop')   ? 1 : undef;
-	my $fadein      = $request->getParam('fadein');
+	# this command can issue either a snooze or a stop
+	my $snooze        = $request->getParam('snooze')        ? 1 : undef;
+	my $stop          = $request->getParam('stop')          ? 1 : undef;
+	my $continueAudio = $request->getParam('continueAudio') ? 1 : 0;
+	my $fadein        = $request->getParam('fadein');
 
 	my $alarm       = Slim::Utils::Alarm->getCurrentAlarm($client);
 
@@ -2473,7 +2474,7 @@ sub jiveAlarmCommand {
 		if ( defined($snooze) ) {
 			$alarm->snooze();
 		} elsif ( defined ($stop) ) {
-			$alarm->stop();
+			$alarm->stop($continueAudio);
 		}
 	}
 

--- a/Slim/Utils/Alarm.pm
+++ b/Slim/Utils/Alarm.pm
@@ -849,14 +849,19 @@ sub stopSnooze {
 
 =head3
 
-stop( )
+stop( [ $continueAudio ] )
 
 Stops this alarm.  Has no effect if the alarm is not sounding.
+
+If $continueAudio is true, the player's playback, volume, power, and shuffle
+state are left untouched — the alarm UI is dismissed without interrupting what
+is playing.  Defaults to false (full restore).
 
 =cut
 
 sub stop {
 	my $self = shift;
+	my $continueAudio = shift;
 
 	my $client = $self->client;
 
@@ -882,37 +887,39 @@ sub stop {
 		$self->{_timeoutTimer} = undef;
 	}
 
-	# Restore analogOutMode to previous setting
-	if ($client->can('setAnalogOutMode') && $client->can('lineOutConnected')
-		&& $client->lineOutConnected()) {
-		# Restore in a second in order to avoid a blip that can occur if setAnalogOutMode
-		# is called during a power off volume fade.  Bug 9093.
-		Slim::Utils::Timers::setTimer($self, Time::HiRes::time() + 1, sub {
-			main::DEBUGLOG && $isDebug && $log->debug('Restoring previous line out mode');
-			$client->setAnalogOutMode();
-		});
-	}
-
-	# Restore original volume if the music is stopped at the end of the alarm and
-	# the volume hasn't been changed from the alarm volume level.  Do this after a pause
-	# to allow any volume fades to complete.
-	Slim::Utils::Timers::setTimer($self, Time::HiRes::time() + 1, sub {
-		# Get volume level directly via the pref as we don't care about temporary
-		# volume levels (vol is reported as 0 after a mute)
-		my $vol = $prefs->client($client)->get('volume');
-		if (! $client->isPlaying && $vol == ($self->{_activeVolume} // $self->volume)) {
-			main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm volume level: ' . $self->{_originalVolume});
-			$client->volume($self->{_originalVolume});
+	if (!$continueAudio) {
+		# Restore analogOutMode to previous setting
+		if ($client->can('setAnalogOutMode') && $client->can('lineOutConnected')
+			&& $client->lineOutConnected()) {
+			# Restore in a second in order to avoid a blip that can occur if setAnalogOutMode
+			# is called during a power off volume fade.  Bug 9093.
+			Slim::Utils::Timers::setTimer($self, Time::HiRes::time() + 1, sub {
+				main::DEBUGLOG && $isDebug && $log->debug('Restoring previous line out mode');
+				$client->setAnalogOutMode();
+			});
 		}
 
-		# Restore client shuffle mode
-		main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm shuffle mode: ' . $self->{_originalShuffleMode});
-		$client->execute(['playlist', 'shuffle', $self->{_originalShuffleMode}]);
+		# Restore original volume if the music is stopped at the end of the alarm and
+		# the volume hasn't been changed from the alarm volume level.  Do this after a pause
+		# to allow any volume fades to complete.
+		Slim::Utils::Timers::setTimer($self, Time::HiRes::time() + 1, sub {
+			# Get volume level directly via the pref as we don't care about temporary
+			# volume levels (vol is reported as 0 after a mute)
+			my $vol = $prefs->client($client)->get('volume');
+			if (! $client->isPlaying && $vol == ($self->{_activeVolume} // $self->volume)) {
+				main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm volume level: ' . $self->{_originalVolume});
+				$client->volume($self->{_originalVolume});
+			}
 
-		# Bug: 12760, 9569 - Return power state to that prior to the alarm
-		main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm power state: ' . ($self->{_originalPower} ? 'on' : 'off'));
-		$client->power($self->{_originalPower});
-	});
+			# Restore client shuffle mode
+			main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm shuffle mode: ' . $self->{_originalShuffleMode});
+			$client->execute(['playlist', 'shuffle', $self->{_originalShuffleMode}]);
+
+			# Bug: 12760, 9569 - Return power state to that prior to the alarm
+			main::DEBUGLOG && $isDebug && $log->debug('Restoring pre-alarm power state: ' . ($self->{_originalPower} ? 'on' : 'off'));
+			$client->power($self->{_originalPower});
+		});
+	}
 
 
 	my $class = ref $self;


### PR DESCRIPTION
## Summary

- Extends `Slim::Utils::Alarm::stop()` with an optional `$continueAudio` flag. When true, all player-state restores (analogOut, volume, shuffle, power) are skipped so playback continues uninterrupted.
- The `jivealarm` command now accepts a `continueAudio:1` parameter, forwarded to `stop()`.
- This wires up the new **Dismiss** menu item being added to the AlarmSnoozeApplet in the SqueezePlay client repos.

As a side-effect this also fixes the `cancelAction` (Back button on device) behaviour: the Lua client already sent `stopAlarm(true)` for Back, but the server was unconditionally restoring player state anyway.

Backward compatible: old clients that don't send `continueAudio` default to `0`, preserving existing behaviour.

## Related

Companion PRs (client side, independent):
- squeezeplay: https://github.com/ralph-irving/squeezeplay/pull/48
- squeezeos-squeezeplay: https://github.com/ralph-irving/squeezeos-squeezeplay/pull/32