### PR TITLE
Guard ReplayGain and URL tag processing against arrayrefs

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1305,6 +1305,7 @@ sub _createOrUpdateAlbum {
 		# Bug 8034, this used to not change gain/peak values if they were already set,
 		# bug we do want to update album gain tags if they are changed.
 		if ( $attributes->{$gainTag} ) {
+			$attributes->{$gainTag} = $attributes->{$gainTag}[0] if ref $attributes->{$gainTag} eq 'ARRAY';
 			$attributes->{$gainTag} =~ s/\s*dB//gi;
 			$attributes->{$gainTag} =~ s/\s//g;  # bug 15965
 			$attributes->{$gainTag} =~ s/,/\./g; # bug 6900, change comma to period
@@ -2802,6 +2803,7 @@ sub _preCheckAttributes {
 	# Bug: 2605 - Get URL out of the attributes - some programs, and
 	# services such as www.allofmp3.com add it.
 	if ($attributes->{'URL'}) {
+		$attributes->{'URL'} = $attributes->{'URL'}[0] if ref $attributes->{'URL'} eq 'ARRAY';
 
 		push @$rawcomments, delete $attributes->{'URL'};
 	}
@@ -2921,6 +2923,7 @@ sub processReplayGainTags {
 		   $shortTag =~ s/^REPLAYGAIN_TRACK_(\w+)$/REPLAY_$1/;
 
 		if (defined $attributes->{$gainTag}) {
+			$attributes->{$gainTag} = $attributes->{$gainTag}[0] if ref $attributes->{$gainTag} eq 'ARRAY';
 
 			$attributes->{$shortTag} = delete $attributes->{$gainTag};
 			$attributes->{$shortTag} =~ s/\s*dB//gi;


### PR DESCRIPTION
## Summary

- Add defensive guards in Schema.pm for three code paths that apply regex to TXXX-derived tag values
- Uses the established `$val = $val->[0] if ref $val eq 'ARRAY'` pattern already present in Schema.pm
- Covers: ReplayGain track gain/peak, album gain/peak, and URL/comments

## Context

Companion to the Audio::Scan multi-value TXXX fix (LMS-Community/Audio-Scan#11). These guards are independently useful as defensive hygiene: they protect against arrayrefs arriving in these paths regardless of source.

Forum discussion: https://forums.lyrion.org/forum/user-forums/ripping-encoding-transcoding-tagging/1816764-lms-metadata-scaan-overrides-local-tags

## Test plan

- [ ] smoketest passes (t/00_smoketest.sh)
- [ ] Manual: scan MP3 files with ReplayGain TXXX tags, verify gain values still parse correctly