### PR TITLE
Fix release-types for squeezeplay/Touch etc

### DIFF
--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -735,7 +735,7 @@ sub setMode {
 	$client->modeParam( handledTransition => 1 );
 }
 
-our @topLevelArgs = qw(track_id artist_id genre_id album_id playlist_id year only_album_years folder_id role_id library_id remote_library release_type work_id composer_id from_search subtitle grouping performance);
+our @topLevelArgs = qw(track_id artist_id genre_id album_id playlist_id year only_album_years folder_id role_id library_id remote_library release_type work_id composer_id from_search subtitle grouping performance menu_mode menu_roles);
 
 sub _topLevel {
 	my ($client, $callback, $args, $pt) = @_;


### PR DESCRIPTION
The necessary parameters were not being passed through the cometd route when browsing from Additional Browse Modes.