### PR TITLE
Add opt-in pref `mergeContributorsByName` for album-artist contributor matching

### DIFF
--- a/Changelog9.html
+++ b/Changelog9.html
@@ -2,7 +2,7 @@
 <ul>
 	<li>New Features:</li>
 	<ul>
-		<li></li>
+		<li><a href="https://github.com/LMS-Community/slimserver/issues/1578">#1578</a> - Add opt-in "Merge contributors by name" preference to prevent duplicate album-artist browse entries when MusicBrainz IDs differ across the same display name.</li>
 	</ul>
 	<br />
 

--- a/HTML/EN/settings/server/behavior.html
+++ b/HTML/EN/settings/server/behavior.html
@@ -105,6 +105,11 @@
 			<label for="pref_useTPE2AsAlbumArtist1" class="stdlabel">[% 'SETUP_USETPE2ASALBUMARTIST_1' | getstring %]</label><br/>
 		[% END %]
 
+		[% WRAPPER settingGroup title="SETUP_MERGECONTRIBUTORSBYNAME" desc="SETUP_MERGECONTRIBUTORSBYNAME_DESC" %]
+			<input type="checkbox" name="pref_mergeContributorsByName" id="pref_mergeContributorsByName" value="1" [% IF prefs.pref_mergeContributorsByName %]checked="checked"[% END %] />
+			<label for="pref_mergeContributorsByName" class="stdlabel">[% 'SETUP_MERGECONTRIBUTORSBYNAME_LABEL' | getstring %]</label>
+		[% END %]
+
 		[% WRAPPER settingGroup title="SETUP_MYCLASSICALGENRES" desc="SETUP_MYCLASSICALGENRES_DESC" %]
 			<input type="text" class="stdedit" name="pref_myClassicalGenres" id="myClassicalGenres" value="[% prefs.pref_myClassicalGenres | html %]" size="40" placeholder="[% "GENRES" | string | html %]"><br/>
 		[% END %]

--- a/Slim/Schema/Contributor.pm
+++ b/Slim/Schema/Contributor.pm
@@ -258,8 +258,19 @@ sub add {
 		my $mbid   = $brainzIDList[$i];
 		my ($id, $oldExtId, $oldMbid, $sth);
 
-		# check Musicbrainz ID first
-		if ($mbid) {
+		my $preferNameMatch = $prefs->get('mergeContributorsByName');
+
+		# Default behaviour: check Musicbrainz ID first, name fallback
+		# only against rows whose musicbrainz_id is NULL.
+		#
+		# When mergeContributorsByName is enabled: look up by name first
+		# regardless of MBID, tie-breaking by preferring rows with a
+		# non-null musicbrainz_id (richer data) then by id ascending
+		# (oldest first) for determinism. MBID lookup is the fallback.
+		# This is opt-in because some libraries legitimately rely on
+		# MBIDs to distinguish two artists who share a display name
+		# (e.g. John Williams the composer vs. the guitarist).
+		if ($mbid && !$preferNameMatch) {
 			$sth = $dbh->prepare_cached( 'SELECT id, extid, musicbrainz_id FROM contributors WHERE musicbrainz_id = ?' );
 			$sth->execute($mbid);
 			($id, $oldExtId, $oldMbid) = $sth->fetchrow_array;
@@ -270,6 +281,24 @@ sub add {
 				$sth = $dbh->prepare_cached( 'SELECT id, extid FROM contributors WHERE name = ? AND musicbrainz_id IS NULL' );
 				$sth->execute($name);
 				($id, $oldExtId) = $sth->fetchrow_array;
+				$sth->finish;
+			}
+		}
+		elsif ($preferNameMatch && $name) {
+			$sth = $dbh->prepare_cached(
+				'SELECT id, extid, musicbrainz_id FROM contributors WHERE name = ? '
+				. 'ORDER BY (musicbrainz_id IS NULL), id LIMIT 1'
+			);
+			$sth->execute($name);
+			($id, $oldExtId, $oldMbid) = $sth->fetchrow_array;
+			$sth->finish;
+
+			# If no name match, fall back to MBID lookup so a brand-new
+			# contributor doesn't get split off from an existing MBID-only row.
+			if ( !$id && $mbid ) {
+				$sth = $dbh->prepare_cached( 'SELECT id, extid, musicbrainz_id FROM contributors WHERE musicbrainz_id = ?' );
+				$sth->execute($mbid);
+				($id, $oldExtId, $oldMbid) = $sth->fetchrow_array;
 				$sth->finish;
 			}
 		}

--- a/Slim/Utils/Prefs.pm
+++ b/Slim/Utils/Prefs.pm
@@ -189,6 +189,7 @@ sub init {
 		'variousArtistAutoIdentification' => 1,
 		'useUnifiedArtistsList' => 0,
 		'useTPE2AsAlbumArtist'  => 1,
+		'mergeContributorsByName' => 0,
 		'variousArtistsString'  => undef,
 		'releaseTypesToIgnore'  => [],
 		'ignoreReleaseTypes'    => 0,
@@ -403,7 +404,7 @@ sub init {
 
 	$prefs->setChange(
 		sub { Slim::Control::Request::executeRequest(undef, ['wipecache', $prefs->get('dontTriggerScanOnPrefChange') ? 'queue' : undef]) },
-		qw(splitList groupdiscs useTPE2AsAlbumArtist cleanupReleaseTypes worksScan)
+		qw(splitList groupdiscs useTPE2AsAlbumArtist mergeContributorsByName cleanupReleaseTypes worksScan)
 	);
 
 	$prefs->setChange( sub {

--- a/Slim/Web/Settings/Server/Behavior.pm
+++ b/Slim/Web/Settings/Server/Behavior.pm
@@ -31,7 +31,7 @@ sub prefs {
 				ignoreReleaseTypes cleanupReleaseTypes groupArtistAlbumsByReleaseType
 				useTPE2AsAlbumArtist variousArtistsString ratingImplementation useUnifiedArtistsList
 				skipsentinel showComposerReleasesbyAlbum myClassicalGenres onlyAlbumYears
-				worksScan)
+				worksScan mergeContributorsByName)
 		   );
 }
 

--- a/strings.txt
+++ b/strings.txt
@@ -20219,6 +20219,15 @@ SETUP_USETPE2ASALBUMARTIST_0
 	RU	Поле TPE2 тега MP3 содержит группу
 	SV	Behandla mp3-taggen TPE2 som band
 
+SETUP_MERGECONTRIBUTORSBYNAME
+	EN	Merge contributors by name
+
+SETUP_MERGECONTRIBUTORSBYNAME_DESC
+	EN	When two tracks share the same album artist display name but carry different MusicBrainz Album Artist IDs (e.g. a band credit on MusicBrainz that uses the solo artist's name string), LMS normally creates separate contributor rows — causing duplicate browse entries for the same apparent artist. Enable this option to match contributors by display name first, ignoring MBID differences, so those tracks are grouped under a single entry. Leave disabled if your library contains genuinely distinct artists who share a name and you rely on MusicBrainz IDs to keep them apart. Changing this setting will trigger a rescan.
+
+SETUP_MERGECONTRIBUTORSBYNAME_LABEL
+	EN	Merge album artist contributors with the same name, even when MusicBrainz IDs differ
+
 LYRICS
 	CS	Texty písní
 	DA	Tekster


### PR DESCRIPTION
# Add opt-in pref `mergeContributorsByName` for album-artist contributor matching

Fixes #1578.

## Summary

Adds a server preference, `mergeContributorsByName`, that changes the contributor lookup in `Slim::Schema::Contributor::add` from "MBID first, name fallback only if existing row has NULL MBID" to "name first, MBID fallback if no name match." Default is OFF; existing behavior is preserved.

## Motivation

Same display name, different MBID → two contributor rows under the same name in the browse UI. The most common trigger is band/collaboration credits on MusicBrainz that use the solo artist's name string in `ALBUMARTIST` (e.g. "Stephen Malkmus" credited to "Stephen Malkmus & The Jicks" on MusicBrainz; "Mirah" credited to a multi-artist collaboration). See the linked issue for a full reproduction, source-code analysis, and empirical confirmation via a per-track tag experiment.

## Change

`Slim/Schema/Contributor.pm`: in `sub add`, gate the existing MBID-first lookup on `!$prefs->get('mergeContributorsByName')`. When the pref is on, look up by `name` first, tie-breaking by preferring rows with non-null `musicbrainz_id` (richer data) then by `id` ascending (oldest first) for determinism. Fall back to MBID lookup only if no name match exists.

`Slim/Utils/Prefs.pm` (or wherever scanner-related prefs are defaulted, depending on layout): default `mergeContributorsByName => 0`.

Settings UI: add a checkbox under My Music → MP3 (or a more general "Contributor scanning" subsection) with the help text:

> When enabled, contributors are matched by name first, even if MusicBrainz IDs differ. Use this if MusicBrainz credits cause the same artist to appear as separate browse entries (e.g. a band-name credit alongside solo releases under the same display name). Leave off if you have legitimately distinct artists who share a display name and rely on MBIDs to keep them apart.

## Tradeoffs and why default-OFF is correct

The current MBID-first behavior is the *right* default for libraries that contain legitimately distinct artists with the same display name (e.g. John Williams the composer vs. John Williams the guitarist) — those users want MBIDs to keep their rows separate, and a global "match by name" would regress them. Making the new behavior opt-in preserves both populations.

## Alternatives considered

- **Per-name allowlist.** More surgical (you can merge "Stephen Malkmus" while still distinguishing the John Williamses) but requires a settings-page UI for managing the list. Worth doing as a follow-up; the global toggle is the smallest patch that fixes the immediate complaint.
- **Always prefer name.** Cleaner code but a regression for the ambiguous-name population.
- **Reverse: blocklist of MBIDs to ignore.** Bad UX (exposes UUIDs to users).

## Test plan

Manual verification on a library exhibiting the bug (Stephen Malkmus and Mirah examples from the issue):

1. With pref OFF (default): clear+rescan, verify `contributors` table still contains both rows (existing behavior preserved).
2. With pref ON: clear+rescan, verify `contributors` table now has a single row per display name; the orphaned rows are pruned by `Contributor::rescan` once they have no remaining `contributor_track` references.
3. Mixed-MBID library with legitimately distinct same-name artists (synthetic test): with pref OFF, verify they stay separate. With pref ON, verify they collapse (expected; user opted in).
4. Rescan idempotency: scan twice in a row with pref ON, confirm no row count drift.

## Patch

See `Contributor.pm.diff` alongside this PR description.

## Note on the existing no-MBID branch (`SELECT … LIMIT 1` with no `ORDER BY`)

While debugging the underlying issue I also noticed that the existing no-MBID name lookup is non-deterministic across rescans because it uses `LIMIT 1` without `ORDER BY`. This makes the documented "strip MBID frames to merge" workaround unreliable — in my own library it picked the canonical contributor for one duplicate and the duplicate row for another. I have *not* changed that path in this PR (out of scope, conservative diff), but it would be a worthwhile follow-up to add `ORDER BY id LIMIT 1` there as well for reproducibility. Happy to do that in a separate PR if the maintainers agree.