### PR TITLE
Titles query album header

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -6702,10 +6702,10 @@ sub _getTagDataForTracks {
 		my $separator = $tags =~ /AA/ ? ',' : ', ';
 		while ( my ($id, $name, $track, $role) = $contrib_sth->fetchrow_array ) {
 			$values{$track} ||= {};
-                       my $role_info = $values{$track}->{$role} ||= {
-                               'ids' => [],
-                               'names' => []
-                       };
+			my $role_info = $values{$track}->{$role} ||= {
+			       'ids' => [],
+			       'names' => []
+			};
 
 			utf8::decode($name);
 			push @{$role_info->{'ids'}}, $id;

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -6388,7 +6388,7 @@ sub _getTagDataForTracks {
 		$join_contributor_tracks->();
 
 		if ( $sql !~ /JOIN contributors/ ) {
-			$sql .= 'LEFT JOIN contributors ON contributors.id = contributor_track.contributor ';
+			$sql .= 'LEFT JOIN contributors ON contributors.id = tracks.primary_artist ';
 		}
 	};
 
@@ -6736,8 +6736,25 @@ sub _getTagDataForTracks {
 				}
 			}
 		}
-		$albumHeader->{title_names} = join(',', Slim::Utils::Misc::uniq(@albumTitleNames)) if $oneAlbum;
-		$albumHeader->{title_ids} = join(',', Slim::Utils::Misc::uniq(@albumTitleIds)) if $oneAlbum;
+		if ( scalar @albumTitleIds ) {
+			@{$albumHeader->{title_names}} = Slim::Utils::Misc::uniq(@albumTitleNames);
+			@{$albumHeader->{title_ids}} = Slim::Utils::Misc::uniq(@albumTitleIds);
+		}
+		elsif ( $oneAlbum ) {
+			# We've been asked for a specific album but for some reason we don't have any artists for the header: get from the album
+			$sql = "SELECT albums.contributor, contributors.name FROM albums JOIN contributors ON albums.contributor = contributors.id WHERE albums.id = $args->{albumId}";
+			my $album_contrib_sth = $dbh->prepare($sql);
+
+			if ( main::DEBUGLOG && $sqllog->is_debug ) {
+				$sqllog->debug( "Tag A/S (album contributor) query: $sql" );
+			}
+
+			$album_contrib_sth->execute;
+			if ( my ($id, $name) = $album_contrib_sth->fetchrow_array ) {
+				@{$albumHeader->{title_names}} = $name;
+				@{$albumHeader->{title_ids}} = $id;
+			}
+		}
 	}
 
 	# Same thing for G/P, multiple genres requires another query

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4865,7 +4865,7 @@ sub titlesQuery {
 		},
 	};
 	$tagDataParams->{performance} = $performance if $performance;
-	my ($items, $itemOrder, $totalCount) = _getTagDataForTracks( $tags, $tagDataParams );
+	my ($items, $itemOrder, $totalCount, $albumHeader) = _getTagDataForTracks( $tags, $tagDataParams );
 
 	if ($stillScanning) {
 		$request->addResult("rescan", 1);
@@ -4891,6 +4891,7 @@ sub titlesQuery {
 	}
 
 	$request->addResult('count', $totalCount);
+	$request->addResult('album_header', $albumHeader) if $albumHeader;
 
 	$request->setStatusDone();
 }
@@ -6255,6 +6256,8 @@ sub _getTagDataForTracks {
 	my $w        = [];
 	my $p        = [];
 	my $total    = 0;
+       my $albumHeader;
+       my $oneAlbum;
 
 	if ( $args->{where} ) {
 		push @{$w}, $args->{where};
@@ -6317,6 +6320,7 @@ sub _getTagDataForTracks {
 
 	if ( my $albumId = $args->{albumId} ) {
 		my @albumIds = split(',', $albumId);
+		$oneAlbum = scalar @albumIds == 1;
 		push @{$w}, 'tracks.album IN (' . join(',', map {'?'} @albumIds) . ')';
 		push @{$p}, @albumIds;
 		delete $args->{releaseType};
@@ -6696,16 +6700,21 @@ sub _getTagDataForTracks {
 		my $separator = $tags =~ /AA/ ? ',' : ', ';
 		while ( my ($id, $name, $track, $role) = $contrib_sth->fetchrow_array ) {
 			$values{$track} ||= {};
-			my $role_info = $values{$track}->{$role} ||= {};
+                       my $role_info = $values{$track}->{$role} ||= {
+                               'ids' => [],
+                               'names' => []
+                       };
 
-			# XXX: what if name has ", " in it?
 			utf8::decode($name);
-			$role_info->{ids}   .= $role_info->{ids} ? ',' . $id : $id;
-			$role_info->{names} .= $role_info->{names} ? $separator . $name : $name;
+			push @{$role_info->{'ids'}}, $id;
+			push @{$role_info->{names}}, $name;
 		}
 
 		my $want_names = $tags =~ /A/;
 		my $want_ids   = $tags =~ /S/;
+		my @albumTitleRoles = map { Slim::Schema::Contributor->typeToRole($_) } Slim::Schema::Contributor->allAlbumLinkRoles();
+		my @albumTitleNames;
+		my @albumTitleIds;
 
 		while ( my ($id, $role) = each %values ) {
 			my $track = $results{$id};
@@ -6713,10 +6722,20 @@ sub _getTagDataForTracks {
 			while ( my ($role_id, $role_info) = each %{$role} ) {
 				my $role = lc( Slim::Schema::Contributor->roleToType($role_id) );
 
-				$track->{"${role}_ids"} = $role_info->{ids}   if $want_ids;
-				$track->{$role}         = $role_info->{names} if $want_names;
+				$track->{"${role}_ids"} = join(',', @{$role_info->{ids}}) if $want_ids;
+				# XXX: what if name has ", " in it?
+				$track->{$role} = join($separator, @{$role_info->{names}}) if $want_names;
+			}
+
+			if ( $oneAlbum ) {
+				foreach (@albumTitleRoles) {
+					push @albumTitleNames, @{$role->{$_}->{names}} if $role->{$_}->{names};
+					push @albumTitleIds, @{$role->{$_}->{ids}} if $role->{$_}->{ids};
+				}
 			}
 		}
+		$albumHeader->{title_names} = join(',', Slim::Utils::Misc::uniq(@albumTitleNames)) if $oneAlbum;
+		$albumHeader->{title_ids} = join(',', Slim::Utils::Misc::uniq(@albumTitleIds)) if $oneAlbum;
 	}
 
 	# Same thing for G/P, multiple genres requires another query
@@ -6792,7 +6811,7 @@ sub _getTagDataForTracks {
 	# delete the temporary table, as it's stored in memory and can be rather large
 	Slim::Plugin::FullTextSearch::Plugin->dropHelperTable('tracksSearch') if $search && Slim::Schema->canFulltextSearch;
 
-	return wantarray ? ( \%results, \@resultOrder, $total ) : \%results;
+	return wantarray ? ( \%results, \@resultOrder, $total, $albumHeader ) : \%results;
 }
 
 # SQLite would not sort single characters the same way as the same characters at

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -6258,8 +6258,8 @@ sub _getTagDataForTracks {
 	my $w        = [];
 	my $p        = [];
 	my $total    = 0;
-       my $albumHeader;
-       my $oneAlbum;
+	my $albumHeader;
+	my $oneAlbum;
 
 	if ( $args->{where} ) {
 		push @{$w}, $args->{where};

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -6623,7 +6623,7 @@ sub _getTagDataForTracks {
 		($valid, $start, $end) = $limit->($total) unless $count_only;
 
 		if ( $count_only || !$valid ) {
-			return wantarray ? ( {}, [], $total ) : {};
+			return wantarray ? ( {}, [], $total, undef) : {};
 		}
 
 		# Limit the real query
@@ -6703,8 +6703,8 @@ sub _getTagDataForTracks {
 		while ( my ($id, $name, $track, $role) = $contrib_sth->fetchrow_array ) {
 			$values{$track} ||= {};
 			my $role_info = $values{$track}->{$role} ||= {
-			       'ids' => [],
-			       'names' => []
+				'ids' => [],
+				'names' => []
 			};
 
 			utf8::decode($name);
@@ -6742,14 +6742,14 @@ sub _getTagDataForTracks {
 		}
 		elsif ( $oneAlbum ) {
 			# We've been asked for a specific album but for some reason we don't have any artists for the header: get from the album
-			$sql = "SELECT albums.contributor, contributors.name FROM albums JOIN contributors ON albums.contributor = contributors.id WHERE albums.id = $args->{albumId}";
+			$sql = "SELECT albums.contributor, contributors.name FROM albums JOIN contributors ON albums.contributor = contributors.id WHERE albums.id = ?";
 			my $album_contrib_sth = $dbh->prepare($sql);
 
 			if ( main::DEBUGLOG && $sqllog->is_debug ) {
-				$sqllog->debug( "Tag A/S (album contributor) query: $sql" );
+				$sqllog->debug( "Tag A/S (album contributor) query: $sql / $args->{albumId}" );
 			}
 
-			$album_contrib_sth->execute;
+			$album_contrib_sth->execute($args->{albumId});
 			if ( my ($id, $name) = $album_contrib_sth->fetchrow_array ) {
 				@{$albumHeader->{title_names}} = $name;
 				@{$albumHeader->{title_ids}} = $id;


### PR DESCRIPTION
When the client requests a track list for a specific album, add an `album_header` to the result to contain the artist name(s) and id(s) according to the user preference for album artist links.

This is to allow client consistency. For example, when displaying an album track listing in Material from a browse albums list, the artist(s) to display in the page header are available in the previous `albums` call,  but they are not available when clicking on the album name in the play queue as there was no previous `albums` call.

This change makes them available in all cases.

I have also changed the returned `artist` and `artist_id` in the `titles_loop`. This was returning random values because it was being set from `contributor_track` which was not in the `GROUP BY`. The change sets it from `tracks.primary_artist` instead. 