### PR TITLE
Fix crashes when a podcast URL contains wide characters

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -1945,7 +1945,7 @@ sub updateOrCreateBase {
 	}
 
 	# make sure we always have an up to date md5 hash value
-	$attributeHash->{urlmd5} = md5_hex($url);
+	$attributeHash->{urlmd5} = md5_hex(Slim::Utils::Unicode::utf8off($url));
 
 	# Short-circuit for remote tracks
 	if (!$integrateRemote && Slim::Music::Info::isRemoteURL($url)) {

--- a/Slim/Utils/DbCache.pm
+++ b/Slim/Utils/DbCache.pm
@@ -154,7 +154,7 @@ sub _key {
 
 	# Get a 60-bit unsigned int from MD5 (SQLite uses 64-bit signed ints for the key)
 	# Have to concat 2 values here so it works on a 32-bit machine
-	my $md5 = Digest::MD5::md5_hex($key);
+	my $md5 = Digest::MD5::md5_hex(Slim::Utils::Unicode::utf8off($key));
 	return hex( substr($md5, 0, 8) ) . hex( substr($md5, 8, 7) );
 }
 


### PR DESCRIPTION
Slimserver fails to parse this podcast rss feed:
https://api.sr.se/api/rss/pod/22712

Specifically it fails to parse this URL:
https://static-cdn.sr.se/laddahem/podradio/2020/08/usapodden_kamala_harris_–_det_historiska_20200812_1718212879.mp3

Note the dash character in the file name.

Parsing fails with an error message like:
> Slim::Formats::XML::gotViaHTTP (190) Wide character in subroutine entry at /usr/share/perl5/Slim/Utils/DbCache.pm line 157.
> Slim::Formats::XML::gotViaHTTP (217) XML/JSON parse error: Wide character in subroutine entry at /usr/share/perl5/Slim/Utils/DbCache.pm line 157.

.. and, once that problem is fixed, playing the podcast URL that contains wide characters produces this error message:
> Slim::Networking::IO::Select::__ANON__ (131) Error: Select task failed calling Slim::Networking::Async::HTTP::_http_read_body: Wide character in subroutine entry at /usr/share/perl5/Slim/Schema.pm line 1947.

Inspiration for the fix is taken from 1042765a1b3d3527fe6a10614afe3ba1bb01fc34

---

I haven't investigated alternative fixes.

Testing done (on slimserver 9.1.0):
I can now list podcast episodes and play the problematic stream URL.