### PR TITLE
Fix RSS feed parsing when a podcast URL contains wide characters

### DIFF
--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -451,7 +451,7 @@ sub parseRSS {
 		}
 
 		if ($enclosure) {
-			$item{'enclosure'}->{'url'}    = trim($enclosure->{'url'});
+			$item{'enclosure'}->{'url'}    = Slim::Utils::Unicode::utf8off(trim($enclosure->{'url'}));
 			$item{'enclosure'}->{'type'}   = trim($enclosure->{'type'});
 			$item{'enclosure'}->{'length'} = trim($enclosure->{'length'});
 		}


### PR DESCRIPTION
Slimserver fails to parse this podcast RSS feed:
https://api.sr.se/api/rss/pod/22712

Specifically it fails to parse this URL:
https://static-cdn.sr.se/laddahem/podradio/2020/08/usapodden_kamala_harris_–_det_historiska_20200812_1718212879.mp3

Note the dash character in the file name.

The RSS parser has been updated to avoid UTF-8 encoding when storing
the stream's URL.

---

If this looks ok the same change should probably be made to the other URLs parsed (such as image URL).

Testing done:
The broken podcast episode mentioned above now works. Various other episodes and podcasts still work.