### PR TITLE
Remove outdated postal address for the Free Software Foundation

### DIFF
--- a/Slim/Buttons/GlobalSearch.pm
+++ b/Slim/Buttons/GlobalSearch.pm
@@ -15,9 +15,8 @@ package Slim::Buttons::GlobalSearch;
 #	GNU General Public License for more details.
 #
 #	You should have received a copy of the GNU General Public License
-#	along with this program; if not, write to the Free Software
-#	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-#	02111-1307 USA
+#	along with this program; if not, see see
+#	<https://www.gnu.org/licenses/>.
 #
 
 =head1 NAME

--- a/Slim/Buttons/Information.pm
+++ b/Slim/Buttons/Information.pm
@@ -16,9 +16,8 @@ package Slim::Buttons::Information;
 #	GNU General Public License for more details.
 #
 #	You should have received a copy of the GNU General Public License
-#	along with this program; if not, write to the Free Software
-#	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-#	02111-1307 USA
+#	along with this program; if not, see see
+#	<https://www.gnu.org/licenses/>.
 #
 
 =head1 NAME


### PR DESCRIPTION
Fixes the following warnings from `rpmlint`:

```
lyrionmusicserver.noarch: E: incorrect-fsf-address /usr/lib/perl5/vendor_perl/Slim/Buttons/GlobalSearch.pm
lyrionmusicserver.noarch: E: incorrect-fsf-address /usr/lib/perl5/vendor_perl/Slim/Buttons/Information.pm
```