### PR TITLE
MusicMagic: add configurable host for remote MusicIP instances

### DIFF
--- a/Slim/Plugin/MusicMagic/Common.pm
+++ b/Slim/Plugin/MusicMagic/Common.pm
@@ -78,6 +78,7 @@ sub grabFilters {
 	my ($class, $client, $params, $callback, @args) = @_;
 
 	my $MMSport = $prefs->get('port');
+	my $MMShost = $prefs->get('host') || 'localhost';
 
 	my $http = Slim::Networking::SimpleAsyncHTTP->new(
 		\&_gotFilters,
@@ -96,7 +97,7 @@ sub grabFilters {
 		}
 	);
 
-	$http->get( "http://localhost:$MMSport/api/filters" );
+	$http->get( "http://$MMShost:$MMSport/api/filters" );
 }
 
 sub getFilterList {

--- a/Slim/Plugin/MusicMagic/Common.pm
+++ b/Slim/Plugin/MusicMagic/Common.pm
@@ -74,11 +74,14 @@ sub checkDefaults {
 	}, 'Slim::Plugin::MusicMagic::Prefs');
 }
 
+sub getBaseUrl {
+	my $host = $prefs->get('host') || 'localhost';
+	my $port = $prefs->get('port');
+	return "http://$host:$port/api";
+}
+
 sub grabFilters {
 	my ($class, $client, $params, $callback, @args) = @_;
-
-	my $MMSport = $prefs->get('port');
-	my $MMShost = $prefs->get('host') || 'localhost';
 
 	my $http = Slim::Networking::SimpleAsyncHTTP->new(
 		\&_gotFilters,
@@ -97,7 +100,7 @@ sub grabFilters {
 		}
 	);
 
-	$http->get( "http://$MMShost:$MMSport/api/filters" );
+	$http->get( getBaseUrl() . '/filters' );
 }
 
 sub getFilterList {

--- a/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
+++ b/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
@@ -87,6 +87,10 @@
 			[% END %]
 		[% END %]
 
+		[% WRAPPER settingGroup title="SETUP_MMSHOST" desc="SETUP_MMSHOST_DESC" %]
+			<input type="text" class="stdedit" name="pref_host" id="host" value="[% prefs.pref_host || 'localhost' | html %]" size="40">
+		[% END %]
+
 		[% IF prefs.exists('pref_port') %]
 			[% WRAPPER settingGroup title="SETUP_MMSPORT" desc="SETUP_MMSPORT_DESC" %]
 				<input type="text" class="stdedit" name="pref_port" id="port" value="[% prefs.pref_port | html %]" size="5">

--- a/Slim/Plugin/MusicMagic/Importer.pm
+++ b/Slim/Plugin/MusicMagic/Importer.pm
@@ -27,8 +27,6 @@ use Slim::Utils::Versions;
 
 my $initialized = 0;
 my $MMMVersion  = 0;
-my $MMSport;
-my $MMShost;
 
 my $log = Slim::Utils::Log->addLogCategory({
 	'category'     => 'plugin.musicip',
@@ -87,12 +85,9 @@ sub initPlugin {
 
 	Slim::Plugin::MusicMagic::Common::checkDefaults();
 
-	$MMSport = $prefs->get('port');
-	$MMShost = $prefs->get('host') || 'localhost';
+	main::INFOLOG && $log->info("Testing for API on " . Slim::Plugin::MusicMagic::Common::getBaseUrl());
 
-	main::INFOLOG && $log->info("Testing for API on $MMShost:$MMSport");
-
-	my $initialized = get( "http://$MMShost:$MMSport/api/version", 5 );
+	my $initialized = get( Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/version', 5 );
 
 	if (defined $initialized) {
 
@@ -171,7 +166,7 @@ sub doneScanning {
 
 	main::INFOLOG && $log->info("Done Scanning");
 
-	my $lastDate = get("http://$MMShost:$MMSport/api/cacheid?contents");
+	my $lastDate = get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/cacheid?contents');
 
 	if ($lastDate) {
 
@@ -186,9 +181,6 @@ sub doneScanning {
 sub exportFunction {
 	my $class = shift;
 
-	$MMSport = $prefs->get('port') unless $MMSport;
-	$MMShost = $prefs->get('host') || 'localhost' unless $MMShost;
-
 	$class->exportSongs;
 	$class->exportPlaylists;
 	$class->exportDuplicates;
@@ -202,7 +194,7 @@ sub exportSongs {
 	if ($fullRescan == 1 || $prefs->get('musicip') == 1) {
 		main::INFOLOG && $log->info("MusicIP mixable status full scan");
 
-		my $count = get("http://$MMShost:$MMSport/api/getSongCount");
+		my $count = get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/getSongCount');
 		if ($count) {
 			# convert to integer
 			chomp($count);
@@ -225,7 +217,7 @@ sub exportSongs {
 			main::INFOLOG && $log->info("Fetching ALL song data via songs/extended..");
 
 			my $MMMSongData = catdir( preferences('server')->get('librarycachedir'), 'mmm-song-data.txt' );
-			my $MMMDataURL  = "http://$MMShost:$MMSport/api/songs?extended";
+			my $MMMDataURL  = Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/songs?extended';
 
 			getstore($MMMDataURL, $MMMSongData);
 
@@ -261,7 +253,7 @@ sub exportSongs {
 			unlink($MMMSongData);
 		} else {
 			for (my $scan = 0; $scan <= $count; $scan++) {
-				my $content = get("http://$MMShost:$MMSport/api/getSong?index=$scan");
+				my $content = get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . "/getSong?index=$scan");
 
 				$class->processSong($content, $progress);
 			}
@@ -300,7 +292,7 @@ sub exportSongs {
 			my $pathEnc = Slim::Plugin::MusicMagic::Common::escape($path);
 
 			# Set musicmagic_mixable on $track object and call $track->update to actually store it.
-			my $result = get("http://$MMShost:$MMSport/api/status?song=$pathEnc");
+			my $result = get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . "/status?song=$pathEnc");
 
 			if ($result =~ /^(\w+)\s+(.*)/) {
 
@@ -492,7 +484,7 @@ sub processSong {
 sub exportPlaylists {
 	my $class = shift;
 
-	my @playlists = split(/\n/, get("http://$MMShost:$MMSport/api/playlists"));
+	my @playlists = split(/\n/, get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/playlists'));
 
 	if (!scalar @playlists) {
 		return;
@@ -515,7 +507,7 @@ sub exportPlaylists {
 
 		my $listname = Slim::Plugin::MusicMagic::Common::decode($playlists[$i]);
 
-		my $playlist = get("http://$MMShost:$MMSport/api/getPlaylist?index=$i") || next;
+		my $playlist = get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . "/getPlaylist?index=$i") || next;
 		my @songs    = split(/\n/, $playlist);
 
 		if ( main::INFOLOG && $log->is_info ) {
@@ -537,7 +529,7 @@ sub exportDuplicates {
 
 	main::INFOLOG && $log->info("Checking for duplicates.");
 
-	my @songs = split(/\n/, get("http://$MMShost:$MMSport/api/duplicates"));
+	my @songs = split(/\n/, get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/duplicates'));
 
 	$class->_updatePlaylist(string('MUSICIP_DUPLICATES'), \@songs);
 

--- a/Slim/Plugin/MusicMagic/Importer.pm
+++ b/Slim/Plugin/MusicMagic/Importer.pm
@@ -28,6 +28,7 @@ use Slim::Utils::Versions;
 my $initialized = 0;
 my $MMMVersion  = 0;
 my $MMSport;
+my $MMShost;
 
 my $log = Slim::Utils::Log->addLogCategory({
 	'category'     => 'plugin.musicip',
@@ -87,10 +88,11 @@ sub initPlugin {
 	Slim::Plugin::MusicMagic::Common::checkDefaults();
 
 	$MMSport = $prefs->get('port');
+	$MMShost = $prefs->get('host') || 'localhost';
 
-	main::INFOLOG && $log->info("Testing for API on localhost:$MMSport");
+	main::INFOLOG && $log->info("Testing for API on $MMShost:$MMSport");
 
-	my $initialized = get( "http://localhost:$MMSport/api/version", 5 );
+	my $initialized = get( "http://$MMShost:$MMSport/api/version", 5 );
 
 	if (defined $initialized) {
 
@@ -169,7 +171,7 @@ sub doneScanning {
 
 	main::INFOLOG && $log->info("Done Scanning");
 
-	my $lastDate = get("http://localhost:$MMSport/api/cacheid?contents");
+	my $lastDate = get("http://$MMShost:$MMSport/api/cacheid?contents");
 
 	if ($lastDate) {
 
@@ -185,6 +187,7 @@ sub exportFunction {
 	my $class = shift;
 
 	$MMSport = $prefs->get('port') unless $MMSport;
+	$MMShost = $prefs->get('host') || 'localhost' unless $MMShost;
 
 	$class->exportSongs;
 	$class->exportPlaylists;
@@ -199,7 +202,7 @@ sub exportSongs {
 	if ($fullRescan == 1 || $prefs->get('musicip') == 1) {
 		main::INFOLOG && $log->info("MusicIP mixable status full scan");
 
-		my $count = get("http://localhost:$MMSport/api/getSongCount");
+		my $count = get("http://$MMShost:$MMSport/api/getSongCount");
 		if ($count) {
 			# convert to integer
 			chomp($count);
@@ -222,7 +225,7 @@ sub exportSongs {
 			main::INFOLOG && $log->info("Fetching ALL song data via songs/extended..");
 
 			my $MMMSongData = catdir( preferences('server')->get('librarycachedir'), 'mmm-song-data.txt' );
-			my $MMMDataURL  = "http://localhost:$MMSport/api/songs?extended";
+			my $MMMDataURL  = "http://$MMShost:$MMSport/api/songs?extended";
 
 			getstore($MMMDataURL, $MMMSongData);
 
@@ -258,7 +261,7 @@ sub exportSongs {
 			unlink($MMMSongData);
 		} else {
 			for (my $scan = 0; $scan <= $count; $scan++) {
-				my $content = get("http://localhost:$MMSport/api/getSong?index=$scan");
+				my $content = get("http://$MMShost:$MMSport/api/getSong?index=$scan");
 
 				$class->processSong($content, $progress);
 			}
@@ -297,7 +300,7 @@ sub exportSongs {
 			my $pathEnc = Slim::Plugin::MusicMagic::Common::escape($path);
 
 			# Set musicmagic_mixable on $track object and call $track->update to actually store it.
-			my $result = get("http://localhost:$MMSport/api/status?song=$pathEnc");
+			my $result = get("http://$MMShost:$MMSport/api/status?song=$pathEnc");
 
 			if ($result =~ /^(\w+)\s+(.*)/) {
 
@@ -489,7 +492,7 @@ sub processSong {
 sub exportPlaylists {
 	my $class = shift;
 
-	my @playlists = split(/\n/, get("http://localhost:$MMSport/api/playlists"));
+	my @playlists = split(/\n/, get("http://$MMShost:$MMSport/api/playlists"));
 
 	if (!scalar @playlists) {
 		return;
@@ -512,7 +515,7 @@ sub exportPlaylists {
 
 		my $listname = Slim::Plugin::MusicMagic::Common::decode($playlists[$i]);
 
-		my $playlist = get("http://localhost:$MMSport/api/getPlaylist?index=$i") || next;
+		my $playlist = get("http://$MMShost:$MMSport/api/getPlaylist?index=$i") || next;
 		my @songs    = split(/\n/, $playlist);
 
 		if ( main::INFOLOG && $log->is_info ) {
@@ -534,7 +537,7 @@ sub exportDuplicates {
 
 	main::INFOLOG && $log->info("Checking for duplicates.");
 
-	my @songs = split(/\n/, get("http://localhost:$MMSport/api/duplicates"));
+	my @songs = split(/\n/, get("http://$MMShost:$MMSport/api/duplicates"));
 
 	$class->_updatePlaylist(string('MUSICIP_DUPLICATES'), \@songs);
 

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -33,8 +33,6 @@ use Slim::Utils::Favorites;
 use constant MENU_WEIGHT => 95;
 
 my $initialized = 0;
-my $MMSport;
-my $MMShost;
 my $canPowerSearch;
 
 my $log = Slim::Utils::Log->addLogCategory({
@@ -144,9 +142,9 @@ sub initPlugin {
 	# but continue if it had never been initialized
 	return unless $enabled || !defined $enabled;
 
-	my $response = _syncHTTPRequest("/api/version");
+	my $response = _syncHTTPRequest("/version");
 
-	main::INFOLOG && $log->info("Testing for API on $MMShost:$MMSport");
+	main::INFOLOG && $log->info("Testing for API on " . Slim::Plugin::MusicMagic::Common::getBaseUrl());
 
 	if ($response->is_error) {
 
@@ -154,7 +152,7 @@ sub initPlugin {
 
 		$prefs->set('musicip', 0) if !defined $enabled;
 
-		$log->error("Can't connect to port $MMSport - MusicIP disabled.");
+		$log->error("Can't connect to " . Slim::Plugin::MusicMagic::Common::getBaseUrl() . " - MusicIP disabled.");
 
 	} else {
 
@@ -170,7 +168,7 @@ sub initPlugin {
 		$prefs->set('musicip', scalar @{ Slim::Utils::Misc::getAudioDirs() } ? 2 : 1)  if !defined $enabled;
 
 		# this query should return an API error if Power Search is not available
-		$response = _syncHTTPRequest("/api/mix?filter=?length>120&length=1");
+		$response = _syncHTTPRequest("/mix?filter=?length>120&length=1");
 
 		if ($response->is_success && $response->content !~ /MusicIP API error/i) {
 			$canPowerSearch = 1;
@@ -420,7 +418,7 @@ sub isMusicLibraryFileChanged {
 		},
 	);
 
-	$http->get( "http://$MMShost:$MMSport/api/cacheid?contents" );
+	$http->get( Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/cacheid?contents' );
 }
 
 sub _statusOK {
@@ -525,7 +523,7 @@ sub _cacheidOK {
 		},
 	);
 
-	$http->get( "http://$MMShost:$MMSport/api/getStatus" );
+	$http->get( Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/getStatus' );
 }
 
 sub _musicipError {
@@ -566,7 +564,7 @@ sub grabMoods {
 		return;
 	}
 
-	my $response = _syncHTTPRequest('/api/moods');
+	my $response = _syncHTTPRequest('/moods');
 
 	if ($response->is_success) {
 
@@ -881,9 +879,9 @@ sub getMix {
 		$validMixTypes{$for} . '=' . Slim::Plugin::MusicMagic::Common::escape($id);
 	} @ids);
 
-	main::DEBUGLOG && $log->debug("Request http://$MMShost:$MMSport/api/mix?$mixArgs\&$argString");
+	main::DEBUGLOG && $log->debug("Request " . Slim::Plugin::MusicMagic::Common::getBaseUrl() . "/mix?$mixArgs\&$argString");
 
-	my $response = _syncHTTPRequest("/api/mix?$mixArgs\&$argString");
+	my $response = _syncHTTPRequest("/mix?$mixArgs\&$argString");
 
 	if ($response->is_error) {
 
@@ -895,7 +893,7 @@ sub getMix {
 
 			$log->warn("No mix returned with filter involved - we might want to try without it");
 			$argString =~ s/filter=/xfilter=/;
-			$response = _syncHTTPRequest("/api/mix?$mixArgs\&$argString");
+			$response = _syncHTTPRequest("/mix?$mixArgs\&$argString");
 
 			Slim::Plugin::MusicMagic::Common->grabFilters();
 		}
@@ -1420,14 +1418,11 @@ sub _objectInfoHandler {
 sub _syncHTTPRequest {
 	my $url = shift;
 
-	$MMSport = $prefs->get('port') unless $MMSport;
-	$MMShost = $prefs->get('host') || 'localhost' unless $MMShost;
-
 	my $http = LWP::UserAgent->new;
 
 	$http->timeout($prefs->get('timeout') || 5);
 
-	return $http->get("http://$MMShost:$MMSport$url");
+	return $http->get(Slim::Plugin::MusicMagic::Common::getBaseUrl() . $url);
 }
 
 # This method is used for the in-process rescanner to update mixable status
@@ -1439,7 +1434,7 @@ sub checkSingleTrack {
 	Slim::Plugin::MusicMagic::Importer->initPlugin();
 
 	my $path   = Slim::Utils::Misc::pathFromFileURL($url);
-	my $apiurl = "http://$MMShost:$MMSport/api/getSong?file=" . uri_escape_utf8($path);
+	my $apiurl = Slim::Plugin::MusicMagic::Common::getBaseUrl() . '/getSong?file=' . uri_escape_utf8($path);
 
 	my $http = Slim::Networking::SimpleAsyncHTTP->new(
 		sub {

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -34,6 +34,7 @@ use constant MENU_WEIGHT => 95;
 
 my $initialized = 0;
 my $MMSport;
+my $MMShost;
 my $canPowerSearch;
 
 my $log = Slim::Utils::Log->addLogCategory({
@@ -145,7 +146,7 @@ sub initPlugin {
 
 	my $response = _syncHTTPRequest("/api/version");
 
-	main::INFOLOG && $log->info("Testing for API on localhost:$MMSport");
+	main::INFOLOG && $log->info("Testing for API on $MMShost:$MMSport");
 
 	if ($response->is_error) {
 
@@ -419,7 +420,7 @@ sub isMusicLibraryFileChanged {
 		},
 	);
 
-	$http->get( "http://localhost:$MMSport/api/cacheid?contents" );
+	$http->get( "http://$MMShost:$MMSport/api/cacheid?contents" );
 }
 
 sub _statusOK {
@@ -524,7 +525,7 @@ sub _cacheidOK {
 		},
 	);
 
-	$http->get( "http://localhost:$MMSport/api/getStatus" );
+	$http->get( "http://$MMShost:$MMSport/api/getStatus" );
 }
 
 sub _musicipError {
@@ -880,7 +881,7 @@ sub getMix {
 		$validMixTypes{$for} . '=' . Slim::Plugin::MusicMagic::Common::escape($id);
 	} @ids);
 
-	main::DEBUGLOG && $log->debug("Request http://localhost:$MMSport/api/mix?$mixArgs\&$argString");
+	main::DEBUGLOG && $log->debug("Request http://$MMShost:$MMSport/api/mix?$mixArgs\&$argString");
 
 	my $response = _syncHTTPRequest("/api/mix?$mixArgs\&$argString");
 
@@ -1420,12 +1421,13 @@ sub _syncHTTPRequest {
 	my $url = shift;
 
 	$MMSport = $prefs->get('port') unless $MMSport;
+	$MMShost = $prefs->get('host') || 'localhost' unless $MMShost;
 
 	my $http = LWP::UserAgent->new;
 
 	$http->timeout($prefs->get('timeout') || 5);
 
-	return $http->get("http://localhost:$MMSport$url");
+	return $http->get("http://$MMShost:$MMSport$url");
 }
 
 # This method is used for the in-process rescanner to update mixable status
@@ -1437,7 +1439,7 @@ sub checkSingleTrack {
 	Slim::Plugin::MusicMagic::Importer->initPlugin();
 
 	my $path   = Slim::Utils::Misc::pathFromFileURL($url);
-	my $apiurl = "http://localhost:$MMSport/api/getSong?file=" . uri_escape_utf8($path);
+	my $apiurl = "http://$MMShost:$MMSport/api/getSong?file=" . uri_escape_utf8($path);
 
 	my $http = Slim::Networking::SimpleAsyncHTTP->new(
 		sub {

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -31,7 +31,7 @@ sub page {
 }
 
 sub prefs {
-	return ($prefs, qw(musicip scan_interval player_settings port mix_filter reject_size reject_type
+	return ($prefs, qw(musicip scan_interval player_settings host port mix_filter reject_size reject_type
 			   mix_genre mix_variety mix_style mix_type mix_size playlist_prefix playlist_suffix));
 }
 

--- a/Slim/Plugin/MusicMagic/strings.txt
+++ b/Slim/Plugin/MusicMagic/strings.txt
@@ -572,10 +572,16 @@ SETUP_MUSICMAGICSCANINTERVAL_DESC
 	ZH_CN	当您的MusicIP数据库改变时，Lyrion Music Server将自动地导入最新音乐库信息。您可以指定Lyrion Music Server再装您的MusicIP数据库之前极小等候时间（以秒为单位）。以零为值意味着关闭再装功能。
 
 SETUP_MMSHOST
+	DE	MusicIP-Host
 	EN	MusicIP Host
+	FR	Hôte MusicIP
+	NL	MusicIP-host
 
 SETUP_MMSHOST_DESC
-	EN	The hostname or IP address of the MusicIP server. Change this if MusicIP is running on a different host than Lyrion Music Server (e.g. in a separate Docker container or VM). Defaults to localhost.
+	DE	Der Hostname oder die IP-Adresse des MusicIP-Servers. Ändern Sie dies, wenn MusicIP auf einem anderen Host als Lyrion Music Server läuft (z. B. in einem separaten Docker-Container oder einer VM). Standardwert: localhost. Hinweis: Die Dateipfade zur Musik müssen auf beiden Hosts identisch sein. Docker-Benutzer sollten Volume-Mounts verwenden, um sicherzustellen, dass dieselben Pfade in beiden Containern sichtbar sind.
+	EN	The hostname or IP address of the MusicIP server. Change this if MusicIP is running on a different host than Lyrion Music Server (e.g. in a separate Docker container or VM). Defaults to localhost. Note: file paths to your music must be identical on both hosts. Docker users should ensure this by using matching volume mount paths in both containers.
+	FR	Le nom d'hôte ou l'adresse IP du serveur MusicIP. Modifiez ce paramètre si MusicIP s'exécute sur un hôte différent de Lyrion Music Server (par exemple dans un conteneur Docker séparé ou une VM). Par défaut : localhost. Remarque : les chemins d'accès aux fichiers musicaux doivent être identiques sur les deux hôtes. Les utilisateurs Docker doivent utiliser des montages de volumes identiques dans les deux conteneurs.
+	NL	De hostnaam of het IP-adres van de MusicIP-server. Wijzig dit als MusicIP op een andere host draait dan Lyrion Music Server (bijv. in een aparte Docker-container of VM). Standaard: localhost. Let op: de bestandspaden naar je muziek moeten identiek zijn op beide hosts. Docker-gebruikers dienen hiervoor overeenkomende volume-mounts in beide containers te gebruiken.
 
 SETUP_MMSPORT
 	CS	HTTP port MusicIP

--- a/Slim/Plugin/MusicMagic/strings.txt
+++ b/Slim/Plugin/MusicMagic/strings.txt
@@ -572,16 +572,42 @@ SETUP_MUSICMAGICSCANINTERVAL_DESC
 	ZH_CN	当您的MusicIP数据库改变时，Lyrion Music Server将自动地导入最新音乐库信息。您可以指定Lyrion Music Server再装您的MusicIP数据库之前极小等候时间（以秒为单位）。以零为值意味着关闭再装功能。
 
 SETUP_MMSHOST
+	CS	MusicIP host
+	DA	MusicIP-host
 	DE	MusicIP-Host
 	EN	MusicIP Host
+	ES	Host de MusicIP
+	FI	MusicIP-isäntä
 	FR	Hôte MusicIP
+	HE	מארח MusicIP
+	HU	MusicIP-kiszolgáló
+	IT	Host MusicIP
 	NL	MusicIP-host
+	NO	MusicIP-vert
+	PL	Host usługi MusicIP
+	PT	Host MusicIP
+	RU	Хост MusicIP
+	SV	MusicIP-värd
+	ZH_CN	MusicIP主机
 
 SETUP_MMSHOST_DESC
+	CS	Název hostitele nebo IP adresa serveru MusicIP. Změňte toto nastavení, pokud MusicIP běží na jiném hostiteli než Lyrion Music Server (např. v samostatném kontejneru Docker nebo VM). Výchozí hodnota je localhost. Poznámka: cesty k hudebním souborům musí být na obou hostitelích identické. Uživatelé Dockeru to mohou zajistit použitím stejných cest pro připojení svazků v obou kontejnerech.
+	DA	Værtsnavn eller IP-adresse på MusicIP-serveren. Skift dette, hvis MusicIP kører på en anden vært end Lyrion Music Server (f.eks. i en separat Docker-container eller VM). Standard er localhost. Bemærk: filstier til din musik skal være identiske på begge værter. Docker-brugere bør sikre dette ved at bruge matchende volume-monteringsstier i begge containere.
 	DE	Der Hostname oder die IP-Adresse des MusicIP-Servers. Ändern Sie dies, wenn MusicIP auf einem anderen Host als Lyrion Music Server läuft (z. B. in einem separaten Docker-Container oder einer VM). Standardwert: localhost. Hinweis: Die Dateipfade zur Musik müssen auf beiden Hosts identisch sein. Docker-Benutzer sollten Volume-Mounts verwenden, um sicherzustellen, dass dieselben Pfade in beiden Containern sichtbar sind.
 	EN	The hostname or IP address of the MusicIP server. Change this if MusicIP is running on a different host than Lyrion Music Server (e.g. in a separate Docker container or VM). Defaults to localhost. Note: file paths to your music must be identical on both hosts. Docker users should ensure this by using matching volume mount paths in both containers.
+	ES	El nombre de host o la dirección IP del servidor MusicIP. Cambie esto si MusicIP se ejecuta en un host diferente al de Lyrion Music Server (p. ej., en un contenedor Docker separado o en una VM). El valor predeterminado es localhost. Nota: las rutas de los archivos de música deben ser idénticas en ambos hosts. Los usuarios de Docker deben garantizarlo usando rutas de montaje de volumen coincidentes en ambos contenedores.
+	FI	MusicIP-palvelimen isäntänimi tai IP-osoite. Muuta tätä, jos MusicIP toimii eri isännällä kuin Lyrion Music Server (esim. erillisessä Docker-säiliössä tai VM:ssä). Oletusarvo on localhost. Huomio: musiikkitiedostojen polkujen täytyy olla identtiset molemmilla isännillä. Docker-käyttäjien tulee varmistaa tämä käyttämällä vastaavia volume-liitospolkuja molemmissa säiliöissä.
 	FR	Le nom d'hôte ou l'adresse IP du serveur MusicIP. Modifiez ce paramètre si MusicIP s'exécute sur un hôte différent de Lyrion Music Server (par exemple dans un conteneur Docker séparé ou une VM). Par défaut : localhost. Remarque : les chemins d'accès aux fichiers musicaux doivent être identiques sur les deux hôtes. Les utilisateurs Docker doivent utiliser des montages de volumes identiques dans les deux conteneurs.
+	HE	שם המארח או כתובת ה-IP של שרת MusicIP. שנה זאת אם MusicIP פועל במארח שונה מ-Lyrion Music Server (למשל, בקונטיינר Docker נפרד או VM). ברירת המחדל היא localhost. הערה: נתיבי הקבצים של המוזיקה חייבים להיות זהים בשני המארחים. משתמשי Docker צריכים להבטיח זאת על ידי שימוש בנתיבי עיגון כרכים תואמים בשני הקונטיינרים.
+	HU	A MusicIP-kiszolgáló gazdaneve vagy IP-címe. Módosítsa ezt, ha a MusicIP a Lyrion Music Servertől eltérő kiszolgálón fut (pl. külön Docker-tárolóban vagy VM-ben). Alapértelmezett érték: localhost. Megjegyzés: a zenefájlok elérési útjának mindkét kiszolgálón azonosnak kell lennie. Docker-felhasználóknak ezt a megfelelő kötetkötési útvonalak mindkét tárolóban való használatával kell biztosítaniuk.
+	IT	Il nome host o l'indirizzo IP del server MusicIP. Modificare questa impostazione se MusicIP è in esecuzione su un host diverso da Lyrion Music Server (ad es. in un contenitore Docker separato o in una VM). Il valore predefinito è localhost. Nota: i percorsi dei file musicali devono essere identici su entrambi gli host. Gli utenti Docker devono garantirlo utilizzando percorsi di montaggio del volume corrispondenti in entrambi i contenitori.
 	NL	De hostnaam of het IP-adres van de MusicIP-server. Wijzig dit als MusicIP op een andere host draait dan Lyrion Music Server (bijv. in een aparte Docker-container of VM). Standaard: localhost. Let op: de bestandspaden naar je muziek moeten identiek zijn op beide hosts. Docker-gebruikers dienen hiervoor overeenkomende volume-mounts in beide containers te gebruiken.
+	NO	Vertsnavn eller IP-adresse til MusicIP-serveren. Endre dette hvis MusicIP kjører på en annen vert enn Lyrion Music Server (f.eks. i en egen Docker-container eller VM). Standard er localhost. Merk: filbaner til musikken din må være identiske på begge verter. Docker-brukere bør sikre dette ved å bruke samsvarende volummonteringsstier i begge containerne.
+	PL	Nazwa hosta lub adres IP serwera MusicIP. Zmień to ustawienie, jeśli MusicIP działa na innym hoście niż Lyrion Music Server (np. w osobnym kontenerze Docker lub maszynie wirtualnej). Domyślna wartość to localhost. Uwaga: ścieżki do plików muzycznych muszą być identyczne na obu hostach. Użytkownicy Dockera powinni to zapewnić, używając identycznych ścieżek montowania woluminów w obu kontenerach.
+	PT	O nome do host ou o endereço IP do servidor MusicIP. Altere isto se o MusicIP estiver a ser executado num host diferente do Lyrion Music Server (por exemplo, num contentor Docker separado ou numa VM). A predefinição é localhost. Nota: os caminhos dos ficheiros de música têm de ser idênticos em ambos os hosts. Os utilizadores de Docker devem garantir isso utilizando caminhos de montagem de volume correspondentes em ambos os contentores.
+	RU	Имя хоста или IP-адрес сервера MusicIP. Измените это, если MusicIP работает на другом хосте, отличном от Lyrion Music Server (например, в отдельном контейнере Docker или виртуальной машине). По умолчанию используется localhost. Примечание: пути к музыкальным файлам должны быть одинаковыми на обоих хостах. Пользователям Docker необходимо обеспечить это с помощью совпадающих путей монтирования томов в обоих контейнерах.
+	SV	Värdnamnet eller IP-adressen för MusicIP-servern. Ändra detta om MusicIP körs på en annan värd än Lyrion Music Server (t.ex. i en separat Docker-container eller VM). Standard är localhost. Obs: filsökvägarna till din musik måste vara identiska på båda värdarna. Docker-användare bör säkerställa detta genom att använda matchande volymmonterade sökvägar i båda containrarna.
+	ZH_CN	MusicIP服务器的主机名或IP地址。如果MusicIP运行在与Lyrion Music Server不同的主机上（例如在单独的Docker容器或虚拟机中），请更改此设置。默认为localhost。注意：音乐文件路径在两台主机上必须完全相同。Docker用户应通过在两个容器中使用相同的卷挂载路径来确保这一点。
 
 SETUP_MMSPORT
 	CS	HTTP port MusicIP

--- a/Slim/Plugin/MusicMagic/strings.txt
+++ b/Slim/Plugin/MusicMagic/strings.txt
@@ -571,6 +571,12 @@ SETUP_MUSICMAGICSCANINTERVAL_DESC
 	SV	När din MusicIP-databas ändras importeras biblioteksinformationen automatiskt till Lyrion Music Server. Du kan ange en minimitid (i sekunder) som Lyrion Music Server ska vänta mellan varje gång informationen från MusicIP-databasen uppdateras. Om värdet 0 anges avaktiveras uppdateringsfunktionen.
 	ZH_CN	当您的MusicIP数据库改变时，Lyrion Music Server将自动地导入最新音乐库信息。您可以指定Lyrion Music Server再装您的MusicIP数据库之前极小等候时间（以秒为单位）。以零为值意味着关闭再装功能。
 
+SETUP_MMSHOST
+	EN	MusicIP Host
+
+SETUP_MMSHOST_DESC
+	EN	The hostname or IP address of the MusicIP server. Change this if MusicIP is running on a different host than Lyrion Music Server (e.g. in a separate Docker container or VM). Defaults to localhost.
+
 SETUP_MMSPORT
 	CS	HTTP port MusicIP
 	DA	MusicIP HTTP-port


### PR DESCRIPTION
# MusicMagic: Add configurable host for remote MusicIP instances

## Problem

The MusicMagic plugin hardcodes `localhost` in all HTTP requests to the MusicIP
Mixer API across three files (`Plugin.pm`, `Importer.pm`, `Common.pm`). This
makes it impossible to use MusicIP when it is running on a different host than
LMS — a common scenario when both are running in separate Docker containers,
VMs, or separate machines.

Users in this situation see:

```
Can't connect to port 10002 - MusicIP disabled.
```

even when MusicIP is running and reachable, because all requests go to
`localhost` inside the LMS process/container rather than to the actual MusicIP
host.

## Solution

This change adds a `host` preference to the MusicMagic plugin, read via
`$prefs->get('host')`, defaulting to `'localhost'` when not set. This is
consistent with how the existing `port` preference works and is fully backwards
compatible — existing installations with MusicIP on the same host require no
configuration changes.

The host can be configured via the MusicMagic settings page in the LMS web
interface (a new **MusicIP Host** field, added alongside the existing port
field). It can also be set directly in `<config dir>/prefs/plugin/musicip.prefs`:

```yaml
host: <hostname-or-ip>
```

For example, in a Docker environment where MusicIP runs in a container named
`musicip`:

```yaml
host: musicip
port: 10002
```

## Files changed

- `Slim/Plugin/MusicMagic/Plugin.pm` — adds `$MMShost` variable, reads from
  prefs in `_syncHTTPRequest`, replaces all `localhost` URL references
- `Slim/Plugin/MusicMagic/Importer.pm` — adds `$MMShost` variable, reads from
  prefs in `initPlugin` and `startScan`, replaces all `localhost` URL references
- `Slim/Plugin/MusicMagic/Common.pm` — reads `host` from prefs as a local
  variable in `grabFilters`, replaces `localhost` URL reference
- `Slim/Plugin/MusicMagic/Settings.pm` — adds `host` to the list of managed
  preferences so the settings page reads and writes it
- `Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html`
  — adds a **MusicIP Host** input field above the existing port field; defaults
  to `localhost` when the preference has not been set
- `Slim/Plugin/MusicMagic/strings.txt` — adds `SETUP_MMSHOST` and
  `SETUP_MMSHOST_DESC` string keys (EN only; translations welcome)

## Testing

Tested on LMS v9.1.1 with MusicIP Mixer 1.8, both running in separate Docker
containers on a Synology NAS connected via a custom Docker bridge network.
MusicIP import scan completes successfully and song context menu options appear
as expected.