### PR TITLE
Schema: order matters when loading DBIx::Class::Schema classes

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -165,22 +165,23 @@ sub init {
 
 	# Load the DBIx::Class::Schema classes we've defined.
 	# If you add a class to the schema, you must add it here as well.
+	# Order matters with newer DBIx versions
 	$class->load_classes(qw/
 		Album
-		Comment
 		Contributor
-		ContributorAlbum
-		ContributorTrack
+		Work
 		Genre
-		GenreTrack
-		LibraryTrack
 		MetaInformation
 		Playlist
 		PlaylistTrack
 		Track
+		Comment
+		ContributorAlbum
+		ContributorTrack
+		GenreTrack
+		LibraryTrack
 		Year
 		Progress
-		Work
 		Composer
 	/);
 	$class->load_classes('TrackPersistent') unless (!main::STATISTICS);


### PR DESCRIPTION
When using newer DBIx versions the order where classes are loaded matters. When the order isn't correct the following error (or variants of it) occurs (at least during rescanning):

Slim::Schema::throw_exception (298) Error:
DBIx::Class::Relationship::BelongsTo::catch {...} (): Foreign class 'Slim::Schema::Track' does not seem to be a Result class (or it simply did not load entirely due to a circular relation chain) at /usr/share/perl5/Slim/Schema/Comment.pm line 16

I don't know *exactly* what determines the right order, but by ensuring Slim::Schema::Track is loaded before classes that fail, I got an error free order.