### PR TITLE
Set RPM Vendor tag in build workflow

### DIFF
--- a/.github/workflows/00_build.yaml
+++ b/.github/workflows/00_build.yaml
@@ -99,6 +99,7 @@ jobs:
         if: ${{ matrix.flavour[0] == 'rpm' }}
         run: |
           dnf install -y git rpm-build rpmdevtools systemd-rpm-macros rsync jq unzip perl which
+          echo "%vendor Lyrion Community" >> /etc/rpm/macros
 
       # we must check out here, as  otherwise the build action is not available
       - name: Check out LMS code


### PR DESCRIPTION
It’s better to set this here in the build environment rather than hard-code it into the `.spec` file as we previously did (see associated commit to the `slimserver-platforms` repository).