### PR TITLE
Work around ARMv6 SIGILL in arm deb startup

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -49,6 +49,16 @@ runs:
         path: platforms
         ref: ${{ steps.getversion.outputs.GIT_BRANCH }}
 
+    - name: Apply LMS platform build patches
+      shell: bash
+      run: |
+        if compgen -G "server/.github/patches/slimserver-platforms-*.patch" > /dev/null; then
+          for patch_file in server/.github/patches/slimserver-platforms-*.patch; do
+            echo "Applying $patch_file"
+            patch -d platforms -p1 < "$patch_file"
+          done
+        fi
+
 
     - name: Check out pCP platform code
       if: ${{ startsWith(inputs.build-params, 'pcp') }}

--- a/.github/patches/slimserver-platforms-armv6-dbd-sqlite.patch
+++ b/.github/patches/slimserver-platforms-armv6-dbd-sqlite.patch
@@ -1,0 +1,23 @@
+diff --git a/buildme.pl b/buildme.pl
+--- a/buildme.pl
++++ b/buildme.pl
+@@ -33,7 +33,7 @@ my $dirsToExcludeForLinuxPackage = "$dirsToExcludeForLinuxTarball 5.10 5.12 5.1
+ my $dirsToExcludeForFreeBSDTarball = "MSWin32-x86-multi-thread MSWin32-x64-multi-thread PreventStandby i386-linux x86_64-linux i86pc-solaris-thread-multi-64int darwin darwin-x86_64 sparc-linux arm-linux armhf-linux powerpc-linux aarch64-linux icudt46b.dat";
+ my $dirsToExcludeForARMTarball = "MSWin32-x86-multi-thread MSWin32-x64-multi-thread PreventStandby i386-linux x86_64-linux i86pc-solaris-thread-multi-64int darwin darwin-x86_64 sparc-linux i386-freebsd-64int powerpc-linux icudt46b.dat icudt58b.dat";
+ my $dirsToExcludeForPPCTarball = "MSWin32-x86-multi-thread MSWin32-x64-multi-thread PreventStandby i386-linux x86_64-linux i86pc-solaris-thread-multi-64int darwin darwin-x86_64 sparc-linux arm-linux armhf-linux i386-freebsd-64int aarch64-linux icudt46l.dat icudt58l.dat";
+-my $dirsToExcludeForARMDeb = "$dirsToExcludeForARMTarball 5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 5.26 5.38 5.42";
++my $dirsToExcludeForARMDeb = "$dirsToExcludeForARMTarball 5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 5.26 5.38 5.42 CPAN/DBI.pm CPAN/DBI/ CPAN/arch/.*/DBI.pm CPAN/arch/.*/DBI/ auto/DBI/ CPAN/DBD/SQLite CPAN/arch/.*/DBD/SQLite.pm CPAN/arch/.*/DBD/SQLite auto/DBD/SQLite";
+ my $dirsToExcludeForx86_64Deb = "5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.24 5.26 MSWin32-x86-multi-thread MSWin32-x64-multi-thread PreventStandby i386-linux i86pc-solaris-thread-multi-64int darwin darwin-x86_64 sparc-linux arm-linux armhf-linux i386-freebsd-64int powerpc-linux aarch64-linux icudt46b.dat icudt58b.dat";
+ my $dirsToExcludeFori386Deb = "5.10 5.12 5.14 5.16 5.18 5.20 5.22 5.28 5.30 5.32 5.34 5.36 5.38 5.40 5.42 MSWin32-x86-multi-thread MSWin32-x64-multi-thread PreventStandby x86_64-linux i86pc-solaris-thread-multi-64int darwin darwin-x86_64 sparc-linux arm-linux armhf-linux i386-freebsd-64int powerpc-linux aarch64-linux icudt46b.dat icudt58b.dat";
+ my $dirsToExcludeForLinuxNoCpanTarball = "i386-freebsd-64int MSWin32-x86-multi-thread MSWin32-x64-multi-thread i86pc-solaris-thread-multi-64int darwin darwin-x86_64 i386-linux sparc-linux x86_64-linux arm-linux armhf-linux powerpc-linux aarch64-linux /arch/ PreventStandby";
+diff --git a/debian/control b/debian/control
+--- a/debian/control
++++ b/debian/control
+@@ -8,7 +8,7 @@ Architecture: all
+ Conflicts: slimp3,slimserver,squeezecenter,squeezeboxserver,logitechmediaserver
+ Replaces: slimp3,slimserver,squeezecenter,squeezeboxserver,logitechmediaserver
+-Depends: ${misc:Depends}, perl (>= 5.14.0), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates, libcrypt-openssl-rsa-perl, procps, psmisc
++Depends: ${misc:Depends}, perl (>= 5.14.0), adduser, libc6, libgcc1, libstdc++6, zlib1g, libio-socket-ssl-perl, ca-certificates, libcrypt-openssl-rsa-perl, libdbi-perl, libdbd-sqlite3-perl, procps, psmisc
+ Pre-Depends: ${misc:Pre-Depends}
+ Description: Streaming Audio Server
+  Lyrion Music Server is a cross-platform streaming media server that supports a wide range


### PR DESCRIPTION
Fixes #1534.

This PR starts addressing the ARMv6 startup crash seen on Raspberry Pi 1 with the arm deb.

Test findings:
- On the affected host, Perl is 5.32.1 with archname arm-linux-gnueabihf-thread-multi-64int.
- Loading Audio::Scan from the bundled armhf Perl 5.32 path triggers SIGILL.
- Rebuilding a test arm deb with the 9.0.3 ARM Audio::Scan 1.06 artifact avoids that specific illegal-instruction crash.
- DBI/DBD::SQLite were also tested via system packages to rule out the earlier SQLite suspicion.

This patch adds a mechanism to patch slimserver-platforms during the build and adjusts the arm deb packaging path to avoid bundled DBI/SQLite XS conflicts. The remaining production fix should rebuild the ARM Audio::Scan artifact with an ARMv6-compatible baseline or restore a compatible artifact for arm deb builds.