### PR TITLE
Include album-link roles in unified artist list roles

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -378,7 +378,7 @@ sub albumsQuery {
 					push @roles, 'ARTIST' if $roleID eq 'ALBUMARTIST' && !$prefs->get('useUnifiedArtistsList');
 				}
 				elsif ($prefs->get('useUnifiedArtistsList')) {
-					@roles = Slim::Schema::Contributor->activeContributorRoles(1);
+					@roles = Slim::Utils::Misc::uniq(Slim::Schema::Contributor->activeContributorRoles(1), Slim::Schema::Contributor->allAlbumLinkRoles());
 				}
 				else {
 					@roles = Slim::Schema::Contributor->contributorRoles();


### PR DESCRIPTION
If the user is using the combined artist list, the albums query submitted when clicking a contributor name in the albums listing might fail to return results because the results are limited to the roles selected for the combined artist list.

This occurs if the name link in the albums list is present because of a role selected in the preference "artist links in album lists" but the same role is not selected in the unified list pref.

This fix adds adds the "album links" roles to the "unified list roles" in queries for a specific contributor with no role(s) specified.

See test results from @mikeysas here https://forums.lyrion.org/forum/user-forums/3rd-party-software/1828117-material-skin-shortcut-to-publisher-not-working?p=1828340#post1828340
