### PR TITLE
MusicMagic: add genre exclusion filter for MusicIP mixes

### DIFF
--- a/Slim/Plugin/MusicMagic/ClientSettings.pm
+++ b/Slim/Plugin/MusicMagic/ClientSettings.pm
@@ -50,8 +50,20 @@ sub handler {
 		return undef;
 	}
 
+	my $cprefs = $prefs->client($client);
 
-	$params->{'filters'} = Slim::Plugin::MusicMagic::Common->getFilterList();
+	if ( $params->{'saveSettings'} ) {
+
+		my $selected = $params->{'pref_mix_genre_filter'};
+		my @genres   = ref $selected eq 'ARRAY' ? @$selected : (defined $selected ? ($selected) : ());
+
+		$cprefs->set('mix_genre_filter', \@genres);
+	}
+
+	$params->{'filters'}    = Slim::Plugin::MusicMagic::Common->getFilterList();
+	$params->{'genre_list'} = Slim::Plugin::MusicMagic::Common::getGenreList();
+
+	$params->{'prefs'}->{'pref_mix_genre_filter'} = { map { $_ => 1 } @{ $cprefs->get('mix_genre_filter') || [] } };
 
 	return $class->SUPER::handler($client, $params);
 }

--- a/Slim/Plugin/MusicMagic/Common.pm
+++ b/Slim/Plugin/MusicMagic/Common.pm
@@ -64,6 +64,7 @@ sub checkDefaults {
 		mix_style       => 20,
 		mix_variety     => 0,
 		mix_genre       => 0,
+		mix_genre_filter => [],
 		mix_size        => 12,
 		reject_size     => 12,
 		reject_type     => 0,
@@ -72,6 +73,12 @@ sub checkDefaults {
 		scan_interval   => 3600,
 		port            => 10002,
 	}, 'Slim::Plugin::MusicMagic::Prefs');
+}
+
+sub getGenreList {
+	my @genres = map { $_->name } Slim::Schema->rs('Genre')->search(undef, { order_by => 'me.namesort' })->all;
+
+	return \@genres;
 }
 
 sub getBaseUrl {

--- a/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
+++ b/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
@@ -78,6 +78,18 @@
 			</select>
 		[% END %]
 
+		[% WRAPPER settingGroup title="SETUP_MIX_GENRE_FILTER" desc="SETUP_MIX_GENRE_FILTER_DESC" %]
+			<select class="stdedit" name="pref_mix_genre_filter" id="mix_genre_filter" multiple="multiple" size="8">
+
+			[% FOREACH genre = genre_list %]
+
+				<option [% IF prefs.pref_mix_genre_filter.item(genre) %]selected [% END %]value="[% genre | html %]">[% genre | html %]</option>
+
+			[%- END -%]
+
+			</select>
+		[% END %]
+
 	[% END %]
 
 	[% WRAPPER settingSection %]

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -865,6 +865,19 @@ sub getMix {
 		$args{'filter'} = Slim::Plugin::MusicMagic::Common::escape($filter);
 	}
 
+	my $genreFilter = defined $client ?
+		($prefs->client($client)->get('mix_genre_filter') || $prefs->get('mix_genre_filter')) :
+		$prefs->get('mix_genre_filter');
+
+	my %genreFilterHash = map { lc($_) => 1 } @{ $genreFilter || [] };
+
+	# genre exclusion happens after MusicIP has already picked the mix, so it can leave us
+	# short of the requested size - ask for extra up front so we've got a top-up pool to draw from
+	my $requestedSize = $args{'size'};
+	my $canTopUp = %genreFilterHash && $requestedSize && $args{'sizetype'} eq 'tracks';
+
+	$args{'size'} = $requestedSize * 3 if $canTopUp;
+
 	my $argString = join( '&', map { "$_=$args{$_}" } keys %args );
 
 	if (!$validMixTypes{$for}) {
@@ -920,13 +933,36 @@ sub getMix {
 		}
 
 		if ( -e $songs[$j] || -e Slim::Utils::Unicode::utf8encode_locale($songs[$j]) ) {
-			push @mix, Slim::Utils::Misc::fileURLFromPath($songs[$j]);
+
+			my $url = Slim::Utils::Misc::fileURLFromPath($songs[$j]);
+
+			if (%genreFilterHash && _trackHasExcludedGenre($url, \%genreFilterHash)) {
+				next;
+			}
+
+			push @mix, $url;
 		} else {
 			$log->error('MIP attempted to mix in a song at ' . $songs[$j] . ' that can\'t be found at that location');
 		}
+
+		last if $canTopUp && scalar(@mix) >= $requestedSize;
 	}
 
 	return \@mix;
+}
+
+sub _trackHasExcludedGenre {
+	my ($url, $genreFilterHash) = @_;
+
+	my $trackObj = Slim::Schema->objectForUrl($url);
+
+	return 0 unless blessed($trackObj) && $trackObj->can('genres');
+
+	for my $genre ($trackObj->genres) {
+		return 1 if $genreFilterHash->{lc $genre->name};
+	}
+
+	return 0;
 }
 
 sub musicmagic_moods {

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -45,7 +45,18 @@ sub handler {
 		return undef;
 	}
 
-	$params->{'filters'} = Slim::Plugin::MusicMagic::Common->getFilterList();
+	if ( $params->{'saveSettings'} ) {
+
+		my $selected = $params->{'pref_mix_genre_filter'};
+		my @genres   = ref $selected eq 'ARRAY' ? @$selected : (defined $selected ? ($selected) : ());
+
+		$prefs->set('mix_genre_filter', \@genres);
+	}
+
+	$params->{'filters'}    = Slim::Plugin::MusicMagic::Common->getFilterList();
+	$params->{'genre_list'} = Slim::Plugin::MusicMagic::Common::getGenreList();
+
+	$params->{'prefs'}->{'pref_mix_genre_filter'} = { map { $_ => 1 } @{ $prefs->get('mix_genre_filter') || [] } };
 
 	return $class->SUPER::handler($client, $params);
 }

--- a/Slim/Plugin/MusicMagic/strings.txt
+++ b/Slim/Plugin/MusicMagic/strings.txt
@@ -158,6 +158,42 @@ SETUP_MIX_FILTER_DESC
 	SV	Du kan skapa olika uppsättningar filtervilkor i MusicIP och sedan använda dem med MusicIP Mix i Lyrion Music Server. Välj filter i listan.
 	ZH_CN	您可以利用MusicIP设立过滤器，并且从这表中选择应用在Lyrion Music Server内MusicIP混音的那些过滤器。
 
+SETUP_MIX_GENRE_FILTER
+	CS	Vyloučené žánry
+	DA	Udelukkede genrer
+	DE	Ausgeschlossene Musikstile
+	EN	Excluded Genres
+	ES	Géneros excluidos
+	FI	Poissuljetut genret
+	FR	Genres exclus
+	HE	סגנונות מוחרגים
+	HU	Kizárt műfajok
+	IT	Generi esclusi
+	NL	Uitgesloten genres
+	NO	Ekskluderte sjangre
+	PL	Wykluczone gatunki
+	RU	Исключённые жанры
+	SV	Exkluderade genrer
+	ZH_CN	排除的曲风
+
+SETUP_MIX_GENRE_FILTER_DESC
+	CS	Vyberte jeden nebo více žánrů z vaší hudební knihovny, které chcete vyloučit z MusicIP mixů. Pokud nevyberete žádný, budou povoleny všechny žánry.
+	DA	Vælg en eller flere genrer fra dit musikbibliotek, som skal udelukkes fra MusicIP-miks. Lad intet være valgt for at tillade alle genrer.
+	DE	Wählen Sie eine oder mehrere Musikstile aus Ihrer Musikbibliothek aus, die aus MusicIP-Mixes ausgeschlossen werden sollen. Wenn nichts ausgewählt ist, sind alle Musikstile zulässig.
+	EN	Select one or more genres from your music library to exclude from MusicIP Mixes. Leave nothing selected to allow all genres.
+	ES	Seleccione uno o más géneros de su biblioteca musical para excluirlos de las mezclas de MusicIP. Si no selecciona ninguno, se permitirán todos los géneros.
+	FI	Valitse musiikkikirjastostasi yksi tai useampi genre, jotka suljetaan pois MusicIP-mikseistä. Jos et valitse mitään, kaikki genret ovat sallittuja.
+	FR	Sélectionnez un ou plusieurs genres de votre bibliothèque musicale à exclure des mix MusicIP. Ne sélectionnez rien pour autoriser tous les genres.
+	HE	בחר סגנון אחד או יותר מספריית המוזיקה שלך שיוחרגו ממיקסים של MusicIP. אם לא תבחר דבר, כל הסגנונות יהיו מותרים.
+	HU	Válasszon ki egy vagy több műfajt a zenei könyvtárából, amelyeket ki szeretne zárni a MusicIP-keverékekből. Ha nem választ ki semmit, minden műfaj engedélyezett lesz.
+	IT	Selezionare uno o più generi dalla libreria musicale da escludere dalle raccolte MusicIP. Se non si seleziona nulla, saranno consentiti tutti i generi.
+	NL	Selecteer een of meer genres uit je muziekbibliotheek die je wilt uitsluiten van MusicIP-mixen. Als je niets selecteert, zijn alle genres toegestaan.
+	NO	Velg én eller flere sjangre fra musikkbiblioteket ditt som skal ekskluderes fra MusicIP-mikser. La ingenting være valgt for å tillate alle sjangre.
+	PL	Wybierz jeden lub kilka gatunków z biblioteki muzycznej, które mają być wykluczone ze składanek MusicIP. Jeśli nic nie zostanie wybrane, dozwolone będą wszystkie gatunki.
+	RU	Выберите один или несколько жанров из вашей музыкальной библиотеки, которые нужно исключить из миксов MusicIP. Если ничего не выбрано, разрешены все жанры.
+	SV	Välj en eller flera genrer från ditt musikbibliotek som ska exkluderas från MusicIP-mix. Lämna inget markerat om du vill tillåta alla genrer.
+	ZH_CN	从您的音乐库中选择一个或多个要从MusicIP混音中排除的曲风。如果不选择任何曲风，则允许所有曲风。
+
 SETUP_MIX_GENRE
 	CS	Mix žánru
 	DA	Miks: Genre


### PR DESCRIPTION
## Summary
- Adds an "Excluded Genres" multi-select (global and per-player) that filters MusicIP mix results against the genres already in your local Lyrion library, so you can keep specific genres out of any mix regardless of seed.
- Since MusicIP has already picked the mix before this exclusion is applied locally, the mix request now asks for extra tracks up front and trims back to the configured size, so excluding genres doesn't leave you with a short mix.
- Adds full translations for the new setting strings (CS/DA/DE/ES/FI/FR/HE/HU/IT/NL/NO/PL/RU/SV/ZH_CN).

## Why not the existing "Mix Filter" setting?
MusicMagic already has a "Mix Filter" option, but it doesn't cover this case:
- It applies a single named filter that has to be predefined inside the standalone MusicIP Mixer desktop app itself (fetched via MusicIP's `/filters` API) — there's no way to build or edit one from within Lyrion, and it's one filter at a time, not an arbitrary combinable set of genres.
- MusicIP also supports inline "Power Search" filter expressions (e.g. `?genre==Rock`) that could in principle express a genre condition, but Power Search is an advanced MusicIP feature gated behind an active MusicIP registration/license key, so it's unavailable to a chunk of users and would fail silently for them.
- Genre matching against MusicIP's own tag data also isn't guaranteed to line up with how a track's genre(s) are recorded in the local library.

This feature instead reads genres directly from the local library (the same list you already browse/see in Lyrion), needs no MusicIP-side setup or paid registration, and supports selecting any number of genres to exclude.

## Test plan
- [x] Verified settings save/load correctly for both the global and per-player MusicMagic settings pages
- [x] Verified excluded genres are correctly dropped from mix results
- [x] Verified mixes are topped back up to the configured size after exclusion
- [x] Manually tested end-to-end against a running lmscommunity/lyrionmusicserver Docker instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)