### PR TITLE
Fix unsafe access for folder array

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -2937,7 +2937,7 @@ sub playlistsQuery {
 		my $chunkCount = 0;
 
 		if ($start < $folderCount) {
-			while ($chunkCount <= $end && $chunkCount < $folderCount) {
+			while ($chunkCount <= $end && $start + $chunkCount < $folderCount) {
 				my $item = $folders[$start + $chunkCount];
 
 				$request->addResultLoop($loopname, $chunkCount, "id", $item->{url});


### PR DESCRIPTION
Hello LMS community!

I've been reading the source code of the slim server CLI to attempt a reimplementation (with the help of an LLM since I'm learning Perl as I go), and the LLM pointed out a bug in the `playlists` query — what I believe is a case of unsafe array access. Thought I'd submit a fix!