### PR TITLE
Switch from JSON::XS::VersionOneAndTwo to JSON::XS

### DIFF
--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -29,7 +29,7 @@ use strict;
 use Scalar::Util qw(blessed looks_like_number);
 use File::Spec::Functions qw(catfile);
 use File::Basename qw(basename dirname);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Utils::Alarm;
 use Slim::Utils::Log;
@@ -427,7 +427,7 @@ sub disconnectCommand {
 		{ timeout => 10 }
 	);
 
-	my $postdata = to_json({
+	my $postdata = encode_json({
 		id     => 1,
 		method => 'slim.request',
 		params => [ $remoteClient, ['connect', Slim::Utils::Network::hostAddr()] ]

--- a/Slim/Control/Commands.pm
+++ b/Slim/Control/Commands.pm
@@ -29,7 +29,7 @@ use strict;
 use Scalar::Util qw(blessed looks_like_number);
 use File::Spec::Functions qw(catfile);
 use File::Basename qw(basename dirname);
-use JSON::XS;
+use JSON::XS qw(encode_json);
 
 use Slim::Utils::Alarm;
 use Slim::Utils::Log;

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -33,7 +33,7 @@ use strict;
 use File::Basename qw(basename);
 use File::Spec::Functions qw(catdir);
 use Storable ();
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use List::Util qw(first max min);
 use MIME::Base64 ();
 use Scalar::Util qw(blessed);

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -33,7 +33,6 @@ use strict;
 use File::Basename qw(basename);
 use File::Spec::Functions qw(catdir);
 use Storable ();
-use JSON::XS;
 use List::Util qw(first max min);
 use MIME::Base64 ();
 use Scalar::Util qw(blessed);

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -12,7 +12,7 @@ package Slim::Formats::XML;
 use strict;
 use File::Slurp;
 use HTML::Entities;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(weaken);
 use URI::Escape qw(uri_escape_utf8);
 use XML::Simple;
@@ -300,7 +300,7 @@ sub parseXMLIntoFeed {
 	my $xml;
 
 	if ( $type =~ /json/ ) {
-		$xml = from_json($$content);
+		$xml = decode_json($$content);
 	}
 	else {
 		$xml = xmlToHash($content);

--- a/Slim/Formats/XML.pm
+++ b/Slim/Formats/XML.pm
@@ -12,7 +12,7 @@ package Slim::Formats::XML;
 use strict;
 use File::Slurp;
 use HTML::Entities;
-use JSON::XS;
+use JSON::XS qw(decode_json);
 use Scalar::Util qw(weaken);
 use URI::Escape qw(uri_escape_utf8);
 use XML::Simple;

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -151,7 +151,7 @@ should be passed a reference to a real sub (not an anonymous one).
 
 
 use strict;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Menu::BrowseLibrary::Releases;
 use Slim::Menu::BrowseLibrary::Works;

--- a/Slim/Menu/BrowseLibrary.pm
+++ b/Slim/Menu/BrowseLibrary.pm
@@ -151,7 +151,6 @@ should be passed a reference to a real sub (not an anonymous one).
 
 
 use strict;
-use JSON::XS;
 
 use Slim::Menu::BrowseLibrary::Releases;
 use Slim::Menu::BrowseLibrary::Works;

--- a/Slim/Networking/Discovery/Players.pm
+++ b/Slim/Networking/Discovery/Players.pm
@@ -10,7 +10,7 @@ package Slim::Networking::Discovery::Players;
 
 use strict;
 
-use JSON::XS;
+use JSON::XS qw(decode_json encode_json);
 
 use Slim::Control::Request;
 use Slim::Networking::Discovery::Server;

--- a/Slim/Networking/Discovery/Players.pm
+++ b/Slim/Networking/Discovery/Players.pm
@@ -10,7 +10,7 @@ package Slim::Networking::Discovery::Players;
 
 use strict;
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Control::Request;
 use Slim::Networking::Discovery::Server;
@@ -95,7 +95,7 @@ sub fetch_players {
 		}
 	);
 
-	my $postdata = to_json({
+	my $postdata = encode_json({
 		id     => 1,
 		method => 'slim.request',
 		params => [ '', ['players', 0, 999] ]
@@ -108,7 +108,7 @@ sub _players_done {
 	my $http   = shift;
 	my $server = $http->params('server');
 
-	my $res = eval { from_json( $http->content ) };
+	my $res = eval { decode_json( $http->content ) };
 
 	if ( $@ || ref $res ne 'HASH' || $res->{error} ) {
 		# don't log the same error more than once a day

--- a/Slim/Plugin/Analytics/Plugin.pm
+++ b/Slim/Plugin/Analytics/Plugin.pm
@@ -4,7 +4,7 @@ use strict;
 
 use Config;
 use Digest::SHA1 qw(sha1_base64);
-use JSON::XS;
+use JSON::XS qw(encode_json);
 use List::Util qw(max);
 
 use base qw(Slim::Plugin::Base);

--- a/Slim/Plugin/Analytics/Plugin.pm
+++ b/Slim/Plugin/Analytics/Plugin.pm
@@ -4,7 +4,7 @@ use strict;
 
 use Config;
 use Digest::SHA1 qw(sha1_base64);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use List::Util qw(max);
 
 use base qw(Slim::Plugin::Base);
@@ -114,7 +114,7 @@ sub _report { if (!main::SCANNER) {
 		sprintf(REPORT_URL, $serverId),
 		'x-lms-id' => $serverId,
 		'Content-Type' => 'application/json',
-		to_json($data),
+		encode_json($data),
 	);
 } }
 

--- a/Slim/Plugin/AudioAddict/API.pm
+++ b/Slim/Plugin/AudioAddict/API.pm
@@ -2,7 +2,7 @@ package Slim::Plugin::AudioAddict::API;
 
 use strict;
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Tie::Cache::LRU::Expires;
 use URI::Escape qw(uri_escape_utf8);
 
@@ -155,7 +155,7 @@ sub _call {
 		sub {
 			my $response = shift;
 
-			my $result = eval { from_json($response->content) };
+			my $result = eval { decode_json($response->content) };
 
 			$@ && $log->error($@);
 			main::DEBUGLOG && $log->is_debug && $log->debug("got: " . Data::Dump::dump($result));

--- a/Slim/Plugin/AudioAddict/API.pm
+++ b/Slim/Plugin/AudioAddict/API.pm
@@ -2,7 +2,7 @@ package Slim::Plugin::AudioAddict::API;
 
 use strict;
 
-use JSON::XS;
+use JSON::XS qw(decode_json);
 use Tie::Cache::LRU::Expires;
 use URI::Escape qw(uri_escape_utf8);
 

--- a/Slim/Plugin/AudioScrobbler/API/ListenBrainz.pm
+++ b/Slim/Plugin/AudioScrobbler/API/ListenBrainz.pm
@@ -14,7 +14,7 @@ use strict;
 
 use base qw(Slim::Plugin::AudioScrobbler::API);
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(blessed);
 use URI;
 use URI::Escape qw(uri_escape_utf8 uri_unescape);
@@ -123,7 +123,7 @@ sub submitNowPlaying {
 		}],
 	};
 
-	my $json = to_json($payload);
+	my $json = encode_json($payload);
 
 	main::DEBUGLOG && $log->debug("Submitting Now Playing track to ListenBrainz: " . $meta->{title});
 
@@ -203,7 +203,7 @@ sub submitScrobbleItems {
 		payload     => [$listen],
 	};
 
-	my $json = to_json($payload);
+	my $json = encode_json($payload);
 
 	if ( main::DEBUGLOG && $log->is_debug ) {
 		$log->debug("ListenBrainz: Submitting item 1 of " . scalar(@$listens) . ": " . $listen->{track_metadata}->{track_name});
@@ -334,7 +334,7 @@ sub _validateOK {
 	# Parse JSON response
 	my $response;
 	eval {
-		$response = from_json($content);
+		$response = decode_json($content);
 	};
 
 	my $ecb = $params->{ecb} || sub {};

--- a/Slim/Plugin/AudioScrobbler/API/ListenBrainz.pm
+++ b/Slim/Plugin/AudioScrobbler/API/ListenBrainz.pm
@@ -14,7 +14,7 @@ use strict;
 
 use base qw(Slim::Plugin::AudioScrobbler::API);
 
-use JSON::XS;
+use JSON::XS qw(decode_json encode_json);
 use Scalar::Util qw(blessed);
 use URI;
 use URI::Escape qw(uri_escape_utf8 uri_unescape);

--- a/Slim/Plugin/DnDPlay/Plugin.pm
+++ b/Slim/Plugin/DnDPlay/Plugin.pm
@@ -9,7 +9,7 @@ package Slim::Plugin::DnDPlay::Plugin;
 use strict;
 
 use File::Temp qw(tempfile);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use URI::QueryParam;
 
 use Slim::Utils::Log;
@@ -176,7 +176,7 @@ sub handleUpload {
 
 	$log->error($result->{error}) if $result->{error};
 
-	my $content = to_json($result);
+	my $content = encode_json($result);
 	$response->header( 'Content-Length' => length($content) );
 	$response->code($result->{code} || 200);
 	$response->header('Connection' => 'close');

--- a/Slim/Plugin/DnDPlay/Plugin.pm
+++ b/Slim/Plugin/DnDPlay/Plugin.pm
@@ -9,7 +9,7 @@ package Slim::Plugin::DnDPlay::Plugin;
 use strict;
 
 use File::Temp qw(tempfile);
-use JSON::XS;
+use JSON::XS qw(encode_json);
 use URI::QueryParam;
 
 use Slim::Utils::Log;

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -11,7 +11,7 @@ use strict;
 use base qw(Slim::Plugin::OPMLBased);
 
 use XML::Simple;
-use JSON::XS;
+use JSON::XS qw(decode_json);
 use Encode qw(encode);
 
 use Slim::Plugin::Podcast::Parser;

--- a/Slim/Plugin/Podcast/Plugin.pm
+++ b/Slim/Plugin/Podcast/Plugin.pm
@@ -11,7 +11,7 @@ use strict;
 use base qw(Slim::Plugin::OPMLBased);
 
 use XML::Simple;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Encode qw(encode);
 
 use Slim::Plugin::Podcast::Parser;
@@ -288,7 +288,7 @@ sub searchHandler {
 	Slim::Networking::SimpleAsyncHTTP->new(
 		sub {
 			my $response = shift;
-			my $result = eval { from_json( $response->content ) };
+			my $result = eval { decode_json( $response->content ) };
 
 			$log->error($@) if $@;
 			main::DEBUGLOG && $log->is_debug && warn Data::Dump::dump($result);

--- a/Slim/Plugin/Podcast/PodcastIndex.pm
+++ b/Slim/Plugin/Podcast/PodcastIndex.pm
@@ -11,7 +11,7 @@ use strict;
 
 use base qw(Slim::Plugin::Podcast::Provider);
 
-use JSON::XS;
+use JSON::XS qw(decode_json);
 use Digest::SHA1 qw(sha1_hex);
 use MIME::Base64;
 use URI::Escape;

--- a/Slim/Plugin/Podcast/PodcastIndex.pm
+++ b/Slim/Plugin/Podcast/PodcastIndex.pm
@@ -11,7 +11,7 @@ use strict;
 
 use base qw(Slim::Plugin::Podcast::Provider);
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Digest::SHA1 qw(sha1_hex);
 use MIME::Base64;
 use URI::Escape;
@@ -112,7 +112,7 @@ sub newsHandler {
 		Slim::Networking::SimpleAsyncHTTP->new(
 			sub {
 				my $response = shift;
-				my $result = eval { from_json( $response->content ) };
+				my $result = eval { decode_json( $response->content ) };
 
 				$log->warn("error parsing new episodes for $url", $@) if $@;
 				main::INFOLOG && $log->is_info && $log->info("found $result->{count} for $url");

--- a/Slim/Plugin/PresetsEditor/Settings.pm
+++ b/Slim/Plugin/PresetsEditor/Settings.pm
@@ -9,7 +9,7 @@ package Slim::Plugin::PresetsEditor::Settings;
 use strict;
 
 use base qw(Slim::Web::Settings);
-use JSON::XS;
+use JSON::XS qw(encode_json);
 
 use Slim::Utils::Alarm;
 use Slim::Utils::Log;

--- a/Slim/Plugin/PresetsEditor/Settings.pm
+++ b/Slim/Plugin/PresetsEditor/Settings.pm
@@ -9,7 +9,7 @@ package Slim::Plugin::PresetsEditor::Settings;
 use strict;
 
 use base qw(Slim::Web::Settings);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Utils::Alarm;
 use Slim::Utils::Log;
@@ -68,7 +68,7 @@ sub handler {
 		$_->{items} && scalar @{$_->{items}}
 	} @$playlistOptions ];
 
-	$params->{urlToName} = to_json(\%urlToName);
+	$params->{urlToName} = encode_json(\%urlToName);
 
 	return $class->SUPER::handler( $client, $params );
 }

--- a/Slim/Plugin/RadioArtwork/Plugin.pm
+++ b/Slim/Plugin/RadioArtwork/Plugin.pm
@@ -26,7 +26,7 @@ package Slim::Plugin::RadioArtwork::Plugin;
 =cut
 
 use strict;
-use JSON::XS;
+use JSON::XS qw(decode_json);
 use Tie::RegexpHash;
 use URI;
 use URI::QueryParam;

--- a/Slim/Plugin/RadioArtwork/Plugin.pm
+++ b/Slim/Plugin/RadioArtwork/Plugin.pm
@@ -26,7 +26,7 @@ package Slim::Plugin::RadioArtwork::Plugin;
 =cut
 
 use strict;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Tie::RegexpHash;
 use URI;
 use URI::QueryParam;
@@ -223,7 +223,7 @@ sub lookupArtwork {
 		sub {
 			my $response = shift;
 
-			my $json = eval { from_json($response->content) };
+			my $json = eval { decode_json($response->content) };
 
 			$log->warn($@) if $@;
 
@@ -267,7 +267,7 @@ sub updateKillWords {
 		sub {
 			my $response = shift;
 
-			my $json = eval { from_json($response->content) };
+			my $json = eval { decode_json($response->content) };
 
 			$log->warn($@) if $@;
 

--- a/Slim/Plugin/RemoteLibrary/LMS.pm
+++ b/Slim/Plugin/RemoteLibrary/LMS.pm
@@ -16,7 +16,7 @@ than the local database.
 
 use strict;
 
-use JSON::XS;
+use JSON::XS qw(decode_json encode_json);
 use MIME::Base64 qw(encode_base64 decode_base64);
 
 use Slim::Menu::BrowseLibrary;

--- a/Slim/Plugin/RemoteLibrary/LMS.pm
+++ b/Slim/Plugin/RemoteLibrary/LMS.pm
@@ -16,7 +16,7 @@ than the local database.
 
 use strict;
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use MIME::Base64 qw(encode_base64 decode_base64);
 
 use Slim::Menu::BrowseLibrary;
@@ -426,7 +426,7 @@ sub remoteRequest {
 
 	my $baseUrl = __PACKAGE__->baseUrl($remote_library);
 
-	my $postdata = to_json({
+	my $postdata = encode_json({
 		id     => 1,
 		method => 'slim.request',
 		params => $request,
@@ -436,7 +436,7 @@ sub remoteRequest {
 		sub {
 			my $http = shift;
 
-			my $res = eval { from_json( $http->content ) };
+			my $res = eval { decode_json( $http->content ) };
 
 			if ( $@ || ref $res ne 'HASH' ) {
 				$log->error( $@ || 'Invalid JSON response: ' . $http->content );

--- a/Slim/Plugin/RemoteLibrary/ProtocolHandler.pm
+++ b/Slim/Plugin/RemoteLibrary/ProtocolHandler.pm
@@ -3,7 +3,6 @@ package Slim::Plugin::RemoteLibrary::ProtocolHandler;
 use strict;
 use base qw(Slim::Player::Protocols::HTTP);
 
-use JSON::XS;
 use Scalar::Util qw(blessed);
 
 use Slim::Networking::SimpleAsyncHTTP;

--- a/Slim/Plugin/RemoteLibrary/ProtocolHandler.pm
+++ b/Slim/Plugin/RemoteLibrary/ProtocolHandler.pm
@@ -3,7 +3,7 @@ package Slim::Plugin::RemoteLibrary::ProtocolHandler;
 use strict;
 use base qw(Slim::Player::Protocols::HTTP);
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(blessed);
 
 use Slim::Networking::SimpleAsyncHTTP;

--- a/Slim/Plugin/TT/OnlineServices.pm
+++ b/Slim/Plugin/TT/OnlineServices.pm
@@ -9,7 +9,7 @@ package Slim::Plugin::TT::OnlineServices;
 use strict;
 use base qw(Template::Plugin);
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 my $services;
 
@@ -29,7 +29,7 @@ sub getIconForId { if ($services) {
 } }
 
 sub getServiceIconProviders {
-	return $services ? to_json(Slim::Plugin::OnlineLibrary::Plugin->getServiceIconProviders()) : '""';
+	return $services ? encode_json(Slim::Plugin::OnlineLibrary::Plugin->getServiceIconProviders()) : '""';
 }
 
 1;

--- a/Slim/Plugin/TT/OnlineServices.pm
+++ b/Slim/Plugin/TT/OnlineServices.pm
@@ -9,7 +9,7 @@ package Slim::Plugin::TT::OnlineServices;
 use strict;
 use base qw(Template::Plugin);
 
-use JSON::XS;
+use JSON::XS qw(encode_json);
 
 my $services;
 

--- a/Slim/Schema/Album.pm
+++ b/Slim/Schema/Album.pm
@@ -4,7 +4,7 @@ package Slim::Schema::Album;
 use strict;
 use base 'Slim::Schema::DBI';
 
-use JSON::XS;
+use JSON::XS qw(decode_json encode_json);
 
 use Slim::Schema::ResultSet::Album;
 

--- a/Slim/Schema/Album.pm
+++ b/Slim/Schema/Album.pm
@@ -4,7 +4,7 @@ package Slim::Schema::Album;
 use strict;
 use base 'Slim::Schema::DBI';
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Schema::ResultSet::Album;
 
@@ -127,7 +127,7 @@ sub addReleaseTypeMap {
 		'name' => 'releaseTypeMap'
 	} );
 
-	$last->value(to_json(\%releaseTypeMap));
+	$last->value(encode_json(\%releaseTypeMap));
 	$last->update;
 }
 
@@ -137,7 +137,7 @@ sub addReleaseTypeStrings {
 	} );
 
 	if ($stringsObj) {
-		my $strings = eval { from_json($stringsObj->value) };
+		my $strings = eval { decode_json($stringsObj->value) };
 		if ($strings && ref $strings) {
 			while (my ($token, $string) = each %$strings) {
 				next if $string == 1;

--- a/Slim/Schema/TrackPersistent.pm
+++ b/Slim/Schema/TrackPersistent.pm
@@ -5,7 +5,7 @@ use strict;
 use base 'Slim::Schema::DBI';
 
 use File::Slurp qw(read_file);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(blessed);
 
 use Slim::Utils::DateTime;
@@ -46,7 +46,7 @@ sub import_json {
 	if ( main::SCANNER ) {
 		my ( $class, $json ) = @_;
 
-		my $tracks = eval { from_json( read_file($json) ) };
+		my $tracks = eval { decode_json( read_file($json) ) };
 		if ( $@ ) {
 			logError($@);
 			return;

--- a/Slim/Schema/TrackPersistent.pm
+++ b/Slim/Schema/TrackPersistent.pm
@@ -5,7 +5,7 @@ use strict;
 use base 'Slim::Schema::DBI';
 
 use File::Slurp qw(read_file);
-use JSON::XS;
+use JSON::XS qw(decode_json);
 use Scalar::Util qw(blessed);
 
 use Slim::Utils::DateTime;

--- a/Slim/Utils/DateTime.pm
+++ b/Slim/Utils/DateTime.pm
@@ -10,7 +10,7 @@ use strict;
 
 use Date::Parse;
 use HTTP::Status qw(RC_INTERNAL_SERVER_ERROR);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use POSIX qw(strftime);
 
 use Slim::Utils::Log;
@@ -496,7 +496,7 @@ sub getTimeZoneInformation {
 	Slim::Networking::SimpleAsyncHTTP->new(
 		sub {
 			my $http = shift;
-			my $res  = eval { from_json($http->content) };
+			my $res  = eval { decode_json($http->content) };
 
 			if ($@ || ref $res ne 'HASH') {
 				$log->error($@ || 'Invalid JSON response: ' . $http->content);

--- a/Slim/Utils/DateTime.pm
+++ b/Slim/Utils/DateTime.pm
@@ -10,7 +10,7 @@ use strict;
 
 use Date::Parse;
 use HTTP::Status qw(RC_INTERNAL_SERVER_ERROR);
-use JSON::XS;
+use JSON::XS qw(decode_json);
 use POSIX qw(strftime);
 
 use Slim::Utils::Log;

--- a/Slim/Utils/Prefs/Base.pm
+++ b/Slim/Utils/Prefs/Base.pm
@@ -19,7 +19,6 @@ Base class for preference objects implementing methods which can be used on glob
 
 use strict;
 
-use JSON::XS;
 use Scalar::Util qw(blessed);
 use Storable;
 

--- a/Slim/Utils/Prefs/Base.pm
+++ b/Slim/Utils/Prefs/Base.pm
@@ -19,7 +19,7 @@ Base class for preference objects implementing methods which can be used on glob
 
 use strict;
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(blessed);
 use Storable;
 

--- a/Slim/Utils/Progress.pm
+++ b/Slim/Utils/Progress.pm
@@ -9,7 +9,7 @@ package Slim::Utils::Progress;
 use strict;
 use base qw(Slim::Utils::Accessor);
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Schema;
 use Slim::Utils::Unicode;
@@ -338,7 +338,7 @@ sub _write_json {
 	}
 
 	require File::Slurp;
-	File::Slurp::write_file( $file, to_json($progress_json) );
+	File::Slurp::write_file( $file, encode_json($progress_json) );
 }
 
 # Clear all progress information from previous runs

--- a/Slim/Utils/Progress.pm
+++ b/Slim/Utils/Progress.pm
@@ -9,7 +9,7 @@ package Slim::Utils::Progress;
 use strict;
 use base qw(Slim::Utils::Accessor);
 
-use JSON::XS;
+use JSON::XS qw(encode_json);
 
 use Slim::Schema;
 use Slim::Utils::Unicode;

--- a/Slim/Utils/SQLiteHelper.pm
+++ b/Slim/Utils/SQLiteHelper.pm
@@ -27,7 +27,7 @@ use File::Basename;
 use File::Path;
 use File::Slurp;
 use File::Spec::Functions qw(catfile);
-use JSON::XS;
+use JSON::XS qw(encode_json);
 use Time::HiRes qw(sleep);
 
 use Slim::Utils::ArtworkCache;

--- a/Slim/Utils/SQLiteHelper.pm
+++ b/Slim/Utils/SQLiteHelper.pm
@@ -27,7 +27,7 @@ use File::Basename;
 use File::Path;
 use File::Slurp;
 use File::Spec::Functions qw(catfile);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Time::HiRes qw(sleep);
 
 use Slim::Utils::ArtworkCache;
@@ -429,7 +429,7 @@ sub updateProgress {
 		$req->authorization_basic($username, $password);
 	}
 
-	$req->content( to_json( {
+	$req->content( encode_json( {
 		id     => 1,
 		method => 'slim.request',
 		params => [ '', [ 'scanner', 'notify', @_ ] ],

--- a/Slim/Utils/Strings.pm
+++ b/Slim/Utils/Strings.pm
@@ -46,7 +46,7 @@ use POSIX qw(setlocale LC_TIME LC_COLLATE);
 use File::Basename qw(dirname);
 use File::Slurp qw(read_file write_file);
 use File::Spec::Functions qw(catdir);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(blessed);
 use Storable;
 
@@ -442,7 +442,7 @@ sub storeExtraStrings {
 	if ( !scalar( keys %{$extraStringsCache} ) && -e $extraCache ) {
 		main::DEBUGLOG && $log->is_debug && $log->debug('Reading extrastrings.json file');
 
-		$extraStringsCache = eval { from_json( read_file($extraCache) ) };
+		$extraStringsCache = eval { decode_json( read_file($extraCache) ) };
 		if ( $@ ) {
 			$log->error("Failed to read extrastrings.json file: $@");
 			$extraStringsCache = {};
@@ -489,7 +489,7 @@ sub _writeExtraStrings {
 	main::DEBUGLOG && $log->is_debug && $log->debug('Writing updated extrastrings.json file');
 
 	$extraStringsDirty = 0;
-	eval { write_file( $extraCache, to_json($extraStringsCache) ) };
+	eval { write_file( $extraCache, encode_json($extraStringsCache) ) };
 
 	$log->error("Failed to write extrastrings.json file: $@") if $@;
 };
@@ -505,7 +505,7 @@ sub loadExtraStrings {
 
 	my $cache = $extraStringsCache || {};
 	if ( !($cache && keys %$cache) && -e $extraCache ) {
-		$cache = eval { from_json( read_file($extraCache) ) };
+		$cache = eval { decode_json( read_file($extraCache) ) };
 	}
 
 	for my $string ( keys %{ $cache || {} } ) {

--- a/Slim/Utils/Strings.pm
+++ b/Slim/Utils/Strings.pm
@@ -46,7 +46,7 @@ use POSIX qw(setlocale LC_TIME LC_COLLATE);
 use File::Basename qw(dirname);
 use File::Slurp qw(read_file write_file);
 use File::Spec::Functions qw(catdir);
-use JSON::XS;
+use JSON::XS qw(decode_json encode_json);
 use Scalar::Util qw(blessed);
 use Storable;
 

--- a/Slim/Utils/Update.pm
+++ b/Slim/Utils/Update.pm
@@ -5,7 +5,7 @@ use File::Slurp qw(write_file);
 use Time::HiRes;
 use Digest::MD5;
 use File::Spec::Functions qw(splitpath catdir);
-use JSON::XS;
+use JSON::XS qw(decode_json);
 
 use Slim::Utils::Log;
 use Slim::Utils::OSDetect;

--- a/Slim/Utils/Update.pm
+++ b/Slim/Utils/Update.pm
@@ -5,7 +5,7 @@ use File::Slurp qw(write_file);
 use Time::HiRes;
 use Digest::MD5;
 use File::Spec::Functions qw(splitpath catdir);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Utils::Log;
 use Slim::Utils::OSDetect;
@@ -99,7 +99,7 @@ sub checkVersionCB {
 
 		my $content = Slim::Utils::Unicode::utf8decode( $http->content() );
 
-		my $versions = from_json($content);
+		my $versions = decode_json($content);
 
 		my $osID = $os->installerOS() || 'default';
 		$versions = $versions->{$::VERSION} || $versions->{latest};

--- a/Slim/Web/Cometd.pm
+++ b/Slim/Web/Cometd.pm
@@ -20,7 +20,7 @@ use strict;
 
 use bytes;
 use HTTP::Date;
-use JSON::XS;
+use JSON::XS qw(decode_json encode_json);
 use Scalar::Util qw(blessed);
 use URI::Escape qw(uri_unescape);
 

--- a/Slim/Web/Cometd.pm
+++ b/Slim/Web/Cometd.pm
@@ -20,7 +20,7 @@ use strict;
 
 use bytes;
 use HTTP::Date;
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(blessed);
 use URI::Escape qw(uri_unescape);
 
@@ -126,7 +126,7 @@ sub handler {
 		return;
 	}
 
-	my $objs = eval { from_json( $message ) };
+	my $objs = eval { decode_json( $message ) };
 	if ( $@ ) {
 		sendResponse(
 			@{$conn},
@@ -695,9 +695,9 @@ sub sendHTTPResponse {
 		);
 	}
 
-	$out = eval { to_json($out) };
+	$out = eval { encode_json($out) };
 	if ( $@ ) {
-		$out = to_json( [ { successful => JSON::XS::false, error => "$@" } ] );
+		$out = encode_json( [ { successful => JSON::XS::false, error => "$@" } ] );
 	}
 
 	my $sendheaders = 1; # should we send headers?
@@ -751,9 +751,9 @@ sub sendHTTPResponse {
 sub sendCLIResponse {
 	my ( $socket, $out ) = @_;
 
-	$out = eval { to_json($out) };
+	$out = eval { encode_json($out) };
 	if ( $@ ) {
-		$out = to_json( [ { successful => JSON::XS::false, error => "$@" } ] );
+		$out = encode_json( [ { successful => JSON::XS::false, error => "$@" } ] );
 	}
 
 	if ( main::DEBUGLOG && $log->is_debug ) {

--- a/Slim/Web/JSONRPC.pm
+++ b/Slim/Web/JSONRPC.pm
@@ -13,7 +13,7 @@ package Slim::Web::JSONRPC;
 use strict;
 
 use HTTP::Status qw(RC_OK RC_FORBIDDEN);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Scalar::Util qw(blessed);
 use URI;
 use URI::QueryParam;
@@ -151,7 +151,7 @@ sub handleURI {
 	# Parse the input
 	# Convert JSON to Perl
 	# FIXME: JSON 1.0 accepts multiple requests ? How do we parse that efficiently?
-	my $procedure = from_json($input);
+	my $procedure = decode_json($input);
 
 
 	# Validate the procedure
@@ -318,7 +318,7 @@ sub writeResponse {
 	}
 
 	# convert Perl object into JSON
-	my $jsonResponse = to_json($responseRef);
+	my $jsonResponse = encode_json($responseRef);
 
 	main::DEBUGLOG && $isDebug && $log->info("JSON raw response: [$jsonResponse]");
 

--- a/Slim/Web/JSONRPC.pm
+++ b/Slim/Web/JSONRPC.pm
@@ -13,7 +13,7 @@ package Slim::Web::JSONRPC;
 use strict;
 
 use HTTP::Status qw(RC_OK RC_FORBIDDEN);
-use JSON::XS;
+use JSON::XS qw(decode_json encode_json);
 use Scalar::Util qw(blessed);
 use URI;
 use URI::QueryParam;

--- a/Slim/Web/Pages/Home.pm
+++ b/Slim/Web/Pages/Home.pm
@@ -10,7 +10,7 @@ use strict;
 
 use Data::URIEncode qw(complex_to_query);
 use HTTP::Status qw(RC_MOVED_TEMPORARILY);
-use JSON::XS;
+use JSON::XS qw(encode_json);
 
 use Slim::Utils::Cache;
 use Slim::Utils::Prefs;

--- a/Slim/Web/Pages/Home.pm
+++ b/Slim/Web/Pages/Home.pm
@@ -10,7 +10,7 @@ use strict;
 
 use Data::URIEncode qw(complex_to_query);
 use HTTP::Status qw(RC_MOVED_TEMPORARILY);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Utils::Cache;
 use Slim::Utils::Prefs;
@@ -238,7 +238,7 @@ sub _updateInfoCB {
 		}
 
 		$response->content_type('application/json');
-		my $content = to_json($json);
+		my $content = encode_json($json);
 		$callback->($client, $params, \$content, $httpClient, $response);
 	}
 	else {

--- a/Slim/Web/Settings/Server/Plugins.pm
+++ b/Slim/Web/Settings/Server/Plugins.pm
@@ -8,7 +8,7 @@ package Slim::Web::Settings::Server::Plugins;
 
 use strict;
 
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Digest::MD5;
 
 use base qw(Slim::Web::Settings);
@@ -324,7 +324,7 @@ sub _addInfo {
 		} keys %$categories
 	);
 
-	$params->{'searchData'} = to_json($searchData);
+	$params->{'searchData'} = encode_json($searchData);
 	$params->{'categories'} = \@categories;
 	$params->{'updates'}  = \@updates;
 	$params->{'active'}   = $active;

--- a/Slim/Web/Settings/Server/Plugins.pm
+++ b/Slim/Web/Settings/Server/Plugins.pm
@@ -8,8 +8,8 @@ package Slim::Web::Settings::Server::Plugins;
 
 use strict;
 
-use JSON::XS;
 use Digest::MD5;
+use JSON::XS qw(encode_json);
 
 use base qw(Slim::Web::Settings);
 

--- a/Slim/Web/Settings/Server/Wizard.pm
+++ b/Slim/Web/Settings/Server/Wizard.pm
@@ -13,7 +13,7 @@ use File::Slurp qw(read_file);
 use File::Spec::Functions qw(catfile);
 use FindBin qw($Bin);
 use HTTP::Status qw(RC_MOVED_TEMPORARILY);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
@@ -208,7 +208,7 @@ sub handler {
 	foreach (Slim::Utils::Misc::uniq(catfile($Bin, 'HTML'), Slim::Utils::OSDetect::dirsFor('HTML'))) {
 		my $path = catfile($_, 'EN', 'settings', 'wizard.json');
 		if (-f $path) {
-			$wzData = from_json(read_file($path));
+			$wzData = decode_json(read_file($path));
 			last if keys %$wzData; # stop if we got data, otherwise try next path
 		}
 	}

--- a/Slim/Web/Settings/Server/Wizard.pm
+++ b/Slim/Web/Settings/Server/Wizard.pm
@@ -13,7 +13,7 @@ use File::Slurp qw(read_file);
 use File::Spec::Functions qw(catfile);
 use FindBin qw($Bin);
 use HTTP::Status qw(RC_MOVED_TEMPORARILY);
-use JSON::XS;
+use JSON::XS qw(decode_json);
 
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;

--- a/Slim/Web/Time.pm
+++ b/Slim/Web/Time.pm
@@ -22,7 +22,7 @@ package Slim::Web::Time;
 use strict;
 
 use HTTP::Status qw(RC_OK RC_NO_CONTENT RC_INTERNAL_SERVER_ERROR);
-use JSON::XS::VersionOneAndTwo;
+use JSON::XS;
 use Time::HiRes;
 
 use Slim::Web::HTTP;

--- a/Slim/Web/Time.pm
+++ b/Slim/Web/Time.pm
@@ -22,7 +22,6 @@ package Slim::Web::Time;
 use strict;
 
 use HTTP::Status qw(RC_OK RC_NO_CONTENT RC_INTERNAL_SERVER_ERROR);
-use JSON::XS;
 use Time::HiRes;
 
 use Slim::Web::HTTP;


### PR DESCRIPTION
The purpose of `JSON::XS::VersionOneAndTwo` is to provide compatibility with the API of versions of `JSON::XS` earlier than 2.01 (released 2007).  However, we know we have at least version 2.3 of `JSON::XS`, since that’s what we specify in `modules.conf`.

I would like to go further and remove `JSON::XS::VersionOneAndTwo` from `modules.conf` and the `CPAN/` directory, but I hesitate, because it seems like something that third-party plugins might expect to be available.

Relates to #138.