### PR TITLE
Add current track's bitrate to status query.

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4108,7 +4108,7 @@ sub statusQuery {
 
 		my $trackGain = $song->replayGain();
 		if (defined $trackGain) {
-				$request->addResult('replay_gain', $trackGain);
+			$request->addResult('replay_gain', $trackGain);
 		}
 
 		if ($tags =~ /b/) {   # get the song's current bitrate

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4120,6 +4120,7 @@ sub statusQuery {
 				$bitrate = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $bitrate/1000);
 				$request->addResult('bitrate', $bitrate);
 			}
+		}
 			
 			# Add other technical song attributes here, e.g. 'type', 'samplerate' and 'samplesize'
 	}

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4009,6 +4009,7 @@ sub statusQuery {
 	# get the initial parameters
 	my $client = $request->client();
 	my $menu = $request->getParam('menu');
+	my $tags = $request->getParam('tags') || '';
 
 	# menu/jive mgmt
 	my $menuMode = defined $menu;
@@ -4105,16 +4106,12 @@ sub statusQuery {
 			$request->addResult('can_seek', 1);
 		}
 
-		my $techInfo = $request->getParam('techInfo');  # see if the user requested technical song info
-		
-		if (!defined $techInfo || $techInfo) {  # return replay gain unless explicitly directed not to
-			my $trackGain = $song->replayGain();
-			if (defined $trackGain) {
+		my $trackGain = $song->replayGain();
+		if (defined $trackGain) {
 				$request->addResult('replay_gain', $trackGain);
-			}
 		}
 
-		if ($techInfo) {  # add additional tech info from song object only if requested
+		if ($tags =~ /b/) {   # get the song's current bitrate
 			my $bitrate = $song->streambitrate();
 			if (defined $bitrate && $bitrate) {
 				$bitrate = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $bitrate/1000);
@@ -4122,7 +4119,7 @@ sub statusQuery {
 			}
 		}
 			
-			# Add other technical song attributes here, e.g. 'type', 'samplerate' and 'samplesize'
+		# Add other technical song attributes here, e.g. 'type', 'samplerate' and 'samplesize'
 	}
 
 	if ($client->currentSleepTime()) {
@@ -4326,7 +4323,6 @@ sub statusQuery {
 
 		main::DEBUGLOG && $isDebug && $log->debug("statusQuery(): setup non-zero player response");
 		# get the other parameters
-		my $tags     = $request->getParam('tags') || '';
 		my $index    = $request->getParam('_index');
 		my $quantity = $request->getParam('_quantity');
 

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4109,6 +4109,12 @@ sub statusQuery {
 		if (defined $trackGain) {
 			$request->addResult('replay_gain', $trackGain);
 		}
+		
+		my $bitrate = $song->streambitrate();
+		if (defined $bitrate) {
+			$bitrate = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $bitrate/1000);
+			$request->addResult('bitrate', $bitrate);
+		}
 	}
 
 	if ($client->currentSleepTime()) {

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4118,8 +4118,27 @@ sub statusQuery {
 				$request->addResult('bitrate', $bitrate);
 			}
 		}
-			
-		# Add other technical song attributes here, e.g. 'type', 'samplerate' and 'samplesize'
+
+		if ($tags =~ /o/) {   # get the song's format (type)
+			my $type = $song->streamformat();
+			if (defined $type && $type) {
+				$request->addResult('type', $type);
+			}
+		}
+
+		if ($tags =~ /T/) {   # get the song's sample rate
+			my $samplerate = $song->samplerate();
+			if (defined $samplerate) {
+				$request->addResult('samplerate', $samplerate);
+			}
+		}
+
+		if ($tags =~ /I/) {   # get the song's sample size
+			my $samplesize = $song->samplesize();
+			if (defined $samplesize) {
+				$request->addResult('samplesize', $samplesize);
+			}
+		}
 	}
 
 	if ($client->currentSleepTime()) {

--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4105,16 +4105,23 @@ sub statusQuery {
 			$request->addResult('can_seek', 1);
 		}
 
-		my $trackGain = $song->replayGain();
-		if (defined $trackGain) {
-			$request->addResult('replay_gain', $trackGain);
-		}
+		my $techInfo = $request->getParam('techInfo');  # see if the user requested technical song info
 		
-		my $bitrate = $song->streambitrate();
-		if (defined $bitrate) {
-			$bitrate = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $bitrate/1000);
-			$request->addResult('bitrate', $bitrate);
+		if (!defined $techInfo || $techInfo) {  # return replay gain unless explicitly directed not to
+			my $trackGain = $song->replayGain();
+			if (defined $trackGain) {
+				$request->addResult('replay_gain', $trackGain);
+			}
 		}
+
+		if ($techInfo) {  # add additional tech info from song object only if requested
+			my $bitrate = $song->streambitrate();
+			if (defined $bitrate && $bitrate) {
+				$bitrate = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $bitrate/1000);
+				$request->addResult('bitrate', $bitrate);
+			}
+			
+			# Add other technical song attributes here, e.g. 'type', 'samplerate' and 'samplesize'
 	}
 
 	if ($client->currentSleepTime()) {


### PR DESCRIPTION
This information can be used by client apps to display the actual bitrate of the currently playing track rather than what is stored in the dictionary, which doesn't reflect any resampling that may have been done in the pipeline. This change will also allow the bitrate of remote tracks imported into the library via OMLI with a bitrate of 0 (due to unknown file size) to be retrieved and displayed by client apps, which wasn't possible before.