### PR TITLE
Handle Wine drive-letter paths in MusicMagic plugin

### DIFF
--- a/Slim/Plugin/MusicMagic/Importer.pm
+++ b/Slim/Plugin/MusicMagic/Importer.pm
@@ -438,6 +438,14 @@ sub processSong {
 	}
 	else {
 		$songInfo{'file'} = Slim::Utils::Unicode::utf8encode_locale($songInfo{'file'});
+
+		# MusicIP may itself be running under Wine (e.g. in a Linux Docker container),
+		# in which case it reports paths in Windows drive-letter form (Wine maps the
+		# Linux filesystem root to a drive, typically Z:\). Translate such paths back
+		# to native Linux paths so they resolve correctly. Regular Linux paths (which
+		# already start with '/') are left untouched.
+		$songInfo{'file'} =~ s|^[A-Za-z]:||;
+		$songInfo{'file'} =~ s|\\|/|g;
 	}
 
 	main::DEBUGLOG && $log->debug("Exporting song: $songInfo{'file'}");

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -921,6 +921,19 @@ sub getMix {
 	}
 
 	my @songs = split(/\n/, $response->content);
+
+	# MusicIP may itself be running under Wine (e.g. in a Linux Docker container),
+	# in which case it reports paths in Windows drive-letter form (Wine maps the
+	# Linux filesystem root to a drive, typically Z:\). Translate such paths back
+	# to native Linux paths so they resolve correctly. Regular Linux paths (which
+	# already start with '/') are left untouched.
+	unless (main::ISWINDOWS) {
+		for my $song (@songs) {
+			$song =~ s|^[A-Za-z]:||;
+			$song =~ s|\\|/|g;
+		}
+	}
+
 	my $count = scalar @songs;
 
 	for (my $j = 0; $j < $count; $j++) {


### PR DESCRIPTION
## Problem

MusicIP can itself run under Wine — for example inside a Linux Docker
container (see hb64/musicip-wine-1.9.b). In that setup Wine maps the
Linux filesystem root to a drive letter (typically `Z:\`), so MusicIP
reports song paths back to LMS in Windows drive-letter form
(e.g. `Z:\music\Artist\Album\Song.mp3`) even though the server itself
is running on Linux.

LMS then fails to resolve these paths (`-e $songs[$j]` never matches),
so tracks picked by the MusicIP mixer / Mood Mixer are silently
dropped and no music plays, even though MusicIP itself picked valid
tracks.

## Fix

Translate any Windows drive-letter-style path back to a native Linux
path before it's used, but only on non-Windows platforms and only
when the path actually looks like a Windows path (starts with a
drive letter). Regular Linux paths, which always start with `/`,
never match and are left completely untouched — so this is a no-op
on a normal native Linux MusicIP setup.

Applied in the two places MusicIP-reported paths are consumed:
- `Importer.pm::processSong` (library scan / import)
- `Plugin.pm::getMix` (Mood Mixer / mix results)

## Testing

- Verified on a Linux Docker container running MusicIP 1.9b under
  Wine: Mood Mixer previously silently produced tracks that never
  matched a resolvable path; with this patch, Mood Mixer works
  correctly.
- Verified on a native Linux MusicIP 1.8 setup that behavior is
  unchanged (regex never matches native `/`-prefixed paths).