### PR TITLE
UPnP/DLNA: support EOF for HTTP/1.1 chunked transfer-encoding

### DIFF
--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -78,7 +78,18 @@ sub _sysread {
 		my $raw = $self->SUPER::_sysread( my $buf, MAX_RAW_READ, 0 );
 
 		# propagate "no data yet" (EWOULDBLOCK/EINTR) and real read errors as-is
-		return $raw unless $raw;
+		if ( !$raw ) {
+			# A closed socket ($raw defined as 0) or a hard read error (undef $raw
+			# with an errno other than "try again") before we ever saw the chunk
+			# stream's own 0-size terminator below means the source dropped the
+			# connection rather than ending the stream gracefully. Undo the
+			# isLive(0) set by parseHeaders() so StreamingController::_RetryOrNext()
+			# reconnects, same as it would for any other isLive stream that got cut off.
+			if ( ( defined($raw) || ( $! != EWOULDBLOCK && $! != EINTR ) ) && ( my $song = ${*$self}{'song'} ) ) {
+				$song->isLive(1);
+			}
+			return $raw;
+		}
 
 		$dechunk->{'raw'} .= $buf;
 
@@ -164,7 +175,32 @@ sub scanUrl {
 
 sub audioScrobblerSource { 'P' }
 
-# XXX parseHeaders, needed?
+# Slim::Player::Protocols::HTTP::parseHeaders() sets isLive(1) whenever no
+# Content-Length is known, which is also the case for chunked-encoded streams.
+#
+# StreamingController::_RetryOrNext() treats isLive tracks as infinite radio
+# and, once played for more than 10s, tries to reconnect to the same URI.
+# DLNA/UPnP tracks are finite, discrete tracks despite lacking a known length,
+# so we override parseHeaders() to set isLive(0) for them instead.
+#
+# Only chunked responses get this treatment: they're the only ones where
+# _sysread() can tell a graceful stream end (its own EOF chunk) apart from a
+# genuine connection abort, and re-arms isLive(1) itself when it sees the
+# latter, so a real disconnect still triggers a reconnect.
+# For any other response (fixed Content-Length, or no chunking), leave
+# isLive exactly as the base class set it.
+sub parseHeaders {
+        my $self = shift;
+        my $ret  = $self->SUPER::parseHeaders(@_);
+
+        if ( grep { /^Transfer-Encoding\s*:\s*chunked/i } @_ ) {
+                if ( my $song = ${*$self}{'song'} ) {
+                        $song->isLive(0);
+                }
+        }
+
+        return $ret;
+}
 
 # XXX parseDirectHeaders, needed?
 


### PR DESCRIPTION
This amends commit fb070df921c89d08b8c0005366432add9d29fa7a that added support of chunked-transfer encoding to DLNA/UPnP streams proxied thourgh LMS. Such streams have no Content-Length, so Slim::Player::Protocols::HTTP::parseHeaders() sets isLive(1) on them.

StreamingController::_RetryOrNext() treats isLive tracks as infinite radio and, once played for more than 10s, tries to reconnect to them when the stream (unexpectedly) ends.
Unfortunately, reception of a graceful connection shutdown by a HTTP/1.1 EOF chunk, which is perfectly okay for media received from DLNA Media Servers, also triggers this behavior.

To fix this for the chunked case, we override parseHeaders() here to force isLive back to 0 for them, whereas responses with a known Content-Length keep the base class behaviour unchanged, relying on Slim::Player::Protocols::HTTP's own Range-based resume logic instead.

In addition, _sysread() now tells a graceful stream ending by EOF apart from a genuine connection abort. In the latter case, isLive is set back to 1 before the drop is handled, so _RetryOrNext() still attempts a reconnect, same as it always did for isLive streams. In contrast, the EOF chunk ends the track gracefully without a reconnect attempt.

---

Tested with:

- BubbleUPnP
- pa-dlna 1.2 (which still needs the setting `track_metadata = no` in the config file as before, since its track change handling is currently incompatible to LMS)