### PR TITLE
Add MusicIP host setting and Dynamic Path Conversion

### DIFF
--- a/Slim/Plugin/MusicMagic/Common.pm
+++ b/Slim/Plugin/MusicMagic/Common.pm
@@ -8,6 +8,7 @@ package Slim::Plugin::MusicMagic::Common;
 # version 2.
 
 use strict;
+use File::Spec::Functions qw(catfile);
 use URI::Escape;
 
 use Slim::Utils::Log;
@@ -72,7 +73,45 @@ sub checkDefaults {
 		playlist_suffix => '',
 		scan_interval   => 3600,
 		port            => 10002,
+		path_conversion_enabled => 0,
+		path_conversion_source  => '',
+		path_conversion_dest    => '',
 	}, 'Slim::Plugin::MusicMagic::Prefs');
+}
+
+# Path Conversion - similar to the SugarCube LMS plugin's own feature of
+# the same kind. Lets the user configure a source (MusicIP-side) path
+# prefix and a destination (Lyrion-side) path prefix, for cases where
+# MusicIP reports paths that don't match what Lyrion expects - e.g. when
+# MusicIP itself runs under Wine (in which case it reports paths in
+# Windows drive-letter form, since Wine maps the Linux filesystem root
+# to a drive, typically Z:\), or when running MusicIP on a different
+# host/container than Lyrion Music Server with a different mount layout.
+#
+# Disabled by default, and a no-op unless both the source and
+# destination are configured, so this never affects a standard
+# native-platform MusicIP install.
+sub translatePath {
+	my $path = shift;
+
+	return $path unless $prefs->get('path_conversion_enabled');
+
+	my $source = $prefs->get('path_conversion_source');
+	my $dest   = $prefs->get('path_conversion_dest');
+
+	return $path unless defined $source && length($source) && defined $dest;
+
+	if ($path =~ s|^\Q$source\E||i) {
+		# re-join whatever's left of the path using the destination's
+		# own (OS-native) separator, so this works symmetrically in
+		# either direction - e.g. a Windows-style source converted to
+		# a Unix-style dest (MusicIP under Wine), or the other way
+		# around - rather than just blindly flipping backslashes.
+		my @parts = grep { length } split m|[\\/]|, $path;
+		$path = @parts ? catfile($dest, @parts) : $dest;
+	}
+
+	return $path;
 }
 
 sub getGenreList {

--- a/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
+++ b/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
@@ -99,13 +99,30 @@
 			[% END %]
 		[% END %]
 
-		[% WRAPPER settingGroup title="SETUP_MMSHOST" desc="SETUP_MMSHOST_DESC" %]
-			<input type="text" class="stdedit" name="pref_host" id="host" value="[% prefs.pref_host || 'localhost' | html %]" size="40">
+		[% IF prefs.exists('pref_host') %]
+			[% WRAPPER settingGroup title="SETUP_MMSHOST" desc="SETUP_MMSHOST_DESC" %]
+				<input type="text" class="stdedit" name="pref_host" id="host" value="[% prefs.pref_host || 'localhost' | html %]" size="40">
+			[% END %]
 		[% END %]
 
 		[% IF prefs.exists('pref_port') %]
 			[% WRAPPER settingGroup title="SETUP_MMSPORT" desc="SETUP_MMSPORT_DESC" %]
 				<input type="text" class="stdedit" name="pref_port" id="port" value="[% prefs.pref_port | html %]" size="5">
+			[% END %]
+		[% END %]
+
+		[% IF prefs.exists('pref_path_conversion_enabled') %]
+			[% WRAPPER settingGroup title="MUSICIP_PATH_CONVERSION" desc="MUSICIP_PATH_CONVERSION_DESC" %]
+				<input type="checkbox" name="pref_path_conversion_enabled" id="path_conversion_enabled" value="1" [% IF prefs.pref_path_conversion_enabled %]checked[% END %]>
+				<label for="path_conversion_enabled">[% "MUSICIP_PATH_CONVERSION_ENABLE" | string %]</label>
+			[% END %]
+
+			[% WRAPPER settingGroup title="MUSICIP_PATH_CONVERSION_SOURCE" %]
+				<input type="text" class="stdedit" name="pref_path_conversion_source" id="path_conversion_source" value="[% prefs.pref_path_conversion_source | html %]" size="40" placeholder="Z:\music">
+			[% END %]
+
+			[% WRAPPER settingGroup title="MUSICIP_PATH_CONVERSION_DEST" %]
+				<input type="text" class="stdedit" name="pref_path_conversion_dest" id="path_conversion_dest" value="[% prefs.pref_path_conversion_dest | html %]" size="40" placeholder="/music">
 			[% END %]
 		[% END %]
 

--- a/Slim/Plugin/MusicMagic/Importer.pm
+++ b/Slim/Plugin/MusicMagic/Importer.pm
@@ -438,6 +438,10 @@ sub processSong {
 	}
 	else {
 		$songInfo{'file'} = Slim::Utils::Unicode::utf8encode_locale($songInfo{'file'});
+
+		# Path Conversion - a no-op unless configured and the path
+		# actually matches the configured source prefix.
+		$songInfo{'file'} = Slim::Plugin::MusicMagic::Common::translatePath($songInfo{'file'});
 	}
 
 	main::DEBUGLOG && $log->debug("Exporting song: $songInfo{'file'}");

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -932,6 +932,10 @@ sub getMix {
 
 		}
 
+		# Path Conversion - a no-op unless configured and the path
+		# actually matches the configured source prefix.
+		$songs[$j] = Slim::Plugin::MusicMagic::Common::translatePath($songs[$j]);
+
 		if ( -e $songs[$j] || -e Slim::Utils::Unicode::utf8encode_locale($songs[$j]) ) {
 
 			my $url = Slim::Utils::Misc::fileURLFromPath($songs[$j]);

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -32,7 +32,8 @@ sub page {
 
 sub prefs {
 	return ($prefs, qw(musicip scan_interval player_settings host port mix_filter reject_size reject_type
-			   mix_genre mix_genre_filter mix_variety mix_style mix_type mix_size playlist_prefix playlist_suffix));
+			   mix_genre mix_genre_filter mix_variety mix_style mix_type mix_size playlist_prefix playlist_suffix
+			   path_conversion_enabled path_conversion_source path_conversion_dest));
 }
 
 sub handler {

--- a/Slim/Plugin/MusicMagic/strings.txt
+++ b/Slim/Plugin/MusicMagic/strings.txt
@@ -645,6 +645,21 @@ SETUP_MMSHOST_DESC
 	SV	Värdnamnet eller IP-adressen för MusicIP-servern. Ändra detta om MusicIP körs på en annan värd än Lyrion Music Server (t.ex. i en separat Docker-container eller VM). Standard är localhost. Obs: filsökvägarna till din musik måste vara identiska på båda värdarna. Docker-användare bör säkerställa detta genom att använda matchande volymmonterade sökvägar i båda containrarna.
 	ZH_CN	MusicIP服务器的主机名或IP地址。如果MusicIP运行在与Lyrion Music Server不同的主机上（例如在单独的Docker容器或虚拟机中），请更改此设置。默认为localhost。注意：音乐文件路径在两台主机上必须完全相同。Docker用户应通过在两个容器中使用相同的卷挂载路径来确保这一点。
 
+MUSICIP_PATH_CONVERSION
+	EN	Path Conversion
+
+MUSICIP_PATH_CONVERSION_DESC
+	EN	If MusicIP reports song paths that don't match what Lyrion Music Server expects (for example when MusicIP itself runs under Wine and reports Windows-style paths, or when running MusicIP on a different host with a different mount layout), enable this and configure a source and destination path to have them translated automatically.
+
+MUSICIP_PATH_CONVERSION_ENABLE
+	EN	Enable Path Conversion
+
+MUSICIP_PATH_CONVERSION_SOURCE
+	EN	MusicIP path (source)
+
+MUSICIP_PATH_CONVERSION_DEST
+	EN	Lyrion path (destination)
+
 SETUP_MMSPORT
 	CS	HTTP port MusicIP
 	DA	MusicIP HTTP-port


### PR DESCRIPTION
MusicIP-reported song paths are used as-is, which breaks down once MusicIP and Lyrion Music Server don't share the exact same filesystem view — for example MusicIP running in a separate Docker container/VM, or under Wine reporting Windows-style paths (the case from #1624, which this PR supersedes with a general solution). The settings page description for the existing host setting already points at this scenario, but currently only suggests matching volume mounts as a workaround; that isn't always possible.

Dynamic Path Conversion (DPC)

A configurable source/destination path prefix pair, applied wherever MusicIP-reported paths are consumed (Importer.pm::processSong, Plugin.pm::getMix) — the same two call sites the Wine-specific fix in #1624 targeted. Disabled by default and a no-op unless both source and destination are configured, so it never affects a standard installation. Works the same way the SugarCube LMS plugin's own DPC setting does.

Fix: host field leaking onto the per-player settings page

While testing, found that musicmagic.html's pref_host field was the only field on the page not wrapped in [% IF prefs.exists('pref_host') %] — every other field, including port, has that guard. Since ClientSettings.pm correctly excludes host from the per-player prefs list, this meant the field rendered anyway (as an orphaned, non-functional input) whenever the page was reused for the per-player view via mipclient.html. Added the missing guard, matching every other field on the page.

Testing

Verified on a public/9.2 LMS instance:

Mood Mixer / MusicIP Mix work correctly with DPC configured, and fail without it, confirming the path translation is actually exercised
Host field no longer appears on the per-player settings page after the guard fix