### PR TITLE
Further fixes for gapless playback support in UPnP/DLNA Media Renderer

### DIFF
--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -8,7 +8,9 @@ package Slim::Plugin::UPnP::MediaRenderer::AVTransport;
 
 use strict;
 
+use URI ();
 use URI::Escape qw(uri_unescape);
+use UUID::Tiny ();
 
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
@@ -20,6 +22,12 @@ use constant EVENT_RATE => 0.2;
 
 my $log   = logger('plugin.upnp');
 my $prefs = preferences('server');
+
+# Track metadata keyed by the synthetic id (see _newTrackId), kept independent
+# of any particular client's pluginData: in a sync group, Song::getNextSong()/
+# ProtocolHandler::scanUrl()/getMetadataFor() operate on the sync-group's master
+# client, which may not be the client this UPnP session's state is stored on.
+my %_trackMeta;
 
 sub init {
 	my $class = shift;
@@ -95,6 +103,7 @@ sub clientEvent {
 	if ( $cmd eq 'clear' ) {
 		main::DEBUGLOG && $log->is_debug && $log->debug('playlist clear event, resetting state');
 
+		# NOTE: deliberately not cleaning up %_trackMeta here
 		$class->changeState( $client, _initialState() );
 		return;
 	}
@@ -113,21 +122,19 @@ sub clientEvent {
 			if ( scalar @{$playlist} > 1 ) {
 				if ( my $song = ($client->playingSong() || $client->streamingSong()) ) {
 
-					my $nextURI = $pd->{AVT}->{NextAVTransportURI};
+					my $nextId = $pd->{avt_NextTrackId};
 					my $currentURIMetadata = $pd->{AVT}->{CurrentTrackMetaData};
 					my $track = $song->currentTrack;
 
-					# Convert URI to protocol handler
-					$currentURI =~ s/^http/upnp/;
-					$nextURI =~ s/^http/upnp/;
-
-					# Only continue if the track has transitioned to nextURI
-					# this also provides a check if the track not a upnp track
-					if ( $track->url eq $nextURI ) {
+					# Only continue if the track has transitioned to the queued NextURI track,
+					# matched by our internal synthetic id rather than the original URI (see _newTrackId)
+					if ( $nextId && $track->url eq $nextId ) {
 						main::DEBUGLOG && $log->is_debug && $log->debug("playlist $cmd event, queueing next track");
 
-						# player has moved on to next track, copy NextURI to CurrentURI
-						$pd->{avt_AVTransportURIMetaData_hash} = $pd->{avt_NextAVTransportURIMetaData_hash};
+						# player has moved on to next track, drop the metadata of the one that just finished
+						delete $_trackMeta{ $pd->{avt_CurrentTrackId} } if $pd->{avt_CurrentTrackId};
+						$pd->{avt_CurrentTrackId} = $nextId;
+						$pd->{avt_NextTrackId} = undef;
 						$currentURI = $pd->{AVT}->{NextAVTransportURI};
 						$currentURIMetadata = $pd->{AVT}->{NextAVTransportURIMetaData};
 
@@ -140,6 +147,8 @@ sub clientEvent {
 							CurrentTrackMetaData		=> $currentURIMetadata,
 							AVTransportURI				=> $currentURI,
 							AVTransportURIMetaData		=> $currentURIMetadata,
+							NextAVTransportURI			=> '',
+							NextAVTransportURIMetaData	=> '',
 						} );
 					}
 					elsif (main::DEBUGLOG && $log->is_debug) {
@@ -298,6 +307,14 @@ sub SetAVTransportURI {
 
 	# If we get an empty CurrentURI value, clear the playlist
 	if ( exists $args->{CurrentURI} && $args->{CurrentURI} eq '' ) {
+		# clientEvent's 'clear' handler never cleans up %_trackMeta (see comment
+		# there), so do it here instead - this is a genuine reset, no new track follows.
+		my $pd = $client->pluginData();
+		delete $_trackMeta{ $pd->{avt_CurrentTrackId} } if $pd->{avt_CurrentTrackId};
+		delete $_trackMeta{ $pd->{avt_NextTrackId} } if $pd->{avt_NextTrackId};
+		$pd->{avt_CurrentTrackId} = undef;
+		$pd->{avt_NextTrackId} = undef;
+
 		$client->execute( [ 'playlist', 'clear' ] );
 
 		$newstate = 'NO_MEDIA_PRESENT';
@@ -317,12 +334,13 @@ sub SetAVTransportURI {
 
 		my $pd = $client->pluginData();
 
-		# Convert URI to protocol handler
-		my $upnp_uri = $meta->{res}->{uri};
-		$upnp_uri =~ s/^http/upnp/;
+		# Synthetic, globally unique track identity, see _newTrackId
+		my $trackId = $class->_newTrackId( $meta->{res}->{uri} );
+		$meta->{_id} = $trackId;
+		$_trackMeta{$trackId} = $meta;
 
-		Slim::Music::Info::setBitrate( $upnp_uri, $meta->{res}->{bitrate} );
-		Slim::Music::Info::setDuration( $upnp_uri, $meta->{res}->{secs} );
+		Slim::Music::Info::setBitrate( $trackId, $meta->{res}->{bitrate} );
+		Slim::Music::Info::setDuration( $trackId, $meta->{res}->{secs} );
 
 		$mediaDuration = $meta->{res}->{duration}; # XXX more if URI is a playlist?
 		$trackDuration = $mediaDuration;
@@ -330,7 +348,10 @@ sub SetAVTransportURI {
 		$numTracks = 1; # XXX more if playlist
 		$curTrack  = 1;
 
-		$pd->{avt_AVTransportURIMetaData_hash} = $meta;
+		delete $_trackMeta{ $pd->{avt_CurrentTrackId} } if $pd->{avt_CurrentTrackId};
+		delete $_trackMeta{ $pd->{avt_NextTrackId} } if $pd->{avt_NextTrackId};
+		$pd->{avt_CurrentTrackId} = $trackId;
+		$pd->{avt_NextTrackId} = undef;
 
 		my $tstate = $pd->{AVT}->{TransportState};
 
@@ -339,19 +360,19 @@ sub SetAVTransportURI {
 		if ( $tstate eq 'NO_MEDIA_PRESENT' || $tstate eq 'STOPPED' ) {
 			# Both of these go to STOPPED, so load the track without playing it
 			$client->execute( [ 'playlist', 'clear' ] );
-			$client->execute( [ 'playlist', 'add', $upnp_uri, $meta->{title} ] );
+			$client->execute( [ 'playlist', 'add', $trackId, $meta->{title} ] );
 			$newstate = 'STOPPED';
 		}
 		elsif ( $tstate eq 'PLAYING' || $tstate eq 'TRANSITIONING' ) {
 			# Both of these go to PLAYING with the new URI
-			$client->execute( [ 'playlist', 'play', $upnp_uri, $meta->{title} ] );
+			$client->execute( [ 'playlist', 'play', $trackId, $meta->{title} ] );
 			$newstate = $tstate;
 		}
 		elsif ( $tstate eq 'PAUSED_PLAYBACK' ) {
 			# A bit strange, this is apparently supposed to load the new track but remains paused
 			# We'll set it to STOPPED to keep it simple
 			$client->execute( [ 'playlist', 'clear' ] );
-			$client->execute( [ 'playlist', 'add', $upnp_uri, $meta->{title} ] );
+			$client->execute( [ 'playlist', 'add', $trackId, $meta->{title} ] );
 			$newstate = 'STOPPED';
 		}
 	}
@@ -398,7 +419,8 @@ sub SetNextAVTransportURI {
 	if ( exists $args->{NextURI} && $args->{NextURI} eq '' ) {
 
 		# NextURI is blank, clear NextURI track from playlist
-		$pd->{avt_NextAVTransportURIMetaData_hash} = '';
+		delete $_trackMeta{ $pd->{avt_NextTrackId} } if $pd->{avt_NextTrackId};
+		$pd->{avt_NextTrackId} = undef;
 		main::DEBUGLOG && $log->is_debug && $log->debug("NextURI cleared");
 
 	} else {
@@ -412,21 +434,26 @@ sub SetNextAVTransportURI {
 		}
 
 		my $upnp_uri = $meta->{res}->{uri};
-		my $upnp_uricached = $pd->{avt_NextAVTransportURIMetaData_hash}->{res}->{uri};
+		my $cachedMeta = $pd->{avt_NextTrackId} ? $_trackMeta{ $pd->{avt_NextTrackId} } : undef;
+		my $upnp_uricached = $cachedMeta ? $cachedMeta->{res}->{uri} : undef;
 
 		# only update if NextURI has changed or it's not queued yet
-		if ( $upnp_uri ne $upnp_uricached || scalar @{$playlist} < 2 ){
+		if ( !defined($upnp_uricached) || $upnp_uri ne $upnp_uricached || scalar @{$playlist} < 2 ){
 
-			# Convert URI to protocol handler
-			$upnp_uri =~ s/^http/upnp/;
-			Slim::Music::Info::setBitrate( $upnp_uri, $meta->{res}->{bitrate} );
-			Slim::Music::Info::setDuration( $upnp_uri, $meta->{res}->{secs} );
+			# Synthetic, globally unique track identity, see _newTrackId
+			my $trackId = $class->_newTrackId( $meta->{res}->{uri} );
+			$meta->{_id} = $trackId;
+			$_trackMeta{$trackId} = $meta;
 
-			$pd->{avt_NextAVTransportURIMetaData_hash} = $meta;
+			Slim::Music::Info::setBitrate( $trackId, $meta->{res}->{bitrate} );
+			Slim::Music::Info::setDuration( $trackId, $meta->{res}->{secs} );
+
+			delete $_trackMeta{ $pd->{avt_NextTrackId} } if $pd->{avt_NextTrackId};
+			$pd->{avt_NextTrackId} = $trackId;
 
 			# use insert to make sure it is queued next.
-			$client->execute( [ 'playlist', 'insert', $upnp_uri, $meta->{title} ] );
-			main::DEBUGLOG && $log->is_debug && $log->debug("NextURI set " . $upnp_uri . ":" . $meta->{title});
+			$client->execute( [ 'playlist', 'insert', $trackId, $meta->{title} ] );
+			main::DEBUGLOG && $log->is_debug && $log->debug("NextURI set " . $trackId . ":" . $meta->{title});
 		}
 	}
 
@@ -569,22 +596,22 @@ sub Play {
 
 	my $transportState = $state->{TransportState};
 
-	my $upnp_uri = $state->{AVTransportURI};
-	$upnp_uri =~ s/^http/upnp/;
+	# Compare by our internal synthetic id, not by original URI (see _newTrackId)
+	my $trackId = $client->pluginData()->{avt_CurrentTrackId};
 
 	if ( $transportState eq 'PLAYING' || $transportState eq 'TRANSITIONING' ) {
 		# Check if same track is already playing
 		my $playingURI = $client->playingSong->currentTrack->url;
-		if ( $upnp_uri eq $playingURI ) {
-			main::DEBUGLOG && $log->is_debug && $log->debug("Play for $upnp_uri ignored, already playing");
+		if ( $trackId && $trackId eq $playingURI ) {
+			main::DEBUGLOG && $log->is_debug && $log->debug("Play for $trackId ignored, already playing");
 			return;
 		}
 	}
 	elsif ( $transportState eq 'PAUSED_PLAYBACK' ) {
 		# Check if we should just unpause
 		my $playingURI = $client->playingSong->currentTrack->url;
-		if ( $upnp_uri eq $playingURI ) {
-			main::DEBUGLOG && $log->is_debug && $log->debug("Play for $upnp_uri triggering unpause");
+		if ( $trackId && $trackId eq $playingURI ) {
+			main::DEBUGLOG && $log->is_debug && $log->debug("Play for $trackId triggering unpause");
 
 			$client->execute(['play']); # will resume
 
@@ -732,6 +759,29 @@ sub GetCurrentTransportActions {
 }
 
 ### Helper methods
+
+# Creates a synthetic, globally unique track identity.
+# DLNA allows different playlist entries to share the same URI, but LMS keys
+# Schema/Playlist/metadata by a unique url, so this will be used there instead
+# of the (possibly duplicate) original URI.
+# The original URI's file suffix (if any) is kept, so suffix-based type detection
+# (e.g. ProtocolHandler::getFormatForURL) keeps working unchanged.
+sub _newTrackId {
+	my ( $class, $uri ) = @_;
+
+	my $path = $uri ? URI->new($uri)->path : '';
+	my ($suffix) = $path =~ /(\.[A-Za-z0-9]+)$/;
+	$suffix ||= '';
+
+	return 'upnp://' . uc( UUID::Tiny::create_UUID_as_string( UUID::Tiny::UUID_V4() ) ) . '/track' . $suffix;
+}
+
+# Metadata for a track by its synthetic id, regardless of which client's
+# pluginData it was originally stored under (see %_trackMeta above).
+sub trackMetaFor {
+	my ( $class, $id ) = @_;
+	return $id ? $_trackMeta{$id} : undef;
+}
 
 # Elapsed time in H:MM:SS[.F+] format
 sub _relativeTimePosition {

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -388,6 +388,14 @@ sub SetAVTransportURI {
 		}
 	}
 
+	# With repeat enabled, we may accidentally wrap back to index 0 whenever
+	# the next track hasn't been inserted yet, but the DLNA server already ended 
+	# the connection of the current track, making LMS re-connect and repeat the 
+	# still current track instead of waiting for SetNextAVTransportURI.
+	# Repeat is meaningless here anyway since the Control Point, not LMS,
+	# dictates which track to play.
+	Slim::Player::Playlist::repeat( $client, 0 );
+
 	# Event notification, on a timer so playlist clear comes first and deletes everything
 	# then this resets the new data.
 	Slim::Utils::Timers::setTimer( undef, Time::HiRes::time, sub {
@@ -467,6 +475,9 @@ sub SetNextAVTransportURI {
 			main::DEBUGLOG && $log->is_debug && $log->debug("NextURI set " . $trackId . ":" . $meta->{title});
 		}
 	}
+
+	# see SetAVTransportURI
+	Slim::Player::Playlist::repeat( $client, 0 );
 
 	# Change state variables
 	$class->changeState( $client, {

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -94,9 +94,20 @@ sub _initialState {
 ### Eventing
 
 sub clientEvent {
-	my $class   = __PACKAGE__;
-	my $request = shift;
-	my $client  = $request->client;
+	my $class          = __PACKAGE__;
+	my $request        = shift;
+	my $notifiedClient = $request->client || return;
+
+	# Re-target to whichever of our clients is actually in the notified
+	# client's sync group. One of them is the one the UPnP control point is 
+	# talking to and we must ensure that that one catches the event.
+	for my $client ( $notifiedClient->syncGroupActiveMembers() ) {
+		$class->_clientEvent( $request, $client );
+	}
+}
+
+sub _clientEvent {
+	my ( $class, $request, $client ) = @_;
 
 	my $cmd = $request->getRequest(1);
 

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -149,6 +149,9 @@ sub _clientEvent {
 						$currentURI = $pd->{AVT}->{NextAVTransportURI};
 						$currentURIMetadata = $pd->{AVT}->{NextAVTransportURIMetaData};
 
+						my $currentMeta = $_trackMeta{$nextId};
+						my $currentDuration = $currentMeta ? $currentMeta->{res}->{duration} : '00:00:00';
+
 						# Remove track that just finished playing. The plugin protocol
 						# handler can only return metadata for currentURI and NextURI
 						$client->execute(["playlist", "delete", 0]);
@@ -160,6 +163,8 @@ sub _clientEvent {
 							AVTransportURIMetaData		=> $currentURIMetadata,
 							NextAVTransportURI			=> '',
 							NextAVTransportURIMetaData	=> '',
+							CurrentTrackDuration		=> $currentDuration,
+							CurrentMediaDuration		=> $currentDuration,
 						} );
 					}
 					elsif (main::DEBUGLOG && $log->is_debug) {

--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -14,6 +14,8 @@ use Slim::Utils::Errno;
 use Slim::Utils::Log;
 use Slim::Utils::Misc;
 
+use Slim::Plugin::UPnP::MediaRenderer::AVTransport ();
+
 use constant MAX_RAW_READ => 32768;
 
 my $log = logger('plugin.upnp');
@@ -170,6 +172,18 @@ sub new {
 # Avoid scanning
 sub scanUrl {
 	my ($class, $url, $args) = @_;
+
+	# $url is a synthetic per-playlist-entry id (see AVTransport::_newTrackId),
+	# looked up via AVTransport's client-independent registry rather than
+	# $args->{client}'s pluginData: in a sync group, this is called with the
+	# sync-group's master client, which may not be the client this UPnP
+	# session's state was stored on.
+	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor($url);
+
+	if ( ref($meta) eq 'HASH' && ( my $uri = $meta->{res}->{uri} ) ) {
+		$args->{song}->streamUrl($uri);
+	}
+
 	$args->{cb}->($args->{song}->currentTrack());
 }
 
@@ -218,31 +232,13 @@ sub getMetadataFor {
 	my ( $class, $client, $url ) = @_;
 
 	# This returns metadata for any tracks added to the playlist via the plugin.
-
-	# convert protocal handler
-	$url =~ s/^upnp/http/;
-
-	my $pd = ($client && $client->pluginData()) || {};
-	my $meta = $pd->{avt_AVTransportURIMetaData_hash};
-	my $res = $meta->{res};
-	my $currentUri = $res->{uri};
-
-	# if $url doesn't match CurrentURI check against NextUri
-	if ( $url && $currentUri && $url ne $currentUri ) {
-		my $nextMeta = $pd->{avt_NextAVTransportURIMetaData_hash};
-
-		# check for cleared NextUri
-		if ( ref($nextMeta) eq 'HASH' ) {
-
-			my $nextRes = $nextMeta->{res};
-			$currentUri = $nextRes->{uri};
-
-			if ( $currentUri && $url eq $currentUri ) {
-				$meta = $nextMeta;
-				$res = $nextRes;
-			}
-		}
-	}
+	# $url is a synthetic per-playlist-entry id (see AVTransport::_newTrackId),
+	# looked up via AVTransport's client-independent registry rather than
+	# $client's pluginData: in a sync group, this is called with the sync-group's
+	# master client, which may not be the client this UPnP session's state was
+	# stored on.
+	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor($url) || {};
+	my $res  = $meta->{res} || {};
 
 	main::DEBUGLOG && $log->is_debug && $log->debug( 'Metadata returned for  ' . $meta->{title} );
 	return {

--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -161,7 +161,7 @@ sub new {
 		url     => $streamUrl,
 		song    => $args->{song},
 		client  => $client,
-		bitrate => 128_000, # XXX
+		bitrate => $song->bitrate() || 128_000,
 	} ) || return;
 
 	${*$sock}{contentType} = 'audio/mpeg'; # XXX


### PR DESCRIPTION
This PR addresses two problems when LMS is controlled by a DLNA Control Point and using gapless playback:
- **The DLNA spec allows successive tracks to have identical URIs.**
At least [pa-dlna](https://gitlab.com/xdegaye/pa-dlna) is actively using this (even for different tracks!) and this can also happen when used in conjunction with other media servers if the same track is set to play twice in a row. 
Since LMS is using the track url internally as a key for connection management and metadata identification, this causes LMS to mess-up the HTTP connections and the metadata at the track change.
To address this, this PR introduces a new synthetic track url in the form _"upnp://\<GUID\>/track(.\<suffix\>)"_ that instead always uniquely identifies tracks inserted by `SetAVTransportURI` or `SetNextAVTransportURI` as LMS' internal urls.
The actual URI will now only be used for opening the remote connection.
- **The DLNA spec allows the server to close the connection of the current track "at the same time" (or even shortly before!) the next track is announced by `SetNextAVTransportURI`.**
This caused a race-condition in LMS at a track change: When the current connection is closed by the remote shortly before the `SetNextAVTransportURI` arrived and the "Repeat" flag is currently switched on in the client, LMS will start to repeat the current track instead of waiting for arrival of the `SetNextAVTransportURI` message, so the next track will be still placed correclty in the playlist, but the current track will become accidentally repeated.
To address this, we switch off "Repeat" in the client. Repeat is meaningless here anyway since it is the DLNA Control Point, not LMS, that dictates the track order here. The drawback of this is that we permanently alter the client’s "Repeat" flag.

In addition, this PR fixes three pre-existing bugs:
- **Track metadata of UPnP/DLNA tracks have never been properly synchronized among clients of a sync group.**
This is fixed by adding a module-level metadata registry `%_trackMeta` in `AVTransport` that is used to resolve metadata independently from the client context.
- **Newsong/clear detection failed for sync-grouped players, when the sync-group's master was different from the specific player the UPnP control point is actually talking to.**
This is fixed by re-targeting each notification internally to all members of the notified client's sync-group. This ensures that the player the UPnP Control Point is actually talking to certainly receives it.
- **Track bitrate and duration wasn't properly initially set and updated for UPnP/DLNA tracks**
This caused seeking to sometimes not work correctly, because byte position calculations on LMS-side were occasionally wrong, because the actual bitrate of the song was ignored and the song duration was not in sync with the Control Point, because it was not updated at a track change.

Note: As a result of the transition to GUID-based track URLs, the RegEx `http://` → `upnp://` is no longer necessary, so `https://` URIs should now also be supported. However, I have not been able to test this.

Tested with:
- [BubbleUPnP 4.6.5.1](https://play.google.com/store/apps/details?id=com.bubblesoft.android.bubbleupnp) with a single player and players in a sync group
- [pa-dlna 1.2](https://gitlab.com/xdegaye/pa-dlna) with a single player and players in a sync group
- [Hi-Fi Cast 1.135](https://play.google.com/store/apps/details?id=com.findhdmusic.app.upnpcast) with a single player and players in a sync group 
---
**IMPORTANT: 
Although I’ve reviewed and tested the code as thoroughly as possible, I don’t know enough about the internal structures of LMS and I'm not a Perl developer. As the code was generated using AI, it really ought to be looked at very carefully by someone who knows more about it! e.g. @philippe44 ?**

**EDIT:** ...because a discussion about that already arouse: Yes, I used AI, but **-it's me-**, not AI, who spent many many hours in developing this, debugging this, thinking about which would be the best option to solve this problem or that and finally creating this PR.
It was not something like "come on AI, fix this code, no matter how and don't bother me any more, thank you!"

So I really know exactly what I did and what each line of code should do, because **-I-** made every single design decision!
AI only helped me writing Perl syntax and digging through the code to understand what it is doing. But this does not change the need for it being thoroughly reviewed in any way! 