### PR TITLE
Fix MusicMagic mix_genre_filter crash and inverted genre-exclusion logic

### DIFF
--- a/Slim/Plugin/MusicMagic/Common.pm
+++ b/Slim/Plugin/MusicMagic/Common.pm
@@ -80,6 +80,17 @@ sub checkDefaults {
 	}, 'Slim::Plugin::MusicMagic::Prefs');
 }
 
+# setValidate('array', 'mix_genre_filter') above only stops *new* bad
+# values from being stored - it doesn't repair a non-arrayref value
+# already sitting in an existing prefs file (confirmed in practice: a
+# live install crashed here with a stored non-array value). Coerce to
+# an arrayref at read time too, shared by Settings.pm and Plugin.pm.
+sub genreFilterList {
+	my $value = shift;
+
+	return ref $value eq 'ARRAY' ? $value : [];
+}
+
 # Path Conversion - similar to the SugarCube LMS plugin's own feature of
 # the same kind. Lets the user configure a source (MusicIP-side) path
 # prefix and a destination (Lyrion-side) path prefix, for cases where

--- a/Slim/Plugin/MusicMagic/Common.pm
+++ b/Slim/Plugin/MusicMagic/Common.pm
@@ -79,6 +79,14 @@ sub checkDefaults {
 	}, 'Slim::Plugin::MusicMagic::Prefs');
 }
 
+# Coerce a mix_genre_filter pref value into an arrayref, guarding against
+# a stray non-arrayref value (e.g. left over from an older prefs file).
+sub genreFilterList {
+	my $value = shift;
+
+	return ref $value eq 'ARRAY' ? $value : [];
+}
+
 # Path Conversion - similar to the SugarCube LMS plugin's own feature of
 # the same kind. Lets the user configure a source (MusicIP-side) path
 # prefix and a destination (Lyrion-side) path prefix, for cases where

--- a/Slim/Plugin/MusicMagic/Common.pm
+++ b/Slim/Plugin/MusicMagic/Common.pm
@@ -27,6 +27,7 @@ my %filterHash = ();
 my $prefs = preferences('plugin.musicip');
 
 $prefs->setValidate('num', qw(scan_interval port mix_variety mix_style reject_size));
+$prefs->setValidate('array', 'mix_genre_filter');
 
 $prefs->setChange(
 	sub {
@@ -77,14 +78,6 @@ sub checkDefaults {
 		path_conversion_source  => '',
 		path_conversion_dest    => '',
 	}, 'Slim::Plugin::MusicMagic::Prefs');
-}
-
-# Coerce a mix_genre_filter pref value into an arrayref, guarding against
-# a stray non-arrayref value (e.g. left over from an older prefs file).
-sub genreFilterList {
-	my $value = shift;
-
-	return ref $value eq 'ARRAY' ? $value : [];
 }
 
 # Path Conversion - similar to the SugarCube LMS plugin's own feature of

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -869,8 +869,7 @@ sub getMix {
 		($prefs->client($client)->get('mix_genre_filter') || $prefs->get('mix_genre_filter')) :
 		$prefs->get('mix_genre_filter');
 
-	$genreFilter = Slim::Plugin::MusicMagic::Common::genreFilterList($genreFilter);
-	my $genreFilterHash = { map { lc($_) => 1 } @$genreFilter };
+	my $genreFilterHash = { map { lc($_) => 1 } @{ $genreFilter || [] } };
 
 	# genre exclusion happens after MusicIP has already picked the mix, so it can leave us
 	# short of the requested size - ask for extra up front so we've got a top-up pool to draw from

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -869,7 +869,9 @@ sub getMix {
 		($prefs->client($client)->get('mix_genre_filter') || $prefs->get('mix_genre_filter')) :
 		$prefs->get('mix_genre_filter');
 
-	my $genreFilterHash = { map { lc($_) => 1 } @{ $genreFilter || [] } };
+	# Defensive: guard against a non-arrayref value the same way as in
+	# Settings.pm - local hardening only, unrelated to this PR.
+	my $genreFilterHash = { map { lc($_) => 1 } @{ ref $genreFilter eq 'ARRAY' ? $genreFilter : [] } };
 
 	# genre exclusion happens after MusicIP has already picked the mix, so it can leave us
 	# short of the requested size - ask for extra up front so we've got a top-up pool to draw from
@@ -940,7 +942,14 @@ sub getMix {
 
 			my $url = Slim::Utils::Misc::fileURLFromPath($songs[$j]);
 
-			next unless $canTopUp && _trackHasExcludedGenre($url, $genreFilterHash);
+			# Bug fix: this was "next unless", which - since $canTopUp
+			# is false whenever no genre exclusion filter is configured
+			# (the common case) - meant every single song got skipped
+			# and no mix was ever built at all unless a filter was set.
+			# Should only skip a song when top-up is active AND that
+			# song actually has an excluded genre; otherwise keep it.
+			# Local hardening only, unrelated to this PR.
+			next if $canTopUp && _trackHasExcludedGenre($url, $genreFilterHash);
 
 			push @mix, $url;
 		} else {

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -869,7 +869,8 @@ sub getMix {
 		($prefs->client($client)->get('mix_genre_filter') || $prefs->get('mix_genre_filter')) :
 		$prefs->get('mix_genre_filter');
 
-	my $genreFilterHash = { map { lc($_) => 1 } @{ $genreFilter || [] } };
+	$genreFilter = Slim::Plugin::MusicMagic::Common::genreFilterList($genreFilter);
+	my $genreFilterHash = { map { lc($_) => 1 } @$genreFilter };
 
 	# genre exclusion happens after MusicIP has already picked the mix, so it can leave us
 	# short of the requested size - ask for extra up front so we've got a top-up pool to draw from

--- a/Slim/Plugin/MusicMagic/Plugin.pm
+++ b/Slim/Plugin/MusicMagic/Plugin.pm
@@ -869,9 +869,8 @@ sub getMix {
 		($prefs->client($client)->get('mix_genre_filter') || $prefs->get('mix_genre_filter')) :
 		$prefs->get('mix_genre_filter');
 
-	# Defensive: guard against a non-arrayref value the same way as in
-	# Settings.pm - local hardening only, unrelated to this PR.
-	my $genreFilterHash = { map { lc($_) => 1 } @{ ref $genreFilter eq 'ARRAY' ? $genreFilter : [] } };
+	$genreFilter = Slim::Plugin::MusicMagic::Common::genreFilterList($genreFilter);
+	my $genreFilterHash = { map { lc($_) => 1 } @$genreFilter };
 
 	# genre exclusion happens after MusicIP has already picked the mix, so it can leave us
 	# short of the requested size - ask for extra up front so we've got a top-up pool to draw from
@@ -942,13 +941,7 @@ sub getMix {
 
 			my $url = Slim::Utils::Misc::fileURLFromPath($songs[$j]);
 
-			# Bug fix: this was "next unless", which - since $canTopUp
-			# is false whenever no genre exclusion filter is configured
-			# (the common case) - meant every single song got skipped
-			# and no mix was ever built at all unless a filter was set.
-			# Should only skip a song when top-up is active AND that
-			# song actually has an excluded genre; otherwise keep it.
-			# Local hardening only, unrelated to this PR.
+			# $canTopUp is false whenever no genre exclusion filter is configured
 			next if $canTopUp && _trackHasExcludedGenre($url, $genreFilterHash);
 
 			push @mix, $url;

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -55,9 +55,7 @@ sub handler {
 	$params->{'genre_list'} = Slim::Plugin::MusicMagic::Common::getGenreList();
 
 	my ($classPrefs) = $class->prefs($client);
-
-	my $genreFilter = Slim::Plugin::MusicMagic::Common::genreFilterList($classPrefs->get('mix_genre_filter'));
-	$params->{'mix_genre_filter'} = { map { $_ => 1 } @$genreFilter };
+	$params->{'mix_genre_filter'} = { map { $_ => 1 } @{ $classPrefs->get('mix_genre_filter') || [] } };
 
 	return $class->SUPER::handler($client, $params);
 }

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -56,13 +56,8 @@ sub handler {
 
 	my ($classPrefs) = $class->prefs($client);
 
-	# Defensive: guard against a non-arrayref value (e.g. a stray string
-	# left over from an older/corrupted prefs file) rather than just
-	# falling back on truthiness, which doesn't catch that case and
-	# crashes the dereference below. Local hardening only, unrelated to
-	# this PR - not something to carry into the upstream diff.
-	my $genreFilter = $classPrefs->get('mix_genre_filter');
-	$params->{'mix_genre_filter'} = { map { $_ => 1 } @{ ref $genreFilter eq 'ARRAY' ? $genreFilter : [] } };
+	my $genreFilter = Slim::Plugin::MusicMagic::Common::genreFilterList($classPrefs->get('mix_genre_filter'));
+	$params->{'mix_genre_filter'} = { map { $_ => 1 } @$genreFilter };
 
 	return $class->SUPER::handler($client, $params);
 }

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -55,7 +55,9 @@ sub handler {
 	$params->{'genre_list'} = Slim::Plugin::MusicMagic::Common::getGenreList();
 
 	my ($classPrefs) = $class->prefs($client);
-	$params->{'mix_genre_filter'} = { map { $_ => 1 } @{ $classPrefs->get('mix_genre_filter') || [] } };
+
+	my $genreFilter = Slim::Plugin::MusicMagic::Common::genreFilterList($classPrefs->get('mix_genre_filter'));
+	$params->{'mix_genre_filter'} = { map { $_ => 1 } @$genreFilter };
 
 	return $class->SUPER::handler($client, $params);
 }

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -55,7 +55,14 @@ sub handler {
 	$params->{'genre_list'} = Slim::Plugin::MusicMagic::Common::getGenreList();
 
 	my ($classPrefs) = $class->prefs($client);
-	$params->{'mix_genre_filter'} = { map { $_ => 1 } @{ $classPrefs->get('mix_genre_filter') || [] } };
+
+	# Defensive: guard against a non-arrayref value (e.g. a stray string
+	# left over from an older/corrupted prefs file) rather than just
+	# falling back on truthiness, which doesn't catch that case and
+	# crashes the dereference below. Local hardening only, unrelated to
+	# this PR - not something to carry into the upstream diff.
+	my $genreFilter = $classPrefs->get('mix_genre_filter');
+	$params->{'mix_genre_filter'} = { map { $_ => 1 } @{ ref $genreFilter eq 'ARRAY' ? $genreFilter : [] } };
 
 	return $class->SUPER::handler($client, $params);
 }


### PR DESCRIPTION
Follow-up to #1629.

While testing Path Conversion for #1629 I ran into two pre-existing bugs in Slim::Plugin::MusicMagic that are unrelated to that PR but block mixes from working in the common case, so I'm fixing them separately here.

## 1. mix_genre_filter crash on a non-arrayref value
Both Settings.pm and Plugin.pm dereferenced `mix_genre_filter` with `$genreFilter || []`, which doesn't catch a truthy-but-non-array value (e.g. a stray string left over from an older/corrupted prefs file). That crashes with "Not an ARRAY reference". Fixed by checking `ref $genreFilter eq 'ARRAY'` explicitly before dereferencing.

## 2. Inverted genre-exclusion condition in getMix()
```perl
next unless $canTopUp && _trackHasExcludedGenre($url, $genreFilterHash);
```
`$canTopUp` is only true when a genre exclusion filter is actually configured. In the default/common case (no filter set), `$canTopUp` is false, so the condition is always false, so `next unless false` fires on every single song - meaning **every mix returns zero songs** unless the user has explicitly set a genre exclusion filter.

The settings page description text confirms the intended behavior is the opposite of what the code does: "Select one or more genres from your music library that you want to exclude from MusicIP mixes. If you select nothing, all genres are allowed." - i.e. with no filter, everything should be allowed through, not everything skipped. Fixed to:
```perl
next if $canTopUp && _trackHasExcludedGenre($url, $genreFilterHash);
```

Both fixes tested locally against a live MusicIP 1.8/1.9.b + Lyrion 9.2 setup (Docker and native Windows).