### PR TITLE
fix unicode directory names in single directory scan

### DIFF
--- a/Slim/Web/Settings/Server/Basic.pm
+++ b/Slim/Web/Settings/Server/Basic.pm
@@ -96,7 +96,7 @@ sub handler {
 				push @paths, $path;
 
 				if ($paramRef->{"pref_rescan_mediadir$i"}) {
-					$singleDirScan = Slim::Utils::Misc::fileURLFromPath($path);
+					$singleDirScan = Slim::Utils::Misc::fileURLFromPath(Slim::Utils::Unicode::encode_locale($path));
 				}
 
 				push @{ $ignoreFolders }, $path if !$paramRef->{"pref_ignoreInAudioScan$i"};


### PR DESCRIPTION
While testing the artwork changes, I noticed the single dir scan wasn't working with "complicated" directory names. Hopefully this fixes it (at least in works under Linux en-GB).