### PR TITLE
Finish support for querying transcoding results.

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4111,6 +4111,11 @@ sub statusQuery {
 			$request->addResult('replay_gain', $trackGain);
 		}
 
+		my $transcoded = $song->transcoded();
+		if (defined $transcoded) {
+			$request->addResult('is_transcoded', $transcoded);
+		}
+
 		if ($tags =~ /b/) {   # get the song's current bitrate
 			my $bitrate = $song->streambitrate();
 			if (defined $bitrate && $bitrate) {

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -429,6 +429,10 @@ sub open {
 		} elsif (main::INFOLOG && $log->is_info) {
 			 $log->info("Transcoder: streamMode=", $transcoder->{'streamMode'}, ", streamformat=", $transcoder->{'streamformat'});
 		}
+		
+		# Init song's sample rate and sample size before any transcoding
+		$self->samplerate($transcoder->{'sampleRate'});
+		$self->samplesize($transcoder->{'sampleSize'});
 
 		if ($wantTranscoderSeek && (grep(/T/, @{$transcoder->{'usedCapabilities'}}))) {
 			$transcoder->{'start'} = $self->startOffset($self->seekdata()->{'timeOffset'});

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -13,6 +13,7 @@ use strict;
 use base qw(Slim::Utils::Accessor);
 
 use Fcntl qw(SEEK_CUR SEEK_SET);
+use List::Util qw(first max min);
 
 use Slim::Utils::Log;
 use Slim::Schema;
@@ -620,7 +621,23 @@ sub open {
 
 				$self->_transcoded(1);
 
-				$self->_streambitrate(guessBitrateFromFormat($transcoder->{'streamformat'}, $transcoder->{'rateLimit'}) || 0);
+				my $streamformat = $transcoder->{'streamformat'};
+				$self->_streamFormat($streamformat);
+				my $rate;
+				my $sampleSize;
+
+				if ($streamformat eq 'mp3') {
+					$rate = $transcoder->{'rateLimit'};  # bitrate limit
+					$self->samplesize("");  # clear samplesize for mp3
+					$self->samplerate( min($transcoder->{'sampleRate'}, $transcoder->{'samplerateLimit'}) );
+				} else {
+					$rate = $transcoder->{'samplerateLimit'};  # samplerate limit
+					$sampleSize = $transcoder->{'sampleSize'};
+					$self->samplesize($sampleSize);
+					$self->samplerate($rate);
+				}
+
+				$self->_streambitrate(guessBitrateFromFormat($streamformat, $rate, $sampleSize) || 0);
 			}
 		} # ENDIF main::TRANSCODING
 
@@ -681,18 +698,22 @@ sub open {
 
 # Static method
 sub guessBitrateFromFormat {
-	my ($format, $maxRate) = @_;
+	my ($format, $rate, $sampleSize) = @_;
 
 	# Hack to set up stream bitrate for songTime for SliMP3/SB1
 	# Also used when rebuffering, etc.
+
+	if (!defined $sampleSize) {
+		$sampleSize = 16;
+	}
 	if ($format eq 'mp3') {
-		return ($maxRate || 320) * 1000;
+		return ($rate || 320) * 1000;
 	} elsif ($format =~ /wav|aif|pcm/) {
 		# Just assume standard rate
-		return 44_100 * 16 * 2;
+		return $rate * $sampleSize * 2;
 	} elsif ($format eq 'flc') {
-		# Assume 50% compression at standard rate
-		return 44_100 * 16;
+		# Assume 50% compression at max rate
+		return $rate * $sampleSize;
 	}
 }
 
@@ -734,6 +755,7 @@ sub isRemote            {return $_[0]->currentTrackHandler()->isRemote();}
 sub streamformat        {return $_[0]->_streamFormat() || Slim::Music::Info::contentType($_[0]->currentTrack()->url);}
 sub isPlaylist          {return $_[0]->_playlist();}
 sub status              {return $_[0]->_status();}
+sub transcoded          {return $_[0]->_transcoded();}
 
 sub getSeekDataByPosition {
 	my ($self, $bytesReceived) = @_;

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -13,7 +13,7 @@ use strict;
 use base qw(Slim::Utils::Accessor);
 
 use Fcntl qw(SEEK_CUR SEEK_SET);
-use List::Util qw(first max min);
+use List::Util qw(min);
 
 use Slim::Utils::Log;
 use Slim::Schema;
@@ -623,21 +623,23 @@ sub open {
 
 				my $streamformat = $transcoder->{'streamformat'};
 				$self->_streamFormat($streamformat);
-				my $rate;
+				
+				my $bitrate;
 				my $sampleSize;
+				my $sampleRate;
 
-				if ($streamformat eq 'mp3') {
-					$rate = $transcoder->{'rateLimit'};  # bitrate limit
-					$self->samplesize("");  # clear samplesize for mp3
+				if ($streamformat =~ /mp3|aac/) {
+					$bitrate = $transcoder->{'rateLimit'};  # bitrate limit
+					$self->samplesize("");  # clear samplesize for lossy formats
 					$self->samplerate( min($transcoder->{'sampleRate'}, $transcoder->{'samplerateLimit'}) );
 				} else {
-					$rate = $transcoder->{'samplerateLimit'};  # samplerate limit
+					$sampleRate = $transcoder->{'samplerateLimit'};  # samplerate limit
 					$sampleSize = $transcoder->{'sampleSize'};
 					$self->samplesize($sampleSize);
-					$self->samplerate($rate);
+					$self->samplerate($sampleRate);
 				}
 
-				$self->_streambitrate(guessBitrateFromFormat($streamformat, $rate, $sampleSize) || 0);
+				$self->_streambitrate(guessBitrateFromFormat($streamformat, $bitrate, $sampleSize, $sampleRate) || 0);
 			}
 		} # ENDIF main::TRANSCODING
 
@@ -698,7 +700,7 @@ sub open {
 
 # Static method
 sub guessBitrateFromFormat {
-	my ($format, $rate, $sampleSize) = @_;
+	my ($format, $bitrate, $sampleSize, $sampleRate) = @_;
 
 	# Hack to set up stream bitrate for songTime for SliMP3/SB1
 	# Also used when rebuffering, etc.
@@ -706,14 +708,17 @@ sub guessBitrateFromFormat {
 	if (!defined $sampleSize) {
 		$sampleSize = 16;
 	}
-	if ($format eq 'mp3') {
-		return ($rate || 320) * 1000;
+	if (!defined $sampleRate) {
+		$sampleRate = 44_100;
+	}
+	if ($format =~ /mp3|aac/) {
+		return ($bitrate || 320) * 1000;
 	} elsif ($format =~ /wav|aif|pcm/) {
 		# Just assume standard rate
-		return $rate * $sampleSize * 2;
+		return $sampleRate * $sampleSize * 2;
 	} elsif ($format eq 'flc') {
 		# Assume 50% compression at max rate
-		return $rate * $sampleSize;
+		return $sampleRate * $sampleSize;
 	}
 }
 

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -621,6 +621,8 @@ sub open {
 
 				$self->_transcoded(1);
 
+				main::INFOLOG && $log->info("Transcoder: ", Data::Dump::dump($transcoder));
+
 				my $streamformat = $transcoder->{'streamformat'};
 				$self->_streamFormat($streamformat);
 				
@@ -705,12 +707,9 @@ sub guessBitrateFromFormat {
 	# Hack to set up stream bitrate for songTime for SliMP3/SB1
 	# Also used when rebuffering, etc.
 
-	if (!defined $sampleSize) {
-		$sampleSize = 16;
-	}
-	if (!defined $sampleRate) {
-		$sampleRate = 44_100;
-	}
+	$sampleSize //= 16;
+	$sampleRate //= 44_100;
+
 	if ($format =~ /mp3|aac/) {
 		return ($bitrate || 320) * 1000;
 	} elsif ($format =~ /wav|aif|pcm/) {

--- a/Slim/Player/TranscodingHelper.pm
+++ b/Slim/Player/TranscodingHelper.pm
@@ -433,6 +433,8 @@ sub getConvertCommand2 {
 
 		my $streamformat = (split (/-/, $profile))[1];
 
+		my $defaultRateLimit = $track->samplerate > 44100 ? 48000 : 44100;
+
 		$transcoder = {
 			command          => $command,
 			profile          => $profile,
@@ -440,7 +442,7 @@ sub getConvertCommand2 {
 			streamMode       => $streamMode,
 			streamformat     => $streamformat,
 			rateLimit        => $rateLimit || 320,
-			samplerateLimit  => $samplerateLimit || 44100,
+			samplerateLimit  => $samplerateLimit || $defaultRateLimit,
 			clientid         => $clientid || 'undefined',
 			groupid          => $clientprefs ? ($clientprefs->get('syncgroupid') || 0) : 0,
 			name             => $client ? $client->name : 'undefined',


### PR DESCRIPTION
Add `is_transcoded` attribute to status query for client use and further populate the $song data used to report the results. Also improve the accuracy of the guessBitrateFromFormat() routine for lossless formats by using the actual sample rate and sample size of the stream instead of assuming 16/44.1.