### PR TITLE
Fix mix_genre_filter/template variable collision on settings save

### DIFF
--- a/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
+++ b/Slim/Plugin/MusicMagic/HTML/EN/plugins/MusicMagic/settings/musicmagic.html
@@ -83,7 +83,7 @@
 
 			[% FOREACH genre = genre_list %]
 
-				<option [% IF mix_genre_filter.item(genre) %]selected [% END %]value="[% genre | html %]">[% genre | html %]</option>
+				<option [% IF mix_genre_filter_lookup.item(genre) %]selected [% END %]value="[% genre | html %]">[% genre | html %]</option>
 
 			[%- END -%]
 

--- a/Slim/Plugin/MusicMagic/Settings.pm
+++ b/Slim/Plugin/MusicMagic/Settings.pm
@@ -46,9 +46,15 @@ sub handler {
 		return undef;
 	}
 
-	if ( $params->{'saveSettings'} && (my $selected = $params->{'pref_mix_genre_filter'}) ) {
-		# make sure we always store an arrayref, even if only one genre is selected
-		$params->{'pref_mix_genre_filter'} = [ $selected ] unless ref $selected && ref $selected eq 'ARRAY';
+	if ( $params->{'saveSettings'} ) {
+		my $selected = $params->{'pref_mix_genre_filter'};
+
+		# An empty multi-select submits no value at all (undef), which
+		# means "no genres excluded", not "leave unchanged" - store an
+		# empty arrayref for that case. A single selection submits as a
+		# plain scalar rather than a one-item array; wrap it.
+		$params->{'pref_mix_genre_filter'} = !defined $selected ? []
+			: ( ref $selected eq 'ARRAY' ? $selected : [ $selected ] );
 	}
 
 	$params->{'filters'}    = Slim::Plugin::MusicMagic::Common->getFilterList();
@@ -56,8 +62,13 @@ sub handler {
 
 	my ($classPrefs) = $class->prefs($client);
 
+	# Use a differently-named key for the checkbox-state lookup hash: it
+	# used to be called 'mix_genre_filter', identical to the actual pref
+	# name, which Slim::Web::Settings::handler flags and rejects on save
+	# when the filter is empty (it treats any non-'pref_'-prefixed param
+	# matching a real pref name as a template error).
 	my $genreFilter = Slim::Plugin::MusicMagic::Common::genreFilterList($classPrefs->get('mix_genre_filter'));
-	$params->{'mix_genre_filter'} = { map { $_ => 1 } @$genreFilter };
+	$params->{'mix_genre_filter_lookup'} = { map { $_ => 1 } @$genreFilter };
 
 	return $class->SUPER::handler($client, $params);
 }


### PR DESCRIPTION
Follow-up to #1633.

While rolling out the genre-filter fix on a live 9.1 install (via a repo-installed fork), I ran into two more issues in Settings.pm — both pre-existing, unrelated to #1633's changes but living in the same code. Confirmed both are present in public/9.2 as well - they're just silent unless you happen to save the settings page with the genre filter empty, so easy to miss.

1. mix_genre_filter name collision between pref and template variable

Settings.pm reused the preference name mix_genre_filter as the key for a template-local lookup hash (used to mark which genres are pre-selected in the settings-page checkbox list). Slim::Web::Settings::handler flags any non-pref_-prefixed param that matches a real preference name as a template error, and logs:

Preference names must be prefixed by "pref_" in the page template: mix_genre_filter (MUSICMAGIC)

This fires specifically when saving the settings page with the genre filter empty (an unselected multi-select submits no value at all, so pref_mix_genre_filter stays undefined while the same-named lookup hash is still set). Renamed the lookup hash to mix_genre_filter_lookup.

2. Saving an empty genre filter never actually clears it

Related to the above: because an empty multi-select submits nothing, the code that's supposed to normalize the submitted value into an arrayref only ran when something was truthy - so saving with nothing selected left pref_mix_genre_filter undefined instead of storing [], and (once the name collision above is fixed) the validator then rejects the save outright with "Invalid value for mix_genre_filter". Explicitly store an empty arrayref when nothing is selected.

Both fixes tested locally on a live LMS 9.1 install (repo-installed fork), confirmed the settings page saves cleanly with the genre filter both empty and populated. Also reproduced and verified fixed on a 9.2 test setup.