### PR TITLE
MUSICBRAINZ_TRACKID is not unique, so use MUSICBRAINZ_RELEASETRACKID if present.

### DIFF
--- a/Slim/Formats/APE.pm
+++ b/Slim/Formats/APE.pm
@@ -36,10 +36,11 @@ use base qw(Slim::Formats);
 use Audio::Scan;
 
 my %tagMapping = (
-	'TRACK'	       => 'TRACKNUM',
-	'DATE'         => 'YEAR',
-	'DISCNUMBER'   => 'DISC',
-	'ALBUM ARTIST' => 'ALBUMARTIST', # bug 10724 - support APEv2 Album Artist
+	'TRACK'	              => 'TRACKNUM',
+	'DATE'                => 'YEAR',
+	'DISCNUMBER'          => 'DISC',
+	'ALBUM ARTIST'        => 'ALBUMARTIST', # bug 10724 - support APEv2 Album Artist
+	'MUSICBRAINZ_TRACKID' => 'MUSICBRAINZ_ID',
 );
 
 # Given a file, return a hash of name value pairs,

--- a/Slim/Formats/APE.pm
+++ b/Slim/Formats/APE.pm
@@ -77,6 +77,9 @@ sub doTagMapping {
 		}
 	}
 
+	# Prefer MUSICBRAINZ_RELEASETRACKID to MUSICBRAINZ_TRACKID (MUSICBRAINZ_ID)
+	$tags->{MUSICBRAINZ_ID} = delete $tags->{MUSICBRAINZ_RELEASETRACKID} if $tags->{MUSICBRAINZ_RELEASETRACKID};
+
 	# Sometimes the BPM is not an integer so we try to convert.
 	$tags->{BPM} = int($tags->{BPM}) if defined $tags->{BPM};
 

--- a/Slim/Formats/FLAC.pm
+++ b/Slim/Formats/FLAC.pm
@@ -245,6 +245,9 @@ sub doTagMapping {
 		}
 	}
 
+	# Prefer MUSICBRAINZ_RELEASETRACKID to MUSICBRAINZ_TRACKID (MUSICBRAINZ_ID)
+	$tags->{MUSICBRAINZ_ID} = delete $tags->{MUSICBRAINZ_RELEASETRACKID} if $tags->{MUSICBRAINZ_RELEASETRACKID};
+
 	# Special handling for DATE tags
 	# Parse the date down to just the year, for compatibility with other formats
 	if (defined $tags->{DATE} && !defined $tags->{YEAR}) {

--- a/Slim/Formats/MP3.pm
+++ b/Slim/Formats/MP3.pm
@@ -43,6 +43,7 @@ my $scannerlog = logger('scan.scanner');
 my $sourcelog  = logger('player.source');
 
 my %tagMapping = (
+	'MUSICBRAINZ RELEASE TRACK ID'      => 'MUSICBRAINZ_RELEASETRACKID',
 	'MUSICBRAINZ ALBUM ARTIST'          => 'ALBUMARTIST',
 	'MUSICBRAINZ ALBUM ARTIST ID'       => 'MUSICBRAINZ_ALBUMARTIST_ID',
 	'MUSICBRAINZ ALBUM ID'              => 'MUSICBRAINZ_ALBUM_ID',
@@ -339,6 +340,9 @@ sub doTagMapping {
 			$tags->{$new} = delete $tags->{$old};
 		}
 	}
+
+	# Prefer MusicBrainz Release Track Id (MUSICBRAINZ_RELEASETRACKID) to UFID (MUSICBRAINZ_ID)
+	$tags->{MUSICBRAINZ_ID} = delete $tags->{MUSICBRAINZ_RELEASETRACKID} if $tags->{MUSICBRAINZ_RELEASETRACKID};
 
 	# Special handling for UFID, pull out ID from array
 	if ( exists $tags->{MUSICBRAINZ_ID} && ref $tags->{MUSICBRAINZ_ID} eq 'ARRAY' ) {

--- a/Slim/Formats/Movie.pm
+++ b/Slim/Formats/Movie.pm
@@ -46,6 +46,7 @@ my %tagMapping = (
 	'MusicBrainz Album Artist' => 'ALBUMARTIST',
 	'MusicBrainz Album Artist Id' => 'MUSICBRAINZ_ALBUMARTIST_ID',
 	'MusicBrainz Track Id'     => 'MUSICBRAINZ_ID',
+	'MusicBrainz Release Track Id' => 'MUSICBRAINZ_RELEASETRACKID',
 	'MusicBrainz Sortname'     => 'ARTISTSORT',
 	'MusicBrainz Album Status' => 'MUSICBRAINZ_ALBUM_STATUS',
 );
@@ -149,6 +150,9 @@ sub _doTagMapping {
 			}
 		}
 	}
+
+	# Prefer MUSICBRAINZ_RELEASETRACKID to MusicBrainz Track Id (MUSICBRAINZ_ID)
+	$tags->{MUSICBRAINZ_ID} = delete $tags->{MUSICBRAINZ_RELEASETRACKID} if $tags->{MUSICBRAINZ_RELEASETRACKID};
 
 	# Special handling for DATE tags
 	# Parse the date down to just the year, for compatibility with other formats

--- a/Slim/Formats/Ogg.pm
+++ b/Slim/Formats/Ogg.pm
@@ -95,6 +95,9 @@ sub getTag {
 		}
 	}
 
+	# Prefer MUSICBRAINZ_RELEASETRACKID to MUSICBRAINZ_TRACKID (MUSICBRAINZ_ID)
+	$tags->{MUSICBRAINZ_ID} = delete $tags->{MUSICBRAINZ_RELEASETRACKID} if $tags->{MUSICBRAINZ_RELEASETRACKID};
+
 	# Special handling for DATE tags
 	# Parse the date down to just the year, for compatibility with other formats
 	$tags->{YEAR} ||= first { $_ } map {

--- a/Slim/Formats/WMA.pm
+++ b/Slim/Formats/WMA.pm
@@ -52,6 +52,7 @@ my %tagMapping = (
 	'MusicBrainz/Album Type'      => 'RELEASETYPE',
 	'MusicBrainz/Artist Id'       => 'MUSICBRAINZ_ARTIST_ID',
 	'MusicBrainz/Track Id'        => 'MUSICBRAINZ_ID',
+	'MusicBrainz/Release Track Id'=> 'MUSICBRAINZ_RELEASETRACKID',
 	'MusicBrainz/TRM Id'          => 'MUSICBRAINZ_TRM_ID',
 );
 
@@ -72,6 +73,9 @@ sub getTag {
 			$tags->{$new} = delete $tags->{$old};
 		}
 	}
+
+	# Prefer MUSICBRAINZ_RELEASETRACKID to MusicBrainz/Track Id (MUSICBRAINZ_ID)
+	$tags->{MUSICBRAINZ_ID} = delete $tags->{MUSICBRAINZ_RELEASETRACKID} if $tags->{MUSICBRAINZ_RELEASETRACKID};
 
 	# Sometimes the BPM is not an integer so we try to convert.
 	$tags->{BPM} = int($tags->{BPM}) if defined $tags->{BPM};


### PR DESCRIPTION
EDIT: This PR implements proposal 1 (below) only.

See testing summary below https://github.com/LMS-Community/slimserver/pull/1638#issuecomment-5574853827

As requested by @mikeysas , this is a simplistic (perhaps too simplistic) solution to #1372 which (in my understanding) proposes the following:

1. The scanner should prefer MUSICBRAINZ_RELEASETRACKID (if it is present in the tags) over MUSICBRAINZ_TRACKID. The reason for this is that MusicBrainz a while ago changed the usage of MUSICBRAINZ_TRACKID so that it is no longer unique: the same ID would be used for the same track on different albums. MUSICBRAINZ_RELEASETRACKID is now the identifier which uniquely identifies the actual album track.
Our continued use of MUSICBRAINZ_TRACKID can cause problems with persist.db as LMS assumes MUSICBRAINZ_TRACKID will uniquely identify the track. The user experiences this problem in ratings and the new music list. 

2. We could also introduce our own custom tag LYRION_UNIQUETRACKID for users who would like to override MusicBrainz values without actually overwriting their MB tags.

3. We could add a pre or post scan analysis of MUSICBRAINZ_TRACKID to inform the user in scanner.log if they have existing duplicates of this tag across their library.

This PR so far only implements proposal 1. 

Proposal 2 would be easy enough and using our own namespace (LYRION_*) should avoid unintended consequences.

I had some reservations about the effect of proposal 3 on scanner run-time, but having experimented with the required SQL, it's likely to be insignificant compared to total scan run-time.

If we agree to go forward with this, it will need testing with all music file formats (as indicated by the changed files in this PR).

And before releasing, we need to understand and document the detailed effects this could have on the user's existing persist.db.

Testers: either pull this PR or the branch from my LMS fork - https://github.com/darrell-k/slimserver/tree/MUSICBRAINZ_RELEASETRACKID