### PR TITLE
Fix link to Forums in help of Default skin

### DIFF
--- a/HTML/Default/helpheader.html
+++ b/HTML/Default/helpheader.html
@@ -19,7 +19,7 @@ END %]
 			[% BLOCK helpTopic %]
 				<div class="selectorMarker" onmouseover="Highlighter.highlight(this);" id="[% href %]">
 					<div class="homeMenuItem" id="[% token %][% IF category %]:[% category %][% END %]">
-						<a href="[% href %][% IF NOT url.match('^http') %]?player=[% playerURI %][% END %]" [% IF target %]target="[% target %]" [% END %][% IF href.match('^http:') %]target="_new" [% END %] class="browseItemLink">[% title %]</a>
+						<a href="[% href %][% IF NOT href.match('^https?:') %]?player=[% playerURI %][% END %]" [% IF target %]target="[% target %]" [% END %][% IF href.match('^https?:') %]target="_blank" [% END %] class="browseItemLink">[% title %]</a>
 					</div>
 				</div>
 			[% END -%]

--- a/HTML/EN/home.html
+++ b/HTML/EN/home.html
@@ -120,7 +120,7 @@
 	<div>[% "HELP" | string | upper %]</div>
 	<ul>
 	[%- FOREACH link = additionalLinks.help %]
-		<li><a href="[% link.value | html %][% IF NOT link.value.match('^http') %]player=[% playerURI %][% END %]" [% IF link.value.match('^http') %]target="_new"[% END %]>[% link.key | string | html %]</a></li>
+		<li><a href="[% link.value | html %][% IF NOT link.value.match('^http') %]player=[% playerURI %][% END %]" [% IF link.value.match('^http') %]target="_blank"[% END %]>[% link.key | string | html %]</a></li>
 	[%- END %]
 	</ul>
 </div>

--- a/HTML/EN/html/docs/artwork.html
+++ b/HTML/EN/html/docs/artwork.html
@@ -30,7 +30,7 @@
 <p>Many sites that sell CDs include cover art in their catalog. With most browsers, you can right click on the image and select "Save image as..."</p>
 <h4>Useful plugins</h4>
 <p>Several third party developers have written utilities to automatically retreive cover art based on the internal tags of your MP3, Ogg, Flac, or other files. See
-<a href="https://forums.lyrion.org/forumdisplay.php?4-3rd-Party-Software" target="_new" class="browseItemLink"
+<a href="https://forums.lyrion.org/forumdisplay.php?4-3rd-Party-Software" target="_blank" class="browseItemLink"
 >3rd-Party-Software</a> for more information.</p>
 
 <h4>Find albums with small /missing artwork used in your library:</h4>

--- a/HTML/EN/html/docs/remotestreaming.html
+++ b/HTML/EN/html/docs/remotestreaming.html
@@ -43,7 +43,7 @@
 
 <div>
 <br/>
- <p>If you have a question or problem, please visit our user forums at <a href="https://forums.lyrion.org/">https://forums.lyrion.org/</a></p>
+ <p>If you have a question or problem, please visit our user forums at <a href="https://forums.lyrion.org/" target="_blank">https://forums.lyrion.org/</a></p>
 </div>
 
 [% PROCESS helpfooter.html %]

--- a/HTML/EN/upnpinfo.html
+++ b/HTML/EN/upnpinfo.html
@@ -45,7 +45,7 @@
 		
 		[% IF itemobj.url %]
 			<li><div class="songInfoTitle">[% "URL" | string; stringCOLON %]</div>
-				<div class="songInfoText"><a href="[% itemobj.url %]" target="_new">[% itemobj.url | html %]</a></div>
+				<div class="songInfoText"><a href="[% itemobj.url %]" target="_blank">[% itemobj.url | html %]</a></div>
 			</li>
 		[% END %]
 		


### PR DESCRIPTION
- Open the link in a new tab/window (which is mandatory because of the forums’ current content security policy).
- Don’t leak the player’s MAC address.
- Use `target="_blank"` instead of the non-standard `target="_new"`.