### PR TITLE
Don't show sample size for lossy formats.

### DIFF
--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -1333,6 +1333,14 @@ sub isContainer {
 	return 0;
 }
 
+sub isLossy {
+	my $type = shift;
+	
+	if (defined $type && $type =~ /mp3|aac|ogg|ops/) {
+		return 1;
+	}
+}
+
 # Return a list of valid extensions for a particular type as listed in types.conf
 sub validTypeExtensions {
 	my $findTypes  = shift || 'list|audio';

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -432,7 +432,7 @@ sub open {
 
 		# Init song's sample rate and sample size before any transcoding
 		$self->samplerate($transcoder->{'sampleRate'});
-		if ($transcoder->{'streamformat'} !~ /mp3|aac/) {  # Only set sample size for lossless
+		if (!Slim::Music::Info::isLossy($transcoder->{'streamformat'})) {  # Only set sample size for lossless
 			$self->samplesize($transcoder->{'sampleSize'});
 		}
 
@@ -634,7 +634,7 @@ sub open {
 				my $sampleSize;
 				my $sampleRate;
 
-				if ($streamformat =~ /mp3|aac/) {
+				if (Slim::Music::Info::isLossy($streamformat)) {
 					$bitrate = $transcoder->{'rateLimit'};  # bitrate limit
 					$self->samplesize("");  # clear samplesize for lossy formats
 					$self->samplerate( min($transcoder->{'sampleRate'}, $transcoder->{'samplerateLimit'}) );
@@ -714,7 +714,7 @@ sub guessBitrateFromFormat {
 	$sampleSize //= 16;
 	$sampleRate //= 44_100;
 
-	if ($format =~ /mp3|aac/) {
+	if (Slim::Music::Info::isLossy($format)) {
 		return ($bitrate || 320) * 1000;
 	} elsif ($format =~ /wav|aif|pcm/) {
 		# Just assume standard rate

--- a/Slim/Player/Song.pm
+++ b/Slim/Player/Song.pm
@@ -423,16 +423,18 @@ sub open {
 			last if $transcoder;
 		}
 
-		if (! $transcoder) {
+		if (!$transcoder) {
 			logError("Couldn't create command line for $format playback for [$url]");
 			return (undef, ($error || 'PROBLEM_CONVERT_FILE'), $url);
 		} elsif (main::INFOLOG && $log->is_info) {
-			 $log->info("Transcoder: streamMode=", $transcoder->{'streamMode'}, ", streamformat=", $transcoder->{'streamformat'});
+			 $log->info("Transcoder: ", Data::Dump::dump($transcoder));
 		}
-		
+
 		# Init song's sample rate and sample size before any transcoding
 		$self->samplerate($transcoder->{'sampleRate'});
-		$self->samplesize($transcoder->{'sampleSize'});
+		if ($transcoder->{'streamformat'} !~ /mp3|aac/) {  # Only set sample size for lossless
+			$self->samplesize($transcoder->{'sampleSize'});
+		}
 
 		if ($wantTranscoderSeek && (grep(/T/, @{$transcoder->{'usedCapabilities'}}))) {
 			$transcoder->{'start'} = $self->startOffset($self->seekdata()->{'timeOffset'});
@@ -625,11 +627,9 @@ sub open {
 
 				$self->_transcoded(1);
 
-				main::INFOLOG && $log->info("Transcoder: ", Data::Dump::dump($transcoder));
-
 				my $streamformat = $transcoder->{'streamformat'};
 				$self->_streamFormat($streamformat);
-				
+
 				my $bitrate;
 				my $sampleSize;
 				my $sampleRate;


### PR DESCRIPTION
Ignore sample size from $transcoder for lossy formats. Clean up some white space and adjust Info logging.