### PR TITLE
UPnP/DLNA Media Renderer: add support of 'audio/L16' MIME-type

### DIFF
--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -926,6 +926,18 @@ sub _setTrackInfo {
 	$attrs{CHANNELS}   = $res->{channels}   if $res->{channels};
 	$attrs{SAMPLESIZE} = $res->{samplesize} if $res->{samplesize};
 
+	if ( $res->{mime} && $res->{mime} eq 'audio/L16' ) {
+		$attrs{ENDIAN} = 1; # big-endian
+		$attrs{SAMPLESIZE} = 16;
+	}
+	elsif ( $res->{mime} && $res->{mime} eq 'audio/L24' ) {
+		$attrs{ENDIAN} = 1; # big-endian
+		$attrs{SAMPLESIZE} = 24;
+	}
+	elsif ( $res->{mime} && $res->{mime} eq 'audio/x-pcm' ) {
+		$attrs{ENDIAN} = 1; # big-endian
+	}
+
 	Slim::Schema->updateOrCreate( { url => $trackId, attributes => \%attrs } ) if %attrs;
 }
 

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -355,8 +355,7 @@ sub SetAVTransportURI {
 		$meta->{_id} = $trackId;
 		$_trackMeta{$trackId} = $meta;
 
-		Slim::Music::Info::setBitrate( $trackId, $meta->{res}->{bitrate} );
-		Slim::Music::Info::setDuration( $trackId, $meta->{res}->{secs} );
+		$class->_setTrackInfo( $trackId, $meta->{res} );
 
 		$mediaDuration = $meta->{res}->{duration}; # XXX more if URI is a playlist?
 		$trackDuration = $mediaDuration;
@@ -469,8 +468,7 @@ sub SetNextAVTransportURI {
 			$meta->{_id} = $trackId;
 			$_trackMeta{$trackId} = $meta;
 
-			Slim::Music::Info::setBitrate( $trackId, $meta->{res}->{bitrate} );
-			Slim::Music::Info::setDuration( $trackId, $meta->{res}->{secs} );
+			$class->_setTrackInfo( $trackId, $meta->{res} );
 
 			delete $_trackMeta{ $pd->{avt_NextTrackId} } if $pd->{avt_NextTrackId};
 			$pd->{avt_NextTrackId} = $trackId;
@@ -876,16 +874,26 @@ sub _DIDLLiteToHash {
 
 	# Find the best res item to play
 	for my $r ( @{ $x->{res} } ) {
-		my ($mime) = $r->{protocolInfo} =~ /[^:]+:[^:]+:([^:+]+):/;
+		my ($mimeFull) = $r->{protocolInfo} =~ /[^:]+:[^:]+:([^:]+):/;
+		next unless $mimeFull;
+
+		# strip MIME parameters (e.g. audio/L16;rate=48000;channels=2)
+		my ($mime, $mimeParams) = split /;/, $mimeFull, 2;
+
 		next if !$mime || !Slim::Music::Info::mimeToType($mime);
 
 		# Some servers must have missed the (really stupid) part in
 		# the spec where bitrate is defined as bytes/sec, not bits/sec
-		# We try to handle this for common MP3 bitrates
+		# We try to handle this for common L16 and MP3 bitrates
 		my $bitrate = $r->{bitrate};
-		if ( $bitrate =~ /^(?:64|96|128|160|192|256|320)000$/ ) {
+		if ( $bitrate && ( ( $mime eq 'audio/L16' && $bitrate > 192000 )
+			|| $bitrate =~ /^(?:64|96|128|160|192|256|320)000$/ ) ) {
 			$bitrate /= 8;
 		}
+ 
+		# use MIME params, if 'res' doesn't provide sampleFrequency/nrAudioChannels
+		my ($rateParam)     = $mimeParams =~ /\brate=(\d+)/i        if $mimeParams;
+		my ($channelsParam) = $mimeParams =~ /\bchannels=(\d+)/i    if $mimeParams;
 
 		$meta->{res} = {
 			uri          => $r->{content},
@@ -894,12 +902,31 @@ sub _DIDLLiteToHash {
 			bitrate      => $bitrate * 8,
 			secs         => hmsToSecs( $r->{duration} ),
 			duration     => $r->{duration} || '',
+			samplerate   => $r->{sampleFrequency} || $rateParam     || undef,
+			channels     => $r->{nrAudioChannels} || $channelsParam || undef,
+			samplesize   => $r->{bitsPerSample} || undef,
 		};
 
 		last;
 	}
 
 	return $meta;
+}
+
+# sets track info from DIDL-Lite res element decoded by _DIDLLiteToHash
+sub _setTrackInfo {
+	my ( $class, $trackId, $res ) = @_;
+
+	Slim::Music::Info::setContentType( $trackId, $res->{mime} ) if $res->{mime};
+	Slim::Music::Info::setBitrate( $trackId, $res->{bitrate} ) if $res->{bitrate};
+	Slim::Music::Info::setDuration( $trackId, $res->{secs} ) if $res->{secs};
+
+	my %attrs;
+	$attrs{SAMPLERATE} = $res->{samplerate} if $res->{samplerate};
+	$attrs{CHANNELS}   = $res->{channels}   if $res->{channels};
+	$attrs{SAMPLESIZE} = $res->{samplesize} if $res->{samplesize};
+
+	Slim::Schema->updateOrCreate( { url => $trackId, attributes => \%attrs } ) if %attrs;
 }
 
 sub _event_xml {

--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -135,9 +135,15 @@ sub getFormatForURL {
 	my $class = shift;
 	my $url = shift;
 
+	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor($url);
+	if ( $meta && $meta->{res}->{mime} ) {
+		if ( my $type = Slim::Music::Info::mimeToType( $meta->{res}->{mime} ) ) {
+			return $type;
+		}
+	}
+
 	# if typeFromSuffix can't find a result it returns the mp3 default.
-	my $type = Slim::Music::Info::typeFromSuffix($url, 'mp3');
-	return $type;
+	return Slim::Music::Info::typeFromSuffix($url, 'mp3');
 }
 
 # XXX use DLNA.ORG_OP value, and/or MIME type
@@ -164,7 +170,8 @@ sub new {
 		bitrate => $song->bitrate() || 128_000,
 	} ) || return;
 
-	${*$sock}{contentType} = 'audio/mpeg'; # XXX
+	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor( $song->currentTrack->url );
+	${*$sock}{contentType} = ( $meta && $meta->{res}->{mime} ) || 'audio/mpeg';
 
 	return $sock;
 }

--- a/convert.conf
+++ b/convert.conf
@@ -138,6 +138,10 @@ flc mp3 * *
 	# IFB:{BITRATE=--abr %B}T:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=--resample %D}E:{NOSTART=I}
 	[flac] -dc --totally-silent $START$ $END$ --force-raw-format --endian=little --sign=signed -- $FILE$ | [sox] -q -t raw --endian little --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ - -t raw -c 2 - | [lame] --silent -r --little-endian --signed --bitwidth $SAMPLESIZE$ -s $SAMPLERATE$ -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
 
+lpcm mp3 * *
+	# IFB:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}
+	[sox] -q -t raw --endian big --encoding signed-integer -b $SAMPLESIZE$ -r $SAMPLERATE$ -c $CHANNELS$ $FILE$ -t wav - | [lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
+
 wma mp3 * *
 	# F:{PATH=%f}R:{PATH=%F}B:{BITRATE=--abr %B}D:{RESAMPLE=--resample %D}
 	[wmadec] -w $PATH$ | [lame] --silent -q $QUALITY$ $RESAMPLE$ $BITRATE$ - -
@@ -185,6 +189,9 @@ flc pcm * *
 flc aif * *
 	# IFT:{START=--skip=%t}U:{END=--until=%v}
 	[flac] -dcs --force-raw-format --endian=big --sign=signed $START$ $END$ -- $FILE$
+
+lpcm pcm * *
+	-
 
 ogf ogf * *
 	-
@@ -295,6 +302,10 @@ aif flc * *
 wav flc * *
 	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}E:{NOSTART=I}
 	[flac] -cs --totally-silent --compression-level-0 $START$ $END$ -- $FILE$ | [sox] -q -t flac - -t flac -C 0 $RESAMPLE$ -
+
+lpcm flc * *
+	# IFT:{START=--skip=%t}U:{END=--until=%v}D:{RESAMPLE=-r %d}E:{NOSTART=I}
+	[flac] -cs --totally-silent --compression-level-0 $START$ $END$ --force-raw-format --endian=big --sign=signed --bps=$SAMPLESIZE$ --sample-rate=$SAMPLERATE$ --channels=$CHANNELS$ -- $FILE$ | [sox] -q -t flac - -t flac -C 0 $RESAMPLE$ -
 
 ogg flc * *
 	# IFRD:{RESAMPLE=-r %d}

--- a/types.conf
+++ b/types.conf
@@ -27,6 +27,7 @@ gif     gif             image/gif                       -
 htm     htm,html        text/html                       -
 htc     htc             text/x-component                -
 log     log             text/plain                      -
+lpcm    lpcm,l16,l24    audio/L16,audio/L24,audio/x-pcm audio
 ico     ico             image/x-icon                    -
 jpg     jpg,jpeg        image/jpeg                      -
 jnp     jnlp            application/x-java-jnlp-file    -
@@ -43,7 +44,7 @@ mpc     mpc,mp+         audio/x-musepack                audio
 ogg     ogg,oga         audio/x-ogg,application/ogg,audio/ogg,application/x-ogg       audio
 ogf     ogf             audio/ogg;codecs=flac           audio
 ops     opus            audio/opus,audio/ogg;codecs=opus audio
-pcm     pcm,l16,l24     audio/L16,audio/L24,audio/x-pcm audio
+pcm     pcm             -                               audio
 pdf     pdf             application/pdf                 -
 pls     pls             audio/scpls,audio/x-scpls       playlist
 pod     -               application/rss+xml             -


### PR DESCRIPTION
For support of UPnP/DLNA media stream sources of MIME-type 'audio/L16' in the **UPnP/DLNA Media Interface Plugin**, this change addresses two problems:

-  For MIME-type 'audio/L16', the DIDL-Lite Message has additional params encoded in its MIME-type, e.g. `audio/L16;rate=48000;channels=2`, so strip them and store them as track attributes before the MIME-type is inspected by `mimeToType()`
- MIME-types 'audio/L16' and 'audio/L24' are always big-endian per RFC 2586/3190, but LMS' internal 'pcm' type has a variable endianness and is so-far only used as *destination* format for conversion, so it was not accepted as input format of remote streams.
**To resolve this, this PR adds a new global 'lpcm' type as a *source* format for conversions that 'audio/L16', 'audio/L24' and 'audio/x-pcm' map to instead, with a plain pass-through rule to 'pcm'.** The endianness is communicated via the UPnP/DLNA track's 'ENDIAN' attribute on reception, like it is already done for 'aiff'->'pcm' for AIFF Files (see `Slim::Formats::AIFF::getTag()`), so it will be correctly passed through.

**NOTE:** this re-mapping may be a dangerous change, but I noticed no drawbacks so far when playing back titles from my local media library.
But this may still interfere with other streaming services like internet radio client plugins or _Spotify_, which may also receive audio/L16 content. I can't test this! 

Tested with:
- BubbleUPnP 4.6.5.1
- AirMusic 3.4.3
- foobar2000 2.25.10
- pa-dlna 1.2