### PR TITLE
More (final?) changes to support transcoding reporting.

### DIFF
--- a/Slim/Control/Queries.pm
+++ b/Slim/Control/Queries.pm
@@ -4116,18 +4116,19 @@ sub statusQuery {
 			$request->addResult('is_transcoded', $transcoded);
 		}
 
-		if ($tags =~ /b/) {   # get the song's current bitrate
-			my $bitrate = $song->streambitrate();
-			if (defined $bitrate && $bitrate) {
-				$bitrate = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $bitrate/1000);
-				$request->addResult('bitrate', $bitrate);
+		my $type = $song->streamformat();
+		if ($tags =~ /o/) {   # get the song's format (type)
+			if (defined $type && $type) {
+				$request->addResult('type', $type);
 			}
 		}
 
-		if ($tags =~ /o/) {   # get the song's format (type)
-			my $type = $song->streamformat();
-			if (defined $type && $type) {
-				$request->addResult('type', $type);
+		if ($tags =~ /b/) {   # get the song's current bitrate
+			my $vbr = $transcoded ? 0 : $song->currentTrack()->vbr_scale;
+			my $bitrate = $song->streambitrate();
+			if (defined $bitrate && $bitrate) {
+				$bitrate = Slim::Schema::Track->buildPrettyBitRate($bitrate, $vbr, $type);
+				$request->addResult('bitrate', $bitrate);
 			}
 		}
 

--- a/Slim/Schema/Track.pm
+++ b/Slim/Schema/Track.pm
@@ -362,7 +362,7 @@ sub buildPrettyBitRate {
 	if ($bitrate) {
 		my $mode = '';
 		if (Slim::Music::Info::isLossy($format) ) {  # only relevant for lossy formats
-			$mode = defined $vbrScale ? ' VBR' : ' CBR';
+			$mode = defined $vbrScale && $vbrScale == 1 ? ' VBR' : ' CBR';
 		}
 		return sprintf( "%d", ($bitrate / 1000) ) . Slim::Utils::Strings::string('KBPS') . $mode;
 	}


### PR DESCRIPTION
1. Use buildPrettyBitRate() to format the bitrate returned in the status query for consistency.
2. Fix a possible error in reporting VBR vs CBR for lossy formats.