### PR TITLE
Resume transcode pipeline feed when stdin pipe drains

### DIFF
--- a/Slim/Player/Pipeline.pm
+++ b/Slim/Player/Pipeline.pm
@@ -288,6 +288,7 @@ sub sysread {
 					# EOF
 					main::INFOLOG && $log->info("EOF on source stream");
 					$source->close();
+					Slim::Networking::Select::removeWrite($writer);
 					$writer->close();
 					delete ${*$self}{'pipeline_source'};
 					delete ${*$self}{'pipeline_writer'};
@@ -357,6 +358,7 @@ sub close {
 	my $writer = ${*$self}{'pipeline_writer'};
 
 	if (defined($writer)) {
+		Slim::Networking::Select::removeWrite($writer);
 		$writer->close();
 	}
 

--- a/Slim/Player/Source.pm
+++ b/Slim/Player/Source.pm
@@ -340,6 +340,12 @@ sub _readNextChunk {
 						# The advice for future readers is to NOT use EWOULDBLOCK in your ProtocolHandler's sysread()
 						# use EINTR instead which is a bit slower but totally safe.
 						Slim::Networking::Select::addRead(${*$fd}{'pipeline_reader'} || $fd, sub {_wakeupOnReadable(shift, $client);}, 1);
+
+						# If this pipeline's input is full, also wake up when it drains. Until the pipeline
+						# produces its first output, the reader above cannot become readable.
+						if (${*$fd}{'pipeline_pending_size'} && defined ${*$fd}{'pipeline_writer'}) {
+							Slim::Networking::Select::addWrite(${*$fd}{'pipeline_writer'}, sub {_wakeupOnWritable(shift, $client);}, 1);
+						}
 					}
 					return undef;
 				} elsif ($! == EINTR) {
@@ -415,6 +421,22 @@ sub _wakeupOnReadable {
 	main::DEBUGLOG && $log->debug($master->id);
 
 	Slim::Networking::Select::removeRead($fd) if defined $fd;
+
+	_wakeupStream($master);
+}
+
+sub _wakeupOnWritable {
+	my ($fd, $master) = @_;
+
+	main::DEBUGLOG && $log->debug($master->id);
+
+	Slim::Networking::Select::removeWrite($fd) if defined $fd;
+
+	_wakeupStream($master);
+}
+
+sub _wakeupStream {
+	my ($master) = @_;
 
 	foreach ($master->syncGroupActiveMembers()) {
 		if (my $cb = $_->streamReadableCallback) {


### PR DESCRIPTION
FLAC files with a large embedded picture (cover art at several megabytes) have multiple seconds of silence before audio starts when transcoded (e.g. `flc mp3`), even though the same file plays almost instantly when streamed without transcoding. I had first noticed this when LyrPlay was refusing to play specific FLAC files from the beginning, but I could seek within the track successfully.

The cause is in the transcode pump loop (`Pipeline::sysread`/`Source::_readNextChunk`). It feeds the transcoder's stdin only until the OS pipe buffer fills then waits to be told to resume, but can only re-arm when the transcoder's output is readable, which can't happen until the transcoder has consumed enough header to emit its first audio frame. In practice this meant refills only happened via an unrelated 0.4s HTTP retry timer, throttling a multi-MB header to roughly one pipe buffer (~64 KB on Linux) per tick.

This PR adds a write-watcher on the transcoder's stdin whenever the pump loop has bytes it couldn't push through (EWOULDBLOCK on write), so the feed resumes as soon as the transcoder drains its input instead of waiting on the timer. It's a pure event-loop change without any transcoder-specific behavior and should only ever activate when there's a backlog, so it shouldn't affect any case where transcoding was already keeping up.

I've been running with this patch for over a month and everything has seemed OK. Claude-assisted, especially during debugging.