### PR TITLE
Replace links to `lms-community.github.io`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 [![LMS Screen Shot][lyrion-screenshot]](https://lyrion.org)
 
-Lyrion Music Server (aka. LMS, fka. Logitech Mediaserver, SlimServer, SqueezeCenter, SqueezeboxServer, SliMP3) is the server software that powers audio players from [Logitech](https://www.logi.com) (formerly known as SlimDevices), including [Squeezebox 3rd Generation, Squeezebox Boom, Squeezebox Receiver, Transporter, Squeezebox2, Squeezebox and SLIMP3](https://lms-community.github.io/players-and-controllers/hardware-comparison/), and many software emulators like [Squeezelite and SqueezePlay](https://sourceforge.net/projects/lmsclients/files/).
+Lyrion Music Server (aka. LMS, fka. Logitech Mediaserver, SlimServer, SqueezeCenter, SqueezeboxServer, SliMP3) is the server software that powers audio players from [Logitech](https://www.logi.com) (formerly known as SlimDevices), including [Squeezebox 3rd Generation, Squeezebox Boom, Squeezebox Receiver, Transporter, Squeezebox2, Squeezebox and SLIMP3](https://lyrion.org/players-and-controllers/hardware-comparison/), and many software emulators like [Squeezelite and SqueezePlay](https://sourceforge.net/projects/lmsclients/files/).
 
 With the help of many plugins, Lyrion Music Server can stream not only your local music collection, but content from many music services and internet radio stations to your players.
 

--- a/Slim/Plugin/UPnP/MediaRenderer.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer.pm
@@ -29,37 +29,37 @@ my $prefs = preferences('server');
 my %models = (
 	slimp3      => {
 		modelName => 'SliMP3',
-		url       => 'https://lms-community.github.io/players-and-controllers/SLIMP3/',
+		url       => 'https://lyrion.org/players-and-controllers/SLIMP3/',
 		icon      => '/html/images/Players/slimp3',
 	},
 	Squeezebox  => {
 		modelName => 'Squeezebox 1',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox1/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox1/',
 		icon      => '/html/images/Players/squeezebox',
 	},
 	squeezebox2 => {
 		modelName => 'Squeezebox 2',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox2/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox2/',
 		icon      => '/html/images/Players/squeezebox',
 	},
 	squeezebox3 => {
 		modelName => 'Squeezebox 3',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox-classic/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox-classic/',
 		icon      => '/html/images/Players/squeezebox3',
 	},
 	transporter => {
 		modelName => 'Transporter',
-		url       => 'https://lms-community.github.io/players-and-controllers/transporter/',
+		url       => 'https://lyrion.org/players-and-controllers/transporter/',
 		icon      => '/html/images/Players/transporter',
 	},
 	receiver    => {
 		modelName => 'Squeezebox Receiver',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox-receiver/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox-receiver/',
 		icon      => '/html/images/Players/receiver',
 	},
 	boom        => {
 		modelName => 'Squeezebox Boom',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox-boom/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox-boom/',
 		icon      => '/html/images/Players/boom',
 	},
 	softsqueeze => {
@@ -69,7 +69,7 @@ my %models = (
 	},
 	controller  => {
 		modelName => 'Squeezebox Controller',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox-controller/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox-controller/',
 		icon      => '/html/images/Players/controller',
 	},
 	squeezeplay => {
@@ -79,12 +79,12 @@ my %models = (
 	},
 	baby        => {
 		modelName => 'Squeezebox Radio',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox-radio/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox-radio/',
 		icon      => '/html/images/Players/baby',
 	},
 	fab4        => {
 		modelName => 'Squeezebox Touch',
-		url       => 'https://lms-community.github.io/players-and-controllers/squeezebox-touch/',
+		url       => 'https://lyrion.org/players-and-controllers/squeezebox-touch/',
 		icon      => '/html/images/Players/fab4',
 	},
 	default     => {

--- a/Slim/Utils/ExtensionsManager.pm
+++ b/Slim/Utils/ExtensionsManager.pm
@@ -112,10 +112,10 @@ $prefs->init({ repos => [], plugin => {}, auto => 0, useUnsupported => 0 });
 
 my %repos = (
 	# default repos mapped to weight which defines the order they are sorted in
-	'https://lms-community.github.io/lms-plugin-repository/extensions.xml' => 1,
+	'https://lyrion.org/lms-plugin-repository/extensions.xml' => 1,
 );
 
-my $UNSUPPORTED_REPO = 'https://lms-community.github.io/lms-plugin-repository/unsupported.xml';
+my $UNSUPPORTED_REPO = 'https://lyrion.org/lms-plugin-repository/unsupported.xml';
 
 $prefs->setChange(\&initUnsupportedRepo, 'useUnsupported');
 

--- a/Slim/Utils/Update.pm
+++ b/Slim/Utils/Update.pm
@@ -14,7 +14,7 @@ use Slim::Utils::Strings qw(string);
 use Slim::Utils::Timers;
 use Slim::Utils::Unicode;
 
-use constant REPOSITORY_URL => 'https://lms-community.github.io/lms-server-repository/servers.json';
+use constant REPOSITORY_URL => 'https://lyrion.org/lms-server-repository/servers.json';
 
 my $prefs = preferences('server');
 


### PR DESCRIPTION
Update links pointing to https://lms-community.github.io/ to point directly at https://lyrion.org/ (to where they currently redirect).