### PR TITLE
Add server civil-time information to the date query

### DIFF
--- a/Slim/Control/Jive.pm
+++ b/Slim/Control/Jive.pm
@@ -10,9 +10,11 @@ use strict;
 
 use POSIX qw(strftime);
 use Scalar::Util qw(blessed);
+use Time::Local qw(timegm);
 use URI;
 
 use Slim::Menu::BrowseLibrary;
+use Slim::Utils::DateTime;
 use Slim::Utils::Log;
 use Slim::Utils::Prefs;
 use Slim::Player::Playlist;
@@ -2157,8 +2159,18 @@ sub dateQuery {
 		$request->privateData(0);
 	}
 
+	my $epoch = $newTime || time();
+	my @localTime = localtime($epoch);
+
 	# 7.5+ SP devices use epoch time now, much simpler
-	$request->addResult( 'date_epoch', $newTime || time() );
+	$request->addResult( 'date_epoch', $epoch );
+
+	# Expose the server's civil-time information for controllers which cannot
+	# maintain their own timezone database. Interpret the local calendar fields
+	# as UTC to obtain the offset in effect at the same instant as date_epoch.
+	$request->addResult( 'utc_offset_minutes', int((timegm(@localTime[0..5]) - $epoch) / 60) );
+	$request->addResult( 'is_dst', $localTime[8] ? 1 : 0 );
+	$request->addResult( 'timezone', Slim::Utils::DateTime::getServerTZName() || '' );
 
 	# This is the field 7.3 and earlier players expect.
 	#  7.4 is smart enough to take no action when missing

--- a/t/00_smoketest.sh
+++ b/t/00_smoketest.sh
@@ -36,6 +36,19 @@ STATUS=$(curl -m1 -sX POST -d '{"id":0,"params":["",["serverstatus"]],"method":"
 
 echo $STATUS | jq .
 
-RESULT=$(echo $STATUS | fgrep -q version)
+echo $STATUS | jq -e '.result.version | strings' > /dev/null || exit 1
 
-exit $RESULT
+DATE=$(curl -m1 -sX POST -d '{"id":1,"params":["",["date"]],"method":"slim.request"}' http://localhost:9000/jsonrpc.js)
+
+echo $DATE | jq .
+
+echo $DATE | jq -e '
+	.result.date_epoch as $epoch |
+	.result.utc_offset_minutes as $offset |
+	.result.is_dst as $dst |
+	.result.timezone as $timezone |
+	($epoch | type == "number" and floor == .) and
+	($offset | type == "number" and floor == . and . >= -720 and . <= 840) and
+	($dst == 0 or $dst == 1) and
+	($timezone | type == "string")
+' > /dev/null


### PR DESCRIPTION
## Summary

- extend the existing `date` CLI query with the LMS host's current UTC offset, daylight-saving state, and best available IANA timezone name
- derive all civil-time fields from the same epoch returned as `date_epoch`
- add startup smoke-test coverage for the new JSON-RPC fields

## Motivation

Embedded and restricted-network controllers can obtain UTC from LMS, but they should not need their own mutable timezone database merely to display the same local civil time as the server. Local NTP does not supply timezone or DST policy, and Internet time services may be unavailable on isolated IoT or corporate networks.

This keeps the existing `date` query as the source of truth and avoids adding a separate endpoint or requiring an LMS plugin.

## Response fields

The existing `date` and `date_epoch` fields are unchanged. The query now also returns:

- `utc_offset_minutes`: signed UTC offset in effect at `date_epoch`
- `is_dst`: `1` when daylight-saving time is in effect, otherwise `0`
- `timezone`: best available IANA timezone name, or an empty string when the host can calculate local time but cannot identify the zone

Example:

```json
{
  "date_epoch": 1788959384,
  "utc_offset_minutes": -240,
  "is_dst": 1,
  "timezone": "America/Indiana/Indianapolis",
  "date": "0000-00-00T00:00:00+00:00"
}
```

The numeric offset is calculated from the server's `localtime()` result for the same epoch, so it does not depend on network access or on discovery of an IANA zone name.

## Compatibility

This is an additive change. Existing clients continue to receive the fields they already consume and can ignore the new fields.

## Testing

- exercised the patched `date` command through a running LMS JSON-RPC server
- verified UTC and Indianapolis winter/summer offsets
- verified quarter- and half-hour behavior with Kathmandu, Eucla, and Chatham
- added smoke-test assertions for integer epoch/offset values, valid DST state, supported offset range, and string timezone output
- passed shell syntax and `git diff --check`
