### PR TITLE
UPnP/DLNA Media Renderer: On-the-fly bitrate detection and Icy Metadata support

### DIFF
--- a/Slim/Music/Info.pm
+++ b/Slim/Music/Info.pm
@@ -452,7 +452,9 @@ sub setRemoteMetadata {
 
 	if ( $meta->{bitrate} ) {
 		$attr->{BITRATE}   = $meta->{bitrate} * 1000;
-		$attr->{VBR_SCALE} = ( exists $cbr{ $meta->{bitrate} } ) ? undef : 1;
+		$attr->{VBR_SCALE} = exists $meta->{vbr_scale}
+			? $meta->{vbr_scale}
+			: ( exists $cbr{ $meta->{bitrate} } ) ? undef : 1;
 	}
 
 	if ( $meta->{year} ) {

--- a/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/AVTransport.pm
@@ -351,11 +351,9 @@ sub SetAVTransportURI {
 		my $pd = $client->pluginData();
 
 		# Synthetic, globally unique track identity, see _newTrackId
-		my $trackId = $class->_newTrackId( $meta->{res}->{uri} );
-		$meta->{_id} = $trackId;
+		my $trackId = $class->_newTrackId( $meta->{res}->{content} );
+		$class->_setTrackAttributes( $trackId, $meta );
 		$_trackMeta{$trackId} = $meta;
-
-		$class->_setTrackInfo( $trackId, $meta->{res} );
 
 		$mediaDuration = $meta->{res}->{duration}; # XXX more if URI is a playlist?
 		$trackDuration = $mediaDuration;
@@ -456,19 +454,17 @@ sub SetNextAVTransportURI {
 			return [ 714 => 'Illegal MIME-type' ];
 		}
 
-		my $upnp_uri = $meta->{res}->{uri};
+		my $upnp_uri = $meta->{res}->{content};
 		my $cachedMeta = $pd->{avt_NextTrackId} ? $_trackMeta{ $pd->{avt_NextTrackId} } : undef;
-		my $upnp_uricached = $cachedMeta ? $cachedMeta->{res}->{uri} : undef;
+		my $upnp_uricached = $cachedMeta ? $cachedMeta->{res}->{content} : undef;
 
 		# only update if NextURI has changed or it's not queued yet
 		if ( !defined($upnp_uricached) || $upnp_uri ne $upnp_uricached || scalar @{$playlist} < 2 ){
 
 			# Synthetic, globally unique track identity, see _newTrackId
-			my $trackId = $class->_newTrackId( $meta->{res}->{uri} );
-			$meta->{_id} = $trackId;
+			my $trackId = $class->_newTrackId( $meta->{res}->{content} );
+			$class->_setTrackAttributes( $trackId, $meta );
 			$_trackMeta{$trackId} = $meta;
-
-			$class->_setTrackInfo( $trackId, $meta->{res} );
 
 			delete $_trackMeta{ $pd->{avt_NextTrackId} } if $pd->{avt_NextTrackId};
 			$pd->{avt_NextTrackId} = $trackId;
@@ -789,8 +785,7 @@ sub GetCurrentTransportActions {
 # DLNA allows different playlist entries to share the same URI, but LMS keys
 # Schema/Playlist/metadata by a unique url, so this will be used there instead
 # of the (possibly duplicate) original URI.
-# The original URI's file suffix (if any) is kept, so suffix-based type detection
-# (e.g. ProtocolHandler::getFormatForURL) keeps working unchanged.
+# The original URI's file suffix (if any) is kept for compatibility.
 sub _newTrackId {
 	my ( $class, $uri ) = @_;
 
@@ -880,32 +875,30 @@ sub _DIDLLiteToHash {
 		# strip MIME parameters (e.g. audio/L16;rate=48000;channels=2)
 		my ($mime, $mimeParams) = split /;/, $mimeFull, 2;
 
-		next if !$mime || !Slim::Music::Info::mimeToType($mime);
+		my $type = Slim::Music::Info::mimeToType( $mime );
+		# fall back to guessing the type from the file suffix
+		$type ||= Slim::Music::Info::typeFromSuffix($r->{content}, undef);
+		
+		next if !$type;
+		$meta->{ct} = $type;
 
-		# Some servers must have missed the (really stupid) part in
-		# the spec where bitrate is defined as bytes/sec, not bits/sec
-		# We try to handle this for common L16 and MP3 bitrates
-		my $bitrate = $r->{bitrate};
-		if ( $bitrate && ( ( $mime eq 'audio/L16' && $bitrate > 192000 )
-			|| $bitrate =~ /^(?:64|96|128|160|192|256|320)000$/ ) ) {
-			$bitrate /= 8;
-		}
- 
 		# use MIME params, if 'res' doesn't provide sampleFrequency/nrAudioChannels
 		my ($rateParam)     = $mimeParams =~ /\brate=(\d+)/i        if $mimeParams;
 		my ($channelsParam) = $mimeParams =~ /\bchannels=(\d+)/i    if $mimeParams;
 
 		$meta->{res} = {
-			uri          => $r->{content},
-			mime         => $mime,
-			protocolInfo => $r->{protocolInfo},
-			bitrate      => $bitrate * 8,
-			secs         => hmsToSecs( $r->{duration} ),
-			duration     => $r->{duration} || '',
-			samplerate   => $r->{sampleFrequency} || $rateParam     || undef,
-			channels     => $r->{nrAudioChannels} || $channelsParam || undef,
-			samplesize   => $r->{bitsPerSample} || undef,
+			content         => $r->{content},
+			mime            => $mime, # stripped MIME parameters
+			protocolInfo    => $r->{protocolInfo},
+			bitrate         => $r->{bitrate} || undef,
+			duration        => $r->{duration} || '',
+			sampleFrequency => $r->{sampleFrequency} || $rateParam     || undef,
+			nrAudioChannels => $r->{nrAudioChannels} || $channelsParam || undef,
+			bitsPerSample   => $r->{bitsPerSample} || undef,
 		};
+
+		my ($dlnaOp) = $r->{protocolInfo} =~ /DLNA\.ORG_OP=(\d{2})/;
+		$meta->{seekable} = ( defined $dlnaOp && $dlnaOp eq '00' ) ? 0 : 1;
 
 		last;
 	}
@@ -913,28 +906,63 @@ sub _DIDLLiteToHash {
 	return $meta;
 }
 
-# sets track info from DIDL-Lite res element decoded by _DIDLLiteToHash
-sub _setTrackInfo {
-	my ( $class, $trackId, $res ) = @_;
+# sets track attributes from metadata decoded by _DIDLLiteToHash
+sub _setTrackAttributes {
+	my ( $class, $trackId, $meta ) = @_;
 
-	Slim::Music::Info::setContentType( $trackId, $res->{mime} ) if $res->{mime};
-	Slim::Music::Info::setBitrate( $trackId, $res->{bitrate} ) if $res->{bitrate};
-	Slim::Music::Info::setDuration( $trackId, $res->{secs} ) if $res->{secs};
+	$meta->{_id} = $trackId;
+
+	my $res = $meta->{res} || {};
+
+	my $samplesize = $res->{bitsPerSample};
+	if ( $res->{mime} eq 'audio/L16' ) {
+		$samplesize = 16;
+	}
+	elsif ( $res->{mime} eq 'audio/L24' ) {
+		$samplesize = 24;
+	}
+
+	my $bitrate = 0;
+
+	# Some servers don't provide bitrate for LPCM, so calculate it
+	if ( !$res->{bitrate} && $meta->{ct} eq 'lpcm' && $res->{sampleFrequency} && $res->{nrAudioChannels} && $samplesize ) {
+		$bitrate = $res->{sampleFrequency} * $res->{nrAudioChannels} * $samplesize;
+	}
+	# Some servers providing the "bitrate" res elements must have missed
+	# the (really stupid) part in the spec where bitrate is defined as
+	# bytes/sec, not bits/sec. So try to handle this for common L16, WAV
+	# and MP3 bitrates.
+	elsif ( $res->{bitrate} ) {
+		if ( ( $meta->{ct} eq 'mp3' && $res->{bitrate} =~ /^(?:64|96|128|160|192|256|320)000$/ )
+			|| ( ($meta->{ct} eq 'lpcm' || $meta->{ct} eq 'wav') && $samplesize && $res->{bitrate} > 48000 * 2 * $samplesize / 8 )
+			) {
+			# seems to actually be bits/s, not bytes/s, so use it as-is
+			$bitrate = $res->{bitrate};
+		}
+		else {
+			# seems to really be bytes/s, so convert to bits/s
+			$bitrate = $res->{bitrate} * 8;
+		}
+	}
+
+	# note: setRemoteMetadata() expects bitrate in kbits/s, not bits/s
+	$meta->{bitrate} = $bitrate / 1000 if $bitrate;
+	$meta->{secs} = hmsToSecs( $res->{duration} ) if $res->{duration};
+
+	# LPCM/WAV are always CBR, so don't let setRemoteMetadata() guess from
+	# its MP3-only list of common bitrates
+	$meta->{vbr_scale} = undef if $meta->{ct} eq 'lpcm' || $meta->{ct} eq 'wav';
+
+	# this processes ct, title, secs, bitrate, vbr_scale, year, cover
+	Slim::Music::Info::setRemoteMetadata( $trackId, $meta );
 
 	my %attrs;
-	$attrs{SAMPLERATE} = $res->{samplerate} if $res->{samplerate};
-	$attrs{CHANNELS}   = $res->{channels}   if $res->{channels};
-	$attrs{SAMPLESIZE} = $res->{samplesize} if $res->{samplesize};
+	$attrs{SAMPLERATE} = $res->{sampleFrequency} if $res->{sampleFrequency};
+	$attrs{CHANNELS}   = $res->{nrAudioChannels} if $res->{nrAudioChannels};
+	$attrs{SAMPLESIZE} = $samplesize if $samplesize;
 
-	if ( $res->{mime} && $res->{mime} eq 'audio/L16' ) {
-		$attrs{ENDIAN} = 1; # big-endian
-		$attrs{SAMPLESIZE} = 16;
-	}
-	elsif ( $res->{mime} && $res->{mime} eq 'audio/L24' ) {
-		$attrs{ENDIAN} = 1; # big-endian
-		$attrs{SAMPLESIZE} = 24;
-	}
-	elsif ( $res->{mime} && $res->{mime} eq 'audio/x-pcm' ) {
+	# required for 'lpcm' to 'pcm' pass-through
+	if ( $meta->{ct} eq 'lpcm' ) {
 		$attrs{ENDIAN} = 1; # big-endian
 	}
 

--- a/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
+++ b/Slim/Plugin/UPnP/MediaRenderer/ProtocolHandler.pm
@@ -9,6 +9,9 @@ package Slim::Plugin::UPnP::MediaRenderer::ProtocolHandler;
 use strict;
 use base qw(Slim::Player::Protocols::HTTP);
 
+use File::Temp ();
+
+use Slim::Formats;
 use Slim::Utils::Cache;
 use Slim::Utils::Errno;
 use Slim::Utils::Log;
@@ -18,9 +21,20 @@ use Slim::Plugin::UPnP::MediaRenderer::AVTransport ();
 
 use constant MAX_RAW_READ => 32768;
 
+# How much of the (already dechunked/decoded) audio stream to initially buffer in
+# _scanBitrateFeed() below before giving up on determining its bitrate, matching
+# Slim::Utils::Scanner::Remote::parseAudioStream()'s default buffer size.
+use constant SCAN_READ_BYTES => 128 * 1024;
+# How many bytes of audio frames past the end of an ID3v2 tag to also buffer
+# to have something to determine the bitrate from.
+use constant SCAN_READ_PAST_ID3 => 16 * 1024;
+
 my $log = logger('plugin.upnp');
 
 sub isRemote { 1 }
+
+# We are caching the cover image on our own
+sub shouldCacheImage { 0 }
 
 # Always proxy through the server so the outgoing connection to the source uses
 # the same IP address that was published for this player via UPnP, and so we can
@@ -70,6 +84,23 @@ sub response {
 }
 
 sub _sysread {
+	my $self = $_[0];
+
+	my $ret = $self->_sysread_impl( $_[1], $_[2], $_[3] );
+
+	# note: we'll do an on-the-fly bitrate scan as data is read if required
+	if ( $ret ) {
+		$self->_scanBitrateFeed( substr( $_[1], $_[3] || 0, $ret ) );
+	}
+	elsif ( defined $ret ) {
+		# graceful stream end - finalize a still-pending scan with whatever we have
+		$self->_scanBitrateFeed( undef, 1 );
+	}
+
+	return $ret;
+}
+
+sub _sysread_impl {
 	my $self    = $_[0];
 	my $dechunk = ${*$self}{'_dechunk'} || return $self->SUPER::_sysread($_[1], $_[2], $_[3]);
 
@@ -135,20 +166,18 @@ sub getFormatForURL {
 	my $class = shift;
 	my $url = shift;
 
-	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor($url);
-	if ( $meta && $meta->{res}->{mime} ) {
-		if ( my $type = Slim::Music::Info::mimeToType( $meta->{res}->{mime} ) ) {
-			return $type;
-		}
-	}
-
-	# if typeFromSuffix can't find a result it returns the mp3 default.
-	return Slim::Music::Info::typeFromSuffix($url, 'mp3');
+    my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor($url);
+    return ( $meta && exists $meta->{ct} ) ? $meta->{ct} : undef;
 }
 
-# XXX use DLNA.ORG_OP value, and/or MIME type
-sub canSeek { 1 } # We'll assume Range requests are supported by all servers,
-                  # and this is also needed for pause to work properly
+sub canSeek {
+	my ( $class, $client, $song ) = @_;
+
+	return 1 unless $song;
+
+	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor( $song->currentTrack->url );
+	return ( $meta && exists $meta->{seekable} ) ? $meta->{seekable} : 1;
+}
 
 sub canSeekError { return ( 'SEEK_ERROR_TYPE_NOT_SUPPORTED', 'UPnP/DLNA' ); }
 
@@ -176,7 +205,8 @@ sub new {
 	return $sock;
 }
 
-# Avoid scanning
+# Avoid scanning here. Only scan on-the-fly when the track is actually played
+# and the bitrate is still unknown, see _scanBitrateInit and _scanBitrateFeed.
 sub scanUrl {
 	my ($class, $url, $args) = @_;
 
@@ -187,11 +217,105 @@ sub scanUrl {
 	# session's state was stored on.
 	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor($url);
 
-	if ( ref($meta) eq 'HASH' && ( my $uri = $meta->{res}->{uri} ) ) {
+	if ( ref($meta) eq 'HASH' && ( my $uri = $meta->{res}->{content} ) ) {
 		$args->{song}->streamUrl($uri);
 	}
 
 	$args->{cb}->($args->{song}->currentTrack());
+}
+
+sub _scanBitrateInit {
+	my $self = shift;
+
+	# check preconditions
+
+	if ( my $range = ${*$self}{'contentRange'} ) {
+		my ($first) = $range =~ /^(\d+)-/;
+		return 0 if $first;
+	}
+	return 0 if ${*$self}{'metaInterval'};
+
+	my $song = ${*$self}{'song'} || return 0;
+	return 0 if Slim::Music::Info::getBitrate( $song->currentTrack->url );
+
+	my $type = Slim::Music::Info::contentType( $song->currentTrack->url ) || return 0;
+	my $formatClass = Slim::Formats->classForFormat($type) || return 0;
+	return 0 unless Slim::Formats->loadTagFormatForType($type) && $formatClass->can('scanBitrate');
+
+	# all preconditions met, so start scanning on the fly
+
+	main::DEBUGLOG && $log->is_debug && $log->debug( 'Scanning ' . $song->currentTrack->url . ' on the fly for bitrate' );
+
+	return {
+		fh          => File::Temp->new,
+		len         => 0,
+		scanLen     => SCAN_READ_BYTES,
+		url         => $song->currentTrack->url,
+		type        => $type,
+		formatClass => $formatClass,
+	};
+}
+
+# Tees received data into a temp file until enough has been buffered
+# (or the stream ends) to run it through the format's scanBitrate().
+# This is similar to Slim::Utils::Scanner::Remote::parseAudioStream(), but
+# we won't open a separate connection for this.
+sub _scanBitrateFeed {
+	my ( $self, $data, $eof ) = @_;
+
+	my $scan = ${*$self}{'_bitrateScan'};
+
+	# undef means "not yet decided", 0 means "decided: nothing to do"
+	if ( !defined $scan ) {
+		$scan = ${*$self}{'_bitrateScan'} = $self->_scanBitrateInit;
+	}
+
+	return unless $scan;
+
+	if ( defined $data && length $data ) {
+		if ( !$scan->{len} && $scan->{type} eq 'mp3' && $data =~ /^ID3/ ) {
+			# ID3v2 tag on the very first chunk - grow the buffer to cover
+			# the full tag (which may hold a sizeable embedded cover image)
+			# plus some trailing audio frames to determine the bitrate from,
+			# same as Slim::Utils::Scanner::Remote::parseAudioStream() does.
+
+			# get ID3v2 tag length from bytes 7-10
+			my $id3size = 0;
+			for my $b ( unpack 'C4', substr( $data, 6, 4 ) ) {
+				$id3size = ($id3size << 7) + $b;
+			}
+			$id3size += 10;
+
+			$scan->{scanLen} = $id3size + SCAN_READ_PAST_ID3;
+
+			main::DEBUGLOG && $log->is_debug && $log->debug( "ID3v2 tag detected, will buffer $scan->{scanLen} bytes for $scan->{url}" );
+		}
+
+		$scan->{fh}->write( $data, length $data );
+		$scan->{len} += length $data;
+	}
+
+	return if !$eof && $scan->{len} < $scan->{scanLen};
+
+	# enough data buffered (or stream ended) - scan once and stop
+	${*$self}{'_bitrateScan'} = 0;
+
+	my ( $bitrate, $vbr ) = eval { $scan->{formatClass}->scanBitrate( $scan->{fh}, $scan->{url} ) };
+
+	if ( $@ ) {
+		$log->error("Unable to scan bitrate for $scan->{url}: $@");
+	}
+	elsif ( $bitrate && $bitrate > 0 ) {
+		main::DEBUGLOG && $log->is_debug && $log->debug("Scanned bitrate for $scan->{url}: $bitrate");
+
+		Slim::Music::Info::setBitrate( $scan->{url}, $bitrate, $vbr );
+		if ( my $song = ${*$self}{'song'} ) {
+			$song->bitrate($bitrate);
+		}
+		if ( !Slim::Music::Info::getDuration( $scan->{url} ) && ( my $cl = $self->contentLength ) ) {
+			Slim::Music::Info::setDuration( $scan->{url}, ( $cl * 8 ) / $bitrate );
+		}
+	}
 }
 
 sub audioScrobblerSource { 'P' }
@@ -245,18 +369,26 @@ sub getMetadataFor {
 	# master client, which may not be the client this UPnP session's state was
 	# stored on.
 	my $meta = Slim::Plugin::UPnP::MediaRenderer::AVTransport->trackMetaFor($url) || {};
-	my $res  = $meta->{res} || {};
 
-	main::DEBUGLOG && $log->is_debug && $log->debug( 'Metadata returned for  ' . $meta->{title} );
+	# support Icy Metadata updates
+	my $title = Slim::Music::Info::getCurrentTitle( $client, $url );
+
+	# may reflect a bitrate/duration determined on the fly (see _scanBitrateFeed)
+	my $bitrate = Slim::Music::Info::getCurrentBitrate($url) || 0;
+	my $duration = Slim::Music::Info::getDuration($url) || 0;
+
+	my $type = uc( Slim::Music::Info::contentType($url) || '' ) . ' (UPnP/DLNA)'; 
+
+	main::DEBUGLOG && $log->is_debug && $log->debug( 'Metadata returned for  ' . $title );
 	return {
 		artist   => $meta->{artist},
 		album    => $meta->{album},
-		title    => $meta->{title},
-		cover    => $meta->{cover} || '', # XXX default
+		title    => $title,
+		type     => $type,
+		bitrate  => $bitrate,
+		duration => $duration,
 		icon     => '', # XXX default icon
-		duration => $res->{secs} || 0,
-		bitrate  => $res->{bitrate} ? ($res->{bitrate} / 1000) . 'kbps' : 0,
-		type     => $res->{mime} . ' (UPnP/DLNA)',
+		cover    => $meta->{cover} || '', # XXX default
 	};
 }
 


### PR DESCRIPTION
A proper bitrate value is crucial for seeking, so this improves bitrate heuristic for LPCM & WAV and when no bitrate is sent by the server at all, we do an **on-the-fly bitrate detection** using `Audio::Scan->scan_fh()` on the first 128kB of data (or more when a lengthy MP3v2 tag, like a large cover image, is detected).

Unfortunately, we cannot directly use `parseAudioStream()` here, because it would create its own connection (which would be rejected by e.g. _pa-dlna_) and currently does not support HTTP/1.1 chunked transfer encoding, so it required an implementation that is embedded into `_sysread()` instead.

We also improve metadata handling here, so that this also adds support for _Icy Metadata_, although it is not part of the UPnP/DLNA spec, because some Media Servers (like _AirMusic_) are sending it.

In addition, `canSeek()` now honors the `DLNA.ORG_OP` seekable flag (in DIDL-Lite) instead of always assuming Range support.

**Note that this also required a minor change to `Slim::Music::Info::setRemoteMetadata()`** (for cosmetic reasons), because `setRemoteMetadata()` supposed that all bitrates that are not typical MP3-bitrates are VBR, which is in fact very buggy.
We solve this by adding support for an optional `vbr_scale` metadata attribute which is now preferred over guessing.

Tested with:
- BubbleUPnP 4.6.5.1
- AirMusic 3.4.3
- Hi-Fi Cast 1.135
- foobar2000 2.25.10
- pa-dlna 1.2

Audio formats tested:
- `audio/wav`
- `audio/L16`
- `audio/mpeg`