### PR TITLE
Fix disappearing library_track rows

### DIFF
--- a/Slim/Schema.pm
+++ b/Slim/Schema.pm
@@ -2546,6 +2546,11 @@ sub _checkValidity {
 
 		# Do a cascading delete for has_many relationships - this will
 		# clear out Contributors, Genres, etc.
+
+		# The cascading delete removes library_track rows for the deleted track and they're not created
+		# by _newTrack() so store current values to be added back below.
+		my @libraries = map { $_->library } Slim::Schema->search('LibraryTrack', { 'track' => $oldid })->all;
+
 		$track->delete;
 		Slim::Schema::Album->rescan($oldAlbum);
 
@@ -2557,7 +2562,15 @@ sub _checkValidity {
 			'commit'   => 1,
 		});
 
-		$track = Slim::Schema->rs('Track')->find($trackId) if (defined $trackId);
+		if (defined $trackId) {
+			$track = Slim::Schema->rs('Track')->find($trackId);
+
+			foreach (@libraries) {
+				my $rs = Slim::Schema->resultset('LibraryTrack')->new( { track => $trackId, library => $_ } );
+				$rs->update_or_insert;
+			}
+		}
+
 	}
 
 	# Track may have been deleted by _hasChanged

--- a/Slim/Schema/ResultSet/LibraryTrack.pm
+++ b/Slim/Schema/ResultSet/LibraryTrack.pm
@@ -1,0 +1,7 @@
+package Slim::Schema::ResultSet::LibraryTrack;
+
+
+use strict;
+use base qw(Slim::Schema::ResultSet::Base);
+
+1;


### PR DESCRIPTION
I found a problem in `Slim::Schema::_checkValidity` : as explained in the comment

> The cascading delete removes library_track rows for the deleted track and they're not created by _newTrack() so store current values to be added back below.

It may be a timing problem - that the updates triggered by rescan album are not committed before `_checkValidity` runs from the status query so `_checkValidity` retrieves a timestamp of zero from the track object and therefore deletes/recreates the track, losing the library_track rows in the process. 

It's slightly difficult to trigger the bug, but I found I could do it reliably by:

- ensure the browse view is "local tracks only"
- add a short (2 track) album to the playlist
- restart LMS
- browse to the album and then from the drop-down menu (Material Skin) "Rescan Album" (no tag change required)
- refresh and browse to the album again: the first track (current in the playlist) has gone.

I also tested with multiple library views, using the Virtual Library Creator plugin.
